### PR TITLE
Fixed issue with PTX compatibility on new RTX cards

### DIFF
--- a/Src/ILGPU/Backends/PTX/PTXArchitecture.cs
+++ b/Src/ILGPU/Backends/PTX/PTXArchitecture.cs
@@ -76,6 +76,11 @@ namespace ILGPU.Backends
         SM_70,
 
         /// <summary>
+        /// The 7.2 architecture.
+        /// </summary>
+        SM_72,
+
+        /// <summary>
         /// The 7.5 architecture.
         /// </summary>
         SM_75,
@@ -108,6 +113,7 @@ namespace ILGPU.Backends
             { (6L << 32) | 3L, PTXArchitecture.SM_63 },
 
             { (7L << 32) | 0L, PTXArchitecture.SM_70 },
+            { (7L << 32) | 2L, PTXArchitecture.SM_72 },
             { (7L << 32) | 5L, PTXArchitecture.SM_75 },
         };
 

--- a/Src/ILGPU/Backends/PTX/PTXCodeGenerator.cs
+++ b/Src/ILGPU/Backends/PTX/PTXCodeGenerator.cs
@@ -32,7 +32,7 @@ namespace ILGPU.Backends.PTX
         /// <summary>
         /// The supported PTX version.
         /// </summary>
-        public const string PTXVersion = "6.0";
+        public const string PTXVersion = "6.4";
 
         #endregion
 


### PR DESCRIPTION
- PTX 6.0 only supports up to SM_70