### PR TITLE
Added support for .Net Standard 2.1

### DIFF
--- a/.nuget/ILGPU.nuspec
+++ b/.nuget/ILGPU.nuspec
@@ -21,7 +21,6 @@
     <tags>ilgpu gpu msil il cil cpu ptx nvidia amd amp opencl cuda compiler jit</tags>
     <dependencies>
       <dependency id="System.Collections.Immutable" version="1.5.0" />
-      <dependency id="System.Reflection.Emit.ILGeneration" version="4.3.0" />
       <dependency id="System.Reflection.Metadata" version="1.6.0" />
       <dependency id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" />
     </dependencies>

--- a/.nuget/ILGPU.nuspec
+++ b/.nuget/ILGPU.nuspec
@@ -32,6 +32,12 @@
 
     <file src="ILGPU.targets" target="build\ILGPU.targets" />
 
+    <file src="..\Bin\Debug\netstandard2.1\ILGPU.dll" target="lib\netstandard2.1\Debug\ILGPU.dll" />
+    <file src="..\Bin\Debug\netstandard2.1\ILGPU.xml" target="lib\netstandard2.1\Debug\ILGPU.xml" />
+
+    <file src="..\Bin\Release\netstandard2.1\ILGPU.dll" target="lib\netstandard2.1\Release\ILGPU.dll" />
+    <file src="..\Bin\Release\netstandard2.1\ILGPU.xml" target="lib\netstandard2.1\Release\ILGPU.xml" />
+
     <file src="..\Bin\Debug\netcoreapp2.0\ILGPU.dll" target="lib\netcoreapp2.0\Debug\ILGPU.dll" />
     <file src="..\Bin\Debug\netcoreapp2.0\ILGPU.xml" target="lib\netcoreapp2.0\Debug\ILGPU.xml" />
 

--- a/.nuget/ILGPU.targets
+++ b/.nuget/ILGPU.targets
@@ -1,11 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <ItemGroup>
-        <Reference Include="ILGPU" Condition="'$(TargetFrameworkIdentifier)'=='.NETCoreApp'">
-            <HintPath>$(MSBuildThisFileDirectory)../lib/netcoreapp2.0/$(Configuration)/ILGPU.dll</HintPath>
-        </Reference>
-        <Reference Include="ILGPU" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
-            <HintPath>$(MSBuildThisFileDirectory)../lib/net47/$(Configuration)/ILGPU.dll</HintPath>
-        </Reference>
-    </ItemGroup>
+    <PropertyGroup>
+        <TargetFrameworkVersionNumber>$([System.Text.RegularExpressions.Regex]::Replace($(TargetFrameworkVersion), '^[^\d\.]+', '', System.Text.RegularExpressions.RegexOptions.IgnoreCase))</TargetFrameworkVersionNumber>
+    </PropertyGroup>
+    <Choose>
+        <When Condition="('$(TargetFrameworkIdentifier)'=='.NETCoreApp' And $(TargetFrameworkVersionNumber) &gt;= 3.0) Or ('$(TargetFrameworkIdentifier)'=='.NETStandard' And $(TargetFrameworkVersionNumber) &gt;= 2.1)">
+            <ItemGroup>
+                <Reference Include="ILGPU">
+                    <HintPath>$(MSBuildThisFileDirectory)../lib/netstandard2.1/$(Configuration)/ILGPU.dll</HintPath>
+                  </Reference>
+            </ItemGroup>
+        </When>
+        <When Condition="'$(TargetFrameworkIdentifier)'=='.NETCoreApp' And $(TargetFrameworkVersionNumber) &gt;= 2.0">
+            <ItemGroup>
+                <Reference Include="ILGPU">
+                    <HintPath>$(MSBuildThisFileDirectory)../lib/netcoreapp2.0/$(Configuration)/ILGPU.dll</HintPath>
+                </Reference>
+            </ItemGroup>
+        </When>
+        <Otherwise>
+            <ItemGroup>
+                <Reference Include="ILGPU">
+                    <HintPath>$(MSBuildThisFileDirectory)../lib/net47/$(Configuration)/ILGPU.dll</HintPath>
+                </Reference>
+            </ItemGroup>
+        </Otherwise>
+    </Choose>
 </Project>

--- a/LICENSE-3RD-PARTY.txt
+++ b/LICENSE-3RD-PARTY.txt
@@ -3,8 +3,6 @@ Copyrights and Licenses for third party dependencies of ILGPU.
 ILGPU Dependencies:
     - System.Collections.Immutable
     (https://www.nuget.org/packages/System.Collections.Immutable)
-    - System.Reflection.Emit.ILGeneration
-    (https://www.nuget.org/packages/System.Reflection.Emit.ILGeneration)
     - System.Reflection.Metadata
     (https://www.nuget.org/packages/System.Reflection.Metadata)
     - System.Runtime.CompilerServices.Unsafe
@@ -17,14 +15,6 @@ ILGPU Dependencies:
 
 System.Collections.Immutable license can be found via:
 http://go.microsoft.com/fwlink/?LinkId=329770
-
-********************************************************************************
-     ILGPU Compiler Dependency: System.Reflection.Emit.ILGeneration
-********************************************************************************
-
-System.Reflection.Emit.ILGeneration license can be found via:
-http://go.microsoft.com/fwlink/?LinkId=329770
-
 
 ********************************************************************************
      ILGPU Compiler Dependency: System.Reflection.Metadata

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ All kernels (including all hardware features like shared memory and atomics) can
 
 # Build Instructions
 
-ILGPU requires Visual Studio 2017 (Community edition or higher).
+ILGPU requires Visual Studio 2019 (Community edition or higher).
 
 Use the provided Visual Studio solution to build the ILGPU libs
 in the desired configurations (Debug/Release).

--- a/README.md
+++ b/README.md
@@ -59,8 +59,6 @@ Different parts of ILGPU require different third-party libraries.
 * ILGPU Dependencies
     - System.Collections.Immutable
     (https://www.nuget.org/packages/System.Collections.Immutable)
-    - System.Reflection.Emit.ILGeneration
-    (https://www.nuget.org/packages/System.Reflection.Emit.ILGeneration)
     - System.Reflection.Metadata
     (https://www.nuget.org/packages/System.Reflection.Metadata)
     - System.Runtime.CompilerServices.Unsafe

--- a/Src/ILGPU/ILGPU.csproj
+++ b/Src/ILGPU/ILGPU.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net47;netcoreapp2.0</TargetFrameworks>
+        <TargetFrameworks>net47;netcoreapp2.0;netstandard2.1</TargetFrameworks>
         <OutputPath>../../Bin/$(Configuration)/</OutputPath>
         <DocumentationFile>../../Bin/$(Configuration)/ILGPU.xml</DocumentationFile>
         <Configurations>Debug;Release;DebugVerification</Configurations>

--- a/Src/ILGPU/ILGPU.csproj
+++ b/Src/ILGPU/ILGPU.csproj
@@ -50,7 +50,6 @@
 
     <ItemGroup>
         <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
-        <PackageReference Include="System.Reflection.Emit.ILGeneration" Version="4.3.0" />
         <PackageReference Include="System.Reflection.Metadata" Version="1.6.0" />
         <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
     </ItemGroup>


### PR DESCRIPTION
With the recent release of VS2019 v16.3, .NET Core 3.0 and .NET Standard 2.1 are now available.

In particular, .NET Standard 2.1 supports the the Reflection.Emit functionality required by #7 
https://devblogs.microsoft.com/dotnet/announcing-net-standard-2-1/

Unfortunately, .NET Standard 2.1 libraries cannot be used by either .NET Core 2.x nor .NET Framework.
