### PR TITLE
Fixed retrieving version number of ILGPU assembly

### DIFF
--- a/Src/ILGPU/Context.cs
+++ b/Src/ILGPU/Context.cs
@@ -58,7 +58,7 @@ namespace ILGPU
             Justification = "Internal initialization check that should never fail")]
         static Context()
         {
-            var versionString = Assembly.GetCallingAssembly().
+            var versionString = Assembly.GetExecutingAssembly().
                 GetCustomAttribute<AssemblyFileVersionAttribute>().Version;
             int offset = 0;
             for (int i = 0; i < 3; ++i)


### PR DESCRIPTION
Use the version string from the ILGPU assembly, rather than the application that is running ILGPU.

Fixes #32 