### PR TITLE
Updated CudaMemoryBuffer to support MemSetToZero using alternate streams

### DIFF
--- a/Src/ILGPU/Runtime/Cuda/API/CudaAPI.cs
+++ b/Src/ILGPU/Runtime/Cuda/API/CudaAPI.cs
@@ -507,11 +507,36 @@ namespace ILGPU.Runtime.Cuda.API
         /// <param name="destinationDevice">The destination in device memory.</param>
         /// <param name="value">The value to set.</param>
         /// <param name="length">The length in bytes.</param>
+        /// <param name="stream">The accelerator stream for async processing.</param>
+        /// <returns>The error status.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public CudaError Memset(
+            IntPtr destinationDevice,
+            byte value,
+            IntPtr length,
+            AcceleratorStream stream)
+        {
+            var cudaStream = stream as CudaStream;
+            return Memset(
+                destinationDevice,
+                value,
+                length,
+                cudaStream?.StreamPtr ?? IntPtr.Zero);
+        }
+
+        /// <summary>
+        /// Performs a memory-set operation.
+        /// </summary>
+        /// <param name="destinationDevice">The destination in device memory.</param>
+        /// <param name="value">The value to set.</param>
+        /// <param name="length">The length in bytes.</param>
+        /// <param name="stream">The accelerator stream for async processing.</param>
         /// <returns>The error status.</returns>
         public abstract CudaError Memset(
             IntPtr destinationDevice,
             byte value,
-            IntPtr length);
+            IntPtr length,
+            IntPtr stream);
 
         /// <summary>
         /// Resolves a pointer-attribute value.

--- a/Src/ILGPU/Runtime/Cuda/API/NotSupported.cs
+++ b/Src/ILGPU/Runtime/Cuda/API/NotSupported.cs
@@ -206,7 +206,7 @@ namespace ILGPU.Runtime.Cuda.API
             throw new NotSupportedException(RuntimeErrorMessages.CudaNotSupported);
         }
 
-        /// <summary cref="CudaAPI.Memset(IntPtr, byte, IntPtr)"/>
+        /// <summary cref="CudaAPI.Memcpy(IntPtr, IntPtr, IntPtr)"/>
         public override CudaError Memcpy(
             IntPtr destination,
             IntPtr source,
@@ -245,11 +245,12 @@ namespace ILGPU.Runtime.Cuda.API
             throw new NotSupportedException(RuntimeErrorMessages.CudaNotSupported);
         }
 
-        /// <summary cref="CudaAPI.Memset(IntPtr, byte, IntPtr)"/>
+        /// <summary cref="CudaAPI.Memset(IntPtr, byte, IntPtr, IntPtr)"/>
         public override CudaError Memset(
             IntPtr destinationDevice,
             byte value,
-            IntPtr length)
+            IntPtr length,
+            IntPtr stream)
         {
             throw new NotSupportedException(RuntimeErrorMessages.CudaNotSupported);
         }

--- a/Src/ILGPU/Runtime/Cuda/API/Unix.cs
+++ b/Src/ILGPU/Runtime/Cuda/API/Unix.cs
@@ -174,10 +174,11 @@ namespace ILGPU.Runtime.Cuda.API
             [In] IntPtr stream);
 
         [DllImport(LibName)]
-        private static extern CudaError cuMemsetD8_v2(
+        private static extern CudaError cuMemsetD8Async(
             [In] IntPtr destinationDevice,
             [In] byte value,
-            [In] IntPtr length);
+            [In] IntPtr length,
+            [In] IntPtr stream);
 
         [DllImport(LibName)]
         private static extern CudaError cuStreamCreate(
@@ -454,7 +455,7 @@ namespace ILGPU.Runtime.Cuda.API
             return cuMemFree_v2(devicePtr);
         }
 
-        /// <summary cref="CudaAPI.Memset(IntPtr, byte, IntPtr)"/>
+        /// <summary cref="CudaAPI.Memcpy(IntPtr, IntPtr, IntPtr)"/>
         public override CudaError Memcpy(
             IntPtr destination,
             IntPtr source,
@@ -505,13 +506,14 @@ namespace ILGPU.Runtime.Cuda.API
                 stream);
         }
 
-        /// <summary cref="CudaAPI.Memset(IntPtr, byte, IntPtr)"/>
+        /// <summary cref="CudaAPI.Memset(IntPtr, byte, IntPtr, IntPtr)"/>
         public override CudaError Memset(
             IntPtr destinationDevice,
             byte value,
-            IntPtr length)
+            IntPtr length,
+            IntPtr stream)
         {
-            return cuMemsetD8_v2(destinationDevice, value, length);
+            return cuMemsetD8Async(destinationDevice, value, length, stream);
         }
 
         /// <summary cref="CudaAPI.GetPointerAttribute(IntPtr, PointerAttribute, IntPtr)"/>

--- a/Src/ILGPU/Runtime/Cuda/API/Windows.cs
+++ b/Src/ILGPU/Runtime/Cuda/API/Windows.cs
@@ -180,10 +180,11 @@ namespace ILGPU.Runtime.Cuda.API
             [In] IntPtr stream);
 
         [DllImport(LibName)]
-        private static extern CudaError cuMemsetD8_v2(
+        private static extern CudaError cuMemsetD8Async(
             [In] IntPtr destinationDevice,
             [In] byte value,
-            [In] IntPtr length);
+            [In] IntPtr length,
+            [In] IntPtr stream);
 
         [DllImport(LibName)]
         private static extern CudaError cuStreamCreate(
@@ -464,7 +465,7 @@ namespace ILGPU.Runtime.Cuda.API
             return cuMemFree_v2(devicePtr);
         }
 
-        /// <summary cref="CudaAPI.Memset(IntPtr, byte, IntPtr)"/>
+        /// <summary cref="CudaAPI.Memset(IntPtr, byte, IntPtr, IntPtr)"/>
         public override CudaError Memcpy(
             IntPtr destination,
             IntPtr source,
@@ -515,13 +516,14 @@ namespace ILGPU.Runtime.Cuda.API
                 stream);
         }
 
-        /// <summary cref="CudaAPI.Memset(IntPtr, byte, IntPtr)"/>
+        /// <summary cref="CudaAPI.Memset(IntPtr, byte, IntPtr, IntPtr)"/>
         public override CudaError Memset(
             IntPtr destinationDevice,
             byte value,
-            IntPtr length)
+            IntPtr length,
+            IntPtr stream)
         {
-            return cuMemsetD8_v2(destinationDevice, value, length);
+            return cuMemsetD8Async(destinationDevice, value, length, stream);
         }
 
         /// <summary cref="CudaAPI.GetPointerAttribute(IntPtr, PointerAttribute, IntPtr)"/>

--- a/Src/ILGPU/Runtime/Cuda/CudaMemoryBuffer.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaMemoryBuffer.cs
@@ -118,7 +118,7 @@ namespace ILGPU.Runtime.Cuda
         {
             var binding = Accelerator.BindScoped();
 
-            CudaAPI.Current.Memset(NativePtr, 0, new IntPtr(LengthInBytes));
+            CudaAPI.Current.Memset(NativePtr, 0, new IntPtr(LengthInBytes), stream);
 
             binding.Recover();
         }


### PR DESCRIPTION
hi @m4rs-mt , was doing some profiling and noticed that MemSetToZero would always use the default accelerator stream.