### PR TITLE
Rework implementation of dispose pattern

### DIFF
--- a/Src/ILGPU.Tests/Generic/TestBase.cs
+++ b/Src/ILGPU.Tests/Generic/TestBase.cs
@@ -205,6 +205,7 @@ namespace ILGPU.Tests
                 Accelerator.Dispose();
                 Context.Dispose();
             }
+            base.Dispose(disposing);
         }
 
         #endregion

--- a/Src/ILGPU.Tests/Generic/TestBase.cs
+++ b/Src/ILGPU.Tests/Generic/TestBase.cs
@@ -32,9 +32,6 @@ namespace ILGPU.Tests
 
         #endregion
 
-        private Context context;
-        private Accelerator accelerator;
-
         /// <summary>
         /// Constructs a new test base.
         /// </summary>
@@ -45,10 +42,10 @@ namespace ILGPU.Tests
             Output = output;
             ContextProvider = contextProvider;
 
-            context = contextProvider.CreateContext();
-            Assert.True(context != null, "Invalid context");
-            accelerator = contextProvider.CreateAccelerator(context);
-            Assert.True(accelerator != null, "Accelerator not supported");
+            Context = contextProvider.CreateContext();
+            Assert.True(Context != null, "Invalid context");
+            Accelerator = contextProvider.CreateAccelerator(Context);
+            Assert.True(Accelerator != null, "Accelerator not supported");
 
             TestType = GetType();
         }
@@ -69,12 +66,12 @@ namespace ILGPU.Tests
         /// <summary>
         /// Returns the associated context.
         /// </summary>
-        public Context Context => context;
+        public Context Context { get; }
 
         /// <summary>
         /// Returns the associated accelerator.
         /// </summary>
-        public Accelerator Accelerator => accelerator;
+        public Accelerator Accelerator { get; }
 
         /// <summary>
         /// Returns the associated test type.
@@ -203,8 +200,11 @@ namespace ILGPU.Tests
         /// <summary cref="IDisposable.Dispose"/>
         protected override void Dispose(bool disposing)
         {
-            Dispose(ref accelerator);
-            Dispose(ref context);
+            if (disposing)
+            {
+                Accelerator.Dispose();
+                Context.Dispose();
+            }
         }
 
         #endregion

--- a/Src/ILGPU/.editorconfig
+++ b/Src/ILGPU/.editorconfig
@@ -3,9 +3,6 @@
 # CA1000: Do not declare static members on generic types
 dotnet_diagnostic.CA1000.severity = none
 
-# CA1001: Types that own disposable fields should be disposable
-dotnet_diagnostic.CA1001.severity = silent
-
 # CA1034: Nested types should not be visible
 dotnet_diagnostic.CA1034.severity = none
 
@@ -14,9 +11,6 @@ dotnet_diagnostic.CA1043.severity = none
 
 # CA1062: Validate arguments of public methods
 dotnet_diagnostic.CA1062.severity = none
-
-# CA1063: Implement IDisposable Correctly
-dotnet_diagnostic.CA1063.severity = none
 
 # CA1304: Specify CultureInfo
 dotnet_diagnostic.CA1304.severity = none
@@ -39,20 +33,8 @@ dotnet_diagnostic.CA1801.severity = none
 # CA1815: Override equals and operator equals on value types
 dotnet_diagnostic.CA1815.severity = none
 
-# CA2000: Dispose objects before losing scope
-dotnet_diagnostic.CA2000.severity = silent
-
-# CA2213: Disposable fields should be disposed
-dotnet_diagnostic.CA2213.severity = silent
-
 # CA2225: Operator overloads have named alternates
 dotnet_diagnostic.CA2225.severity = silent
 
 # IDE0060: Remove unused parameter
 dotnet_code_quality_unused_parameters = all:silent
-
-# IDE0067: Dispose objects before losing scope
-dotnet_diagnostic.IDE0067.severity = silent
-
-# IDE0069: Disposable fields should be disposed
-dotnet_diagnostic.IDE0069.severity = silent

--- a/Src/ILGPU/Backends/Backend.cs
+++ b/Src/ILGPU/Backends/Backend.cs
@@ -559,13 +559,6 @@ namespace ILGPU.Backends
         }
 
         #endregion
-
-        #region IDisposable
-
-        /// <summary cref="DisposeBase.Dispose(bool)"/>
-        protected override void Dispose(bool disposing) { }
-
-        #endregion
     }
 
     /// <summary>

--- a/Src/ILGPU/Backends/Backend.cs
+++ b/Src/ILGPU/Backends/Backend.cs
@@ -577,8 +577,6 @@ namespace ILGPU.Backends
     {
         #region Instance
 
-        private IntrinsicImplementationProvider<TDelegate> intrinsicProvider;
-
         /// <summary>
         /// Constructs a new generic backend.
         /// </summary>
@@ -595,7 +593,7 @@ namespace ILGPU.Backends
             Func<ABI, ArgumentMapper> argumentMapperProvider)
             : base(context, backendType, backendFlags, abi, argumentMapperProvider)
         {
-            intrinsicProvider = context.IntrinsicManager.CreateProvider<TDelegate>(this);
+            IntrinsicProvider = context.IntrinsicManager.CreateProvider<TDelegate>(this);
         }
 
         #endregion
@@ -605,7 +603,7 @@ namespace ILGPU.Backends
         /// <summary>
         /// Returns the current intrinsic provider.
         /// </summary>
-        public IntrinsicImplementationProvider<TDelegate> IntrinsicProvider => intrinsicProvider;
+        public IntrinsicImplementationProvider<TDelegate> IntrinsicProvider { get; }
 
         #endregion
 
@@ -654,7 +652,7 @@ namespace ILGPU.Backends
         public override void ClearCache(ClearCacheMode mode)
         {
             base.ClearCache(mode);
-            intrinsicProvider.ClearCache(mode);
+            IntrinsicProvider.ClearCache(mode);
         }
 
         #endregion
@@ -664,8 +662,9 @@ namespace ILGPU.Backends
         /// <summary cref="DisposeBase.Dispose(bool)"/>
         protected override void Dispose(bool disposing)
         {
+            if (disposing)
+                IntrinsicProvider.Dispose();
             base.Dispose(disposing);
-            Dispose(ref intrinsicProvider);
         }
 
         #endregion

--- a/Src/ILGPU/Backends/OpenCL/CLBackend.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLBackend.cs
@@ -13,7 +13,6 @@ using ILGPU.IR;
 using ILGPU.IR.Analyses;
 using ILGPU.Runtime;
 using ILGPU.Runtime.OpenCL;
-using System;
 using System.Text;
 
 namespace ILGPU.Backends.OpenCL

--- a/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Views.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Views.cs
@@ -9,7 +9,6 @@
 // Illinois Open Source License. See LICENSE.txt for details
 // -----------------------------------------------------------------------------
 
-using ILGPU.IR;
 using ILGPU.IR.Types;
 using ILGPU.IR.Values;
 

--- a/Src/ILGPU/Backends/OpenCL/CLInstructions.Data.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLInstructions.Data.cs
@@ -246,7 +246,7 @@ namespace ILGPU.Backends.OpenCL
         private static readonly Dictionary<(BinaryArithmeticKind, bool), (string, bool)> BinaryArithmeticOperations =
             new Dictionary<(BinaryArithmeticKind, bool), (string, bool)>()
             {
-                
+
                 { (BinaryArithmeticKind.Add, false), ("+", false) },
                 { (BinaryArithmeticKind.Add, true), ("+", false) },
 

--- a/Src/ILGPU/Context.cs
+++ b/Src/ILGPU/Context.cs
@@ -456,6 +456,7 @@ namespace ILGPU
                 DebugInformationManager.Dispose();
                 TypeContext.Dispose();
             }
+            base.Dispose(disposing);
         }
 
         #endregion
@@ -522,6 +523,7 @@ namespace ILGPU
         {
             if (disposing)
                 Context.ReleaseCodeGenerationLock();
+            base.Dispose(disposing);
         }
 
         #endregion

--- a/Src/ILGPU/Frontend/DebugInformation/AssemblyDebugInformation.cs
+++ b/Src/ILGPU/Frontend/DebugInformation/AssemblyDebugInformation.cs
@@ -9,7 +9,6 @@
 // Illinois Open Source License. See LICENSE.txt for details
 // -----------------------------------------------------------------------------
 
-using ILGPU.Util;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -24,11 +23,10 @@ namespace ILGPU.Frontend.DebugInformation
     /// <summary>
     /// Represents assembly debug information.
     /// </summary>
-    public sealed class AssemblyDebugInformation : DisposeBase
+    public sealed class AssemblyDebugInformation
     {
         #region Instance
 
-        private MetadataReaderProvider metadataReaderProvider;
         private readonly Dictionary<MethodBase, MethodDebugInformation> debugInformation =
             new Dictionary<MethodBase, MethodDebugInformation>();
 
@@ -52,10 +50,8 @@ namespace ILGPU.Frontend.DebugInformation
             Assembly = assembly;
             Modules = ImmutableArray.Create(assembly.GetModules());
 
-            metadataReaderProvider = MetadataReaderProvider.FromPortablePdbStream(
-                pdbStream,
-                MetadataStreamOptions.PrefetchMetadata);
-            MetadataReader = metadataReaderProvider.GetMetadataReader();
+            using (var metadataReaderProvider = MetadataReaderProvider.FromPortablePdbStream(pdbStream, MetadataStreamOptions.PrefetchMetadata))
+                MetadataReader = metadataReaderProvider.GetMetadataReader();
 
             var methodDebugInformationEnumerator = MetadataReader.MethodDebugInformation.GetEnumerator();
             while (methodDebugInformationEnumerator.MoveNext())
@@ -135,16 +131,6 @@ namespace ILGPU.Frontend.DebugInformation
                 return false;
             methodDebugInformation.LoadSequencePoints();
             return true;
-        }
-
-        #endregion
-
-        #region IDisposable
-
-        /// <summary cref="DisposeBase.Dispose(bool)"/>
-        protected override void Dispose(bool disposing)
-        {
-            Dispose(ref metadataReaderProvider);
         }
 
         #endregion

--- a/Src/ILGPU/Frontend/DebugInformation/DebugInformationManager.cs
+++ b/Src/ILGPU/Frontend/DebugInformation/DebugInformationManager.cs
@@ -391,7 +391,7 @@ namespace ILGPU.Frontend.DebugInformation
             methodDebugInformation = null;
             if (!TryLoadSymbols(
                 methodBase.Module.Assembly,
-                out AssemblyDebugInformation assemblyDebugInformation))
+                out var assemblyDebugInformation))
                 return false;
             return assemblyDebugInformation.TryLoadDebugInformation(
                 methodBase,
@@ -443,8 +443,6 @@ namespace ILGPU.Frontend.DebugInformation
             {
                 if (mode == ClearCacheMode.Everything)
                 {
-                    foreach (var debugInformation in assemblies.Values)
-                        debugInformation.Dispose();
                     assemblies.Clear();
                 }
                 else
@@ -458,10 +456,7 @@ namespace ILGPU.Frontend.DebugInformation
                         assembliesToRemove.Add(assembly);
                     }
                     foreach (var assemblyToRemove in assembliesToRemove)
-                    {
-                        assemblies[assemblyToRemove].Dispose();
                         assemblies.Remove(assemblyToRemove);
-                    }
                 }
             }
             finally
@@ -475,12 +470,10 @@ namespace ILGPU.Frontend.DebugInformation
         #region IDisposable
 
         /// <summary cref="DisposeBase.Dispose(bool)"/>
-        [SuppressMessage("Microsoft.Usage", "CA2213:DisposableFieldsShouldBeDisposed", MessageId = "cacheLock",
-            Justification = "Dispose method will be invoked by a helper method")]
         protected override void Dispose(bool disposing)
         {
-            ClearCache(ClearCacheMode.Everything);
-            cacheLock.Dispose();
+            if (disposing)
+                cacheLock.Dispose();
         }
 
         #endregion

--- a/Src/ILGPU/Frontend/DebugInformation/DebugInformationManager.cs
+++ b/Src/ILGPU/Frontend/DebugInformation/DebugInformationManager.cs
@@ -474,6 +474,7 @@ namespace ILGPU.Frontend.DebugInformation
         {
             if (disposing)
                 cacheLock.Dispose();
+            base.Dispose(disposing);
         }
 
         #endregion

--- a/Src/ILGPU/Frontend/ILFrontend.cs
+++ b/Src/ILGPU/Frontend/ILFrontend.cs
@@ -243,6 +243,7 @@ namespace ILGPU.Frontend
                     thread.Join();
                 driverNotifier.Dispose();
             }
+            base.Dispose(disposing);
         }
 
         #endregion
@@ -426,6 +427,7 @@ namespace ILGPU.Frontend
                 isFinished = true;
                 Frontend.FinishCodeGeneration(this);
             }
+            base.Dispose(disposing);
         }
 
         #endregion

--- a/Src/ILGPU/IR/Analyses/Scope.cs
+++ b/Src/ILGPU/IR/Analyses/Scope.cs
@@ -594,6 +594,7 @@ namespace ILGPU.IR.Analyses
         {
             if (disposing)
                 cacheLock.Dispose();
+            base.Dispose(disposing);
         }
 
         #endregion

--- a/Src/ILGPU/IR/Analyses/Scope.cs
+++ b/Src/ILGPU/IR/Analyses/Scope.cs
@@ -592,7 +592,8 @@ namespace ILGPU.IR.Analyses
         /// <summary cref="DisposeBase.Dispose(bool)"/>
         protected override void Dispose(bool disposing)
         {
-            cacheLock.Dispose();
+            if (disposing)
+                cacheLock.Dispose();
         }
 
         #endregion

--- a/Src/ILGPU/IR/Construction/BasicBlock.Builder.cs
+++ b/Src/ILGPU/IR/Construction/BasicBlock.Builder.cs
@@ -22,6 +22,8 @@ using System.Runtime.CompilerServices;
 
 namespace ILGPU.IR
 {
+    [SuppressMessage("Design", "CA1001:Types that own disposable fields should be disposable",
+        Justification = "Handled in Method.Builder.Dispose(bool)")]
     partial class BasicBlock
     {
         /// <summary>
@@ -492,8 +494,11 @@ namespace ILGPU.IR
             /// <summary cref="DisposeBase.Dispose(bool)"/>
             protected override void Dispose(bool disposing)
             {
-                PerformRemoval();
-                BasicBlock.ReleaseBuilder(this);
+                if (disposing)
+                {
+                    PerformRemoval();
+                    BasicBlock.ReleaseBuilder(this);
+                }
             }
 
             #endregion

--- a/Src/ILGPU/IR/Construction/BasicBlock.Builder.cs
+++ b/Src/ILGPU/IR/Construction/BasicBlock.Builder.cs
@@ -499,6 +499,7 @@ namespace ILGPU.IR
                     PerformRemoval();
                     BasicBlock.ReleaseBuilder(this);
                 }
+                base.Dispose(disposing);
             }
 
             #endregion

--- a/Src/ILGPU/IR/Construction/Method.Builder.cs
+++ b/Src/ILGPU/IR/Construction/Method.Builder.cs
@@ -368,6 +368,7 @@ namespace ILGPU.IR
                         builder.Dispose();
                     Method.ReleaseBuilder(this);
                 }
+                base.Dispose(disposing);
             }
 
             #endregion

--- a/Src/ILGPU/IR/Construction/Method.Builder.cs
+++ b/Src/ILGPU/IR/Construction/Method.Builder.cs
@@ -355,16 +355,19 @@ namespace ILGPU.IR
             /// <summary cref="DisposeBase.Dispose(bool)"/>
             protected override void Dispose(bool disposing)
             {
-                // Assign parameters and adjust their indices
-                var @params = parameters.ToImmutable();
-                for (int i = 0, e = @params.Length; i < e; ++i)
-                    @params[i].Index = i;
-                Method.parameters = @params;
+                if (disposing)
+                {
+                    // Assign parameters and adjust their indices
+                    var @params = parameters.ToImmutable();
+                    for (int i = 0, e = @params.Length; i < e; ++i)
+                        @params[i].Index = i;
+                    Method.parameters = @params;
 
-                // Dispose all basic block builders
-                foreach (var builder in basicBlockBuilders)
-                    builder.Dispose();
-                Method.ReleaseBuilder(this);
+                    // Dispose all basic block builders
+                    foreach (var builder in basicBlockBuilders)
+                        builder.Dispose();
+                    Method.ReleaseBuilder(this);
+                }
             }
 
             #endregion

--- a/Src/ILGPU/IR/IRContext.cs
+++ b/Src/ILGPU/IR/IRContext.cs
@@ -588,6 +588,7 @@ namespace ILGPU.IR
         {
             if (disposing)
                 irLock.Dispose();
+            base.Dispose(disposing);
         }
 
         #endregion

--- a/Src/ILGPU/IR/IRContext.cs
+++ b/Src/ILGPU/IR/IRContext.cs
@@ -586,7 +586,8 @@ namespace ILGPU.IR
         /// <summary cref="DisposeBase.Dispose(bool)"/>
         protected override void Dispose(bool disposing)
         {
-            irLock.Dispose();
+            if (disposing)
+                irLock.Dispose();
         }
 
         #endregion

--- a/Src/ILGPU/IR/Intrinsics/IntrinsicImplementationProvider.cs
+++ b/Src/ILGPU/IR/Intrinsics/IntrinsicImplementationProvider.cs
@@ -485,6 +485,7 @@ namespace ILGPU.IR.Intrinsics
         {
             if (disposing)
                 intrinsicContext.Dispose();
+            base.Dispose(disposing);
         }
 
         #endregion

--- a/Src/ILGPU/IR/Intrinsics/IntrinsicImplementationProvider.cs
+++ b/Src/ILGPU/IR/Intrinsics/IntrinsicImplementationProvider.cs
@@ -146,8 +146,8 @@ namespace ILGPU.IR.Intrinsics
 
             private readonly Dictionary<MethodInfo, MappingEntry> mappings;
 
-            private ContextCodeGenerationPhase contextCodeGenerationPhase;
-            private CodeGenerationPhase codeGenerationPhase;
+            private readonly ContextCodeGenerationPhase contextCodeGenerationPhase;
+            private readonly CodeGenerationPhase codeGenerationPhase;
 
             internal IRSpecializationPhase(
                 IntrinsicImplementationProvider<TDelegate> provider,
@@ -235,9 +235,9 @@ namespace ILGPU.IR.Intrinsics
             /// </summary>
             public void Dispose()
             {
-                DisposeBase.Dispose(ref codeGenerationPhase);
+                codeGenerationPhase.Dispose();
                 contextCodeGenerationPhase.Optimize();
-                DisposeBase.Dispose(ref contextCodeGenerationPhase);
+                contextCodeGenerationPhase.Dispose();
 
                 foreach (var mappingEntry in mappings.Values)
                     mappingEntry.Apply();
@@ -304,7 +304,7 @@ namespace ILGPU.IR.Intrinsics
 
         private readonly IntrinsicMethodMatcher<IntrinsicMapping<TDelegate>> methodMatcher;
         private readonly BaseIntrinsicValueMatcher<IntrinsicMapping<TDelegate>>[] valueMatchers;
-        private IRContext intrinsicContext;
+        private readonly IRContext intrinsicContext;
 
         /// <summary>
         /// Constructs a new intrinsic implementation mapping.
@@ -481,8 +481,11 @@ namespace ILGPU.IR.Intrinsics
         #region IDisposable
 
         /// <summary cref="DisposeBase.Dispose(bool)"/>
-        protected override void Dispose(bool disposing) =>
-            Dispose(ref intrinsicContext);
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                intrinsicContext.Dispose();
+        }
 
         #endregion
     }

--- a/Src/ILGPU/IR/Method.cs
+++ b/Src/ILGPU/IR/Method.cs
@@ -18,7 +18,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -539,8 +538,6 @@ namespace ILGPU.IR
         /// Creates a new builder for this method.
         /// </summary>
         /// <returns>The created builder.</returns>
-        [SuppressMessage("Microsoft.Reliability", "CA2000:DisposeObjectsBeforeLosingScope",
-            Justification = "The created builder will be stored inside the object")]
         public Builder CreateBuilder()
         {
             var newBuilder = new Builder(this);

--- a/Src/ILGPU/IR/Types/IRTypeContext.cs
+++ b/Src/ILGPU/IR/Types/IRTypeContext.cs
@@ -530,8 +530,9 @@ namespace ILGPU.IR.Types
         /// <summary cref="DisposeBase.Dispose(bool)"/>
         protected override void Dispose(bool disposing)
         {
+            if (disposing)
+                typeLock.Dispose();
             base.Dispose(disposing);
-            typeLock.Dispose();
         }
 
         #endregion

--- a/Src/ILGPU/IR/Types/TypeInformationManager.cs
+++ b/Src/ILGPU/IR/Types/TypeInformationManager.cs
@@ -343,7 +343,8 @@ namespace ILGPU.IR.Types
         /// <summary cref="DisposeBase.Dispose(bool)"/>
         protected override void Dispose(bool disposing)
         {
-            cachingLock.Dispose();
+            if (disposing)
+                cachingLock.Dispose();
         }
 
         #endregion

--- a/Src/ILGPU/IR/Types/TypeInformationManager.cs
+++ b/Src/ILGPU/IR/Types/TypeInformationManager.cs
@@ -345,6 +345,7 @@ namespace ILGPU.IR.Types
         {
             if (disposing)
                 cachingLock.Dispose();
+            base.Dispose(disposing);
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/Accelerator.cs
+++ b/Src/ILGPU/Runtime/Accelerator.cs
@@ -672,6 +672,7 @@ namespace ILGPU.Runtime
                 DisposeChildObjects();
                 DisposeGC();
             }
+            base.Dispose(disposing);
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/Accelerator.cs
+++ b/Src/ILGPU/Runtime/Accelerator.cs
@@ -115,7 +115,7 @@ namespace ILGPU.Runtime
         /// temporary memory.
         /// </summary>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private MemoryBufferCache memoryCache;
+        private readonly MemoryBufferCache memoryCache;
 
         /// <summary>
         /// Constructs a new accelerator.
@@ -656,22 +656,22 @@ namespace ILGPU.Runtime
         #region IDisposable
 
         /// <summary cref="DisposeBase.Dispose(bool)"/>
-        [SuppressMessage("Microsoft.Usage", "CA2213:DisposableFieldsShouldBeDisposed", MessageId = "memoryCache",
-            Justification = "Dispose method will be invoked by a helper method")]
         protected override void Dispose(bool disposing)
         {
-            Disposed?.Invoke(this, EventArgs.Empty);
-
-            if (disposing && currentAccelerator == this)
+            if (disposing)
             {
-                OnUnbind();
-                currentAccelerator = null;
+                Disposed?.Invoke(this, EventArgs.Empty);
+                if (currentAccelerator == this)
+                {
+                    OnUnbind();
+                    currentAccelerator = null;
+                }
+
+                memoryCache.Dispose();
+
+                DisposeChildObjects();
+                DisposeGC();
             }
-
-            Dispose(ref memoryCache);
-
-            DisposeChildObjects();
-            DisposeGC();
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/ArrayViewSource.cs
+++ b/Src/ILGPU/Runtime/ArrayViewSource.cs
@@ -130,13 +130,6 @@ namespace ILGPU.Runtime
             AcceleratorStream stream,
             Index byteOffset,
             Index byteExtent) => throw new InvalidOperationException();
-
-        #region IDispoable
-
-        /// <summary cref="DisposeBase.Dispose(bool)"/>
-        protected override void Dispose(bool disposing) { }
-
-        #endregion
     }
 
     /// <summary>
@@ -173,6 +166,7 @@ namespace ILGPU.Runtime
                 Marshal.FreeHGlobal(NativePtr);
                 NativePtr = IntPtr.Zero;
             }
+            base.Dispose(disposing);
         }
 
         #endregion
@@ -213,12 +207,5 @@ namespace ILGPU.Runtime
             AcceleratorStream stream,
             Index byteOffset,
             Index byteExtent) => throw new InvalidOperationException();
-
-        #region IDispoable
-
-        /// <summary cref="DisposeBase.Dispose(bool)"/>
-        protected override void Dispose(bool disposing) { }
-
-        #endregion
     }
 }

--- a/Src/ILGPU/Runtime/ArrayViewSource.cs
+++ b/Src/ILGPU/Runtime/ArrayViewSource.cs
@@ -168,8 +168,11 @@ namespace ILGPU.Runtime
         /// <summary cref="DisposeBase.Dispose(bool)"/>
         protected override void Dispose(bool disposing)
         {
-            base.Dispose(disposing);
-            Marshal.FreeHGlobal(NativePtr);
+            if (NativePtr != IntPtr.Zero)
+            {
+                Marshal.FreeHGlobal(NativePtr);
+                NativePtr = IntPtr.Zero;
+            }
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/CPU/CPUAccelerator.cs
+++ b/Src/ILGPU/Runtime/CPU/CPUAccelerator.cs
@@ -499,21 +499,23 @@ namespace ILGPU.Runtime.CPU
         /// <summary cref="DisposeBase.Dispose(bool)"/>
         protected override void Dispose(bool disposing)
         {
-            base.Dispose(disposing);
-
-            lock (taskSynchronizationObject)
+            if (disposing)
             {
-                running = false;
-                currentTask = null;
-                Monitor.PulseAll(taskSynchronizationObject);
+                lock (taskSynchronizationObject)
+                {
+                    running = false;
+                    currentTask = null;
+                    Monitor.PulseAll(taskSynchronizationObject);
+                }
+                foreach (var thread in threads)
+                    thread.Join();
+                threads = null;
+                foreach (var group in groupContexts)
+                    group.Dispose();
+                groupContexts = null;
+                finishedEvent.Dispose();
             }
-            foreach (var thread in threads)
-                thread.Join();
-            threads = null;
-            foreach (var group in groupContexts)
-                group.Dispose();
-            groupContexts = null;
-            finishedEvent.Dispose();
+            base.Dispose(disposing);
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/CPU/CPUAcceleratorId.cs
+++ b/Src/ILGPU/Runtime/CPU/CPUAcceleratorId.cs
@@ -9,8 +9,6 @@
 // Illinois Open Source License. See LICENSE.txt for details
 // -----------------------------------------------------------------------------
 
-using ILGPU.Util;
-
 namespace ILGPU.Runtime.CPU
 {
     /// <summary>
@@ -36,13 +34,6 @@ namespace ILGPU.Runtime.CPU
         private CPUAcceleratorId()
             : base(AcceleratorType.CPU)
         { }
-
-        #endregion
-
-        #region IDisposable
-
-        /// <summary cref="DisposeBase.Dispose(bool)"/>
-        protected override void Dispose(bool disposing) { }
 
         #endregion
     }

--- a/Src/ILGPU/Runtime/CPU/CPUKernel.cs
+++ b/Src/ILGPU/Runtime/CPU/CPUKernel.cs
@@ -10,7 +10,6 @@
 // -----------------------------------------------------------------------------
 
 using ILGPU.Backends;
-using ILGPU.Util;
 using System;
 using System.Reflection;
 
@@ -53,14 +52,6 @@ namespace ILGPU.Runtime.CPU
         /// Returns the associated kernel-execution delegate.
         /// </summary>
         internal CPUKernelExecutionHandler KernelExecutionDelegate { get; }
-
-        #endregion
-
-        #region IDisposable
-
-        /// <summary cref="DisposeBase.Dispose(bool)"/>
-        protected override void Dispose(bool disposing)
-        { }
 
         #endregion
     }

--- a/Src/ILGPU/Runtime/CPU/CPUMemoryBuffer.cs
+++ b/Src/ILGPU/Runtime/CPU/CPUMemoryBuffer.cs
@@ -126,6 +126,7 @@ namespace ILGPU.Runtime.CPU
                 Marshal.FreeHGlobal(NativePtr);
                 NativePtr = IntPtr.Zero;
             }
+            base.Dispose(disposing);
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/CPU/CPUMemoryBuffer.cs
+++ b/Src/ILGPU/Runtime/CPU/CPUMemoryBuffer.cs
@@ -121,8 +121,11 @@ namespace ILGPU.Runtime.CPU
         /// <summary cref="DisposeBase.Dispose(bool)"/>
         protected override void Dispose(bool disposing)
         {
-            Marshal.FreeHGlobal(NativePtr);
-            NativePtr = IntPtr.Zero;
+            if (NativePtr != IntPtr.Zero)
+            {
+                Marshal.FreeHGlobal(NativePtr);
+                NativePtr = IntPtr.Zero;
+            }
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/CPU/CPURuntimeGroupContext.cs
+++ b/Src/ILGPU/Runtime/CPU/CPURuntimeGroupContext.cs
@@ -369,6 +369,7 @@ namespace ILGPU.Runtime.CPU
                 sharedMemoryBuffer.Dispose();
                 broadcastBuffer.Dispose();
             }
+            base.Dispose(disposing);
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/CPU/CPURuntimeGroupContext.cs
+++ b/Src/ILGPU/Runtime/CPU/CPURuntimeGroupContext.cs
@@ -14,7 +14,6 @@ using ILGPU.Util;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
@@ -77,12 +76,12 @@ namespace ILGPU.Runtime.CPU
         /// <summary>
         /// The general group barrier.
         /// </summary>
-        private Barrier groupBarrier;
+        private readonly Barrier groupBarrier;
 
         /// <summary>
         /// A temporary location for broadcast values.
         /// </summary>
-        private MemoryBuffer<byte> broadcastBuffer;
+        private readonly MemoryBuffer<byte> broadcastBuffer;
 
         /// <summary>
         /// The current shared memory offset for allocation.
@@ -102,7 +101,7 @@ namespace ILGPU.Runtime.CPU
         /// <summary>
         /// The actual shared-memory buffer.
         /// </summary>
-        private MemoryBufferCache sharedMemoryBuffer;
+        private readonly MemoryBufferCache sharedMemoryBuffer;
 
         // TODO: remove advancedSharedMemoryBuffer by adjusting
         // the IL-code in debug builds
@@ -362,16 +361,14 @@ namespace ILGPU.Runtime.CPU
         #region IDisposable
 
         /// <summary cref="DisposeBase.Dispose(bool)"/>
-        [SuppressMessage("Microsoft.Usage", "CA2213:DisposableFieldsShouldBeDisposed", MessageId = "groupBarrier", Justification = "Dispose method will be invoked by a helper method")]
-        [SuppressMessage("Microsoft.Usage", "CA2213:DisposableFieldsShouldBeDisposed", MessageId = "sharedMemoryBuffer", Justification = "Dispose method will be invoked by a helper method")]
         protected override void Dispose(bool disposing)
         {
-            if (groupBarrier == null)
-                return;
-
-            Dispose(ref groupBarrier);
-            Dispose(ref sharedMemoryBuffer);
-            Dispose(ref broadcastBuffer);
+            if (disposing)
+            {
+                groupBarrier.Dispose();
+                sharedMemoryBuffer.Dispose();
+                broadcastBuffer.Dispose();
+            }
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/CPU/CPUStream.cs
+++ b/Src/ILGPU/Runtime/CPU/CPUStream.cs
@@ -9,8 +9,6 @@
 // Illinois Open Source License. See LICENSE.txt for details
 // -----------------------------------------------------------------------------
 
-using ILGPU.Util;
-
 namespace ILGPU.Runtime.CPU
 {
     /// <summary>
@@ -34,14 +32,6 @@ namespace ILGPU.Runtime.CPU
 
         /// <summary cref="AcceleratorStream.Synchronize"/>
         public override void Synchronize()
-        { }
-
-        #endregion
-
-        #region IDisposable
-
-        /// <summary cref="DisposeBase.Dispose(bool)"/>
-        protected override void Dispose(bool disposing)
         { }
 
         #endregion

--- a/Src/ILGPU/Runtime/Cuda/CudaAccelerator.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaAccelerator.cs
@@ -618,11 +618,13 @@ namespace ILGPU.Runtime.Cuda
         /// <summary cref="DisposeBase.Dispose(bool)"/>
         protected override void Dispose(bool disposing)
         {
+            if (contextPtr != IntPtr.Zero)
+            {
+                CudaException.ThrowIfFailed(
+                    CurrentAPI.DestroyContext(contextPtr));
+                contextPtr = IntPtr.Zero;
+            }
             base.Dispose(disposing);
-
-            CudaException.ThrowIfFailed(
-                CurrentAPI.DestroyContext(contextPtr));
-            contextPtr = IntPtr.Zero;
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/Cuda/CudaAcceleratorId.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaAcceleratorId.cs
@@ -9,7 +9,6 @@
 // Illinois Open Source License. See LICENSE.txt for details
 // -----------------------------------------------------------------------------
 
-using ILGPU.Util;
 using System;
 
 namespace ILGPU.Runtime.Cuda
@@ -69,13 +68,6 @@ namespace ILGPU.Runtime.Cuda
         /// <returns>The string representation of this accelerator id.</returns>
         public override string ToString() =>
             $"Device {DeviceId}, {base.ToString()}";
-
-        #endregion
-
-        #region IDisposable
-
-        /// <summary cref="DisposeBase.Dispose(bool)"/>
-        protected override void Dispose(bool disposing) { }
 
         #endregion
     }

--- a/Src/ILGPU/Runtime/Cuda/CudaKernel.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaKernel.cs
@@ -100,9 +100,13 @@ namespace ILGPU.Runtime.Cuda
         /// <summary cref="DisposeBase.Dispose(bool)"/>
         protected override void Dispose(bool disposing)
         {
-            CudaException.ThrowIfFailed(CudaAPI.Current.DestroyModule(modulePtr));
-            functionPtr = IntPtr.Zero;
-            modulePtr = IntPtr.Zero;
+            if (modulePtr != IntPtr.Zero)
+            {
+                CudaException.ThrowIfFailed(
+                    CudaAPI.Current.DestroyModule(modulePtr));
+                functionPtr = IntPtr.Zero;
+                modulePtr = IntPtr.Zero;
+            }
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/Cuda/CudaKernel.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaKernel.cs
@@ -107,6 +107,7 @@ namespace ILGPU.Runtime.Cuda
                 functionPtr = IntPtr.Zero;
                 modulePtr = IntPtr.Zero;
             }
+            base.Dispose(disposing);
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/Cuda/CudaMemoryBuffer.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaMemoryBuffer.cs
@@ -135,6 +135,7 @@ namespace ILGPU.Runtime.Cuda
                 CudaException.ThrowIfFailed(CudaAPI.Current.FreeMemory(NativePtr));
                 NativePtr = IntPtr.Zero;
             }
+            base.Dispose(disposing);
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/Cuda/CudaMemoryBuffer.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaMemoryBuffer.cs
@@ -130,8 +130,11 @@ namespace ILGPU.Runtime.Cuda
         /// <summary cref="DisposeBase.Dispose(bool)"/>
         protected override void Dispose(bool disposing)
         {
-            CudaException.ThrowIfFailed(CudaAPI.Current.FreeMemory(NativePtr));
-            NativePtr = IntPtr.Zero;
+            if (NativePtr != IntPtr.Zero)
+            {
+                CudaException.ThrowIfFailed(CudaAPI.Current.FreeMemory(NativePtr));
+                NativePtr = IntPtr.Zero;
+            }
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/Cuda/CudaStream.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaStream.cs
@@ -79,9 +79,11 @@ namespace ILGPU.Runtime.Cuda
         protected override void Dispose(bool disposing)
         {
             if (streamPtr != IntPtr.Zero)
+            {
                 CudaException.ThrowIfFailed(
                     CudaAPI.Current.DestroyStream(streamPtr));
-            streamPtr = IntPtr.Zero;
+                streamPtr = IntPtr.Zero;
+            }
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/Cuda/CudaStream.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaStream.cs
@@ -84,6 +84,7 @@ namespace ILGPU.Runtime.Cuda
                     CudaAPI.Current.DestroyStream(streamPtr));
                 streamPtr = IntPtr.Zero;
             }
+            base.Dispose(disposing);
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/KernelAccelerator.cs
+++ b/Src/ILGPU/Runtime/KernelAccelerator.cs
@@ -12,7 +12,6 @@
 using ILGPU.Backends;
 using ILGPU.Resources;
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace ILGPU.Runtime
@@ -72,8 +71,6 @@ namespace ILGPU.Runtime
         }
 
         /// <summary cref="Accelerator.LoadAutoGroupedKernelInternal(CompiledKernel, out int, out int)"/>
-        [SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope",
-            Justification = "The object must not be disposed here")]
         protected sealed override Kernel LoadAutoGroupedKernelInternal(
             CompiledKernel kernel,
             out int groupSize,

--- a/Src/ILGPU/Runtime/MemoryBufferCache.cs
+++ b/Src/ILGPU/Runtime/MemoryBufferCache.cs
@@ -146,7 +146,8 @@ namespace ILGPU.Runtime
         /// <param name="mode">The clear mode.</param>
         public void ClearCache(ClearCacheMode mode)
         {
-            Dispose(ref cache);
+            cache?.Dispose();
+            cache = null;
         }
 
         #endregion
@@ -156,7 +157,8 @@ namespace ILGPU.Runtime
         /// <summary cref="DisposeBase.Dispose(bool)"/>
         protected override void Dispose(bool disposing)
         {
-            ClearCache(ClearCacheMode.Everything);
+            if (disposing)
+                cache?.Dispose();
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/MemoryBufferCache.cs
+++ b/Src/ILGPU/Runtime/MemoryBufferCache.cs
@@ -159,6 +159,7 @@ namespace ILGPU.Runtime
         {
             if (disposing)
                 cache?.Dispose();
+            base.Dispose(disposing);
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/MemoryBuffers.tt
+++ b/Src/ILGPU/Runtime/MemoryBuffers.tt
@@ -48,7 +48,7 @@ namespace ILGPU.Runtime
         #region Instance
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private MemoryBuffer<T, <#= indexType #>> buffer;
+        private readonly MemoryBuffer<T, <#= indexType #>> buffer;
 
         /// <summary>
         /// Initializes this memory buffer.
@@ -600,7 +600,8 @@ namespace ILGPU.Runtime
         /// <summary cref="DisposeBase.Dispose(bool)"/>
         protected override void Dispose(bool disposing)
         {
-            Dispose(ref buffer);
+            if (disposing)
+                buffer.Dispose();
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/MemoryBuffers.tt
+++ b/Src/ILGPU/Runtime/MemoryBuffers.tt
@@ -602,6 +602,7 @@ namespace ILGPU.Runtime
         {
             if (disposing)
                 buffer.Dispose();
+            base.Dispose(disposing);
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/OpenCL/CLAccelerator.cs
+++ b/Src/ILGPU/Runtime/OpenCL/CLAccelerator.cs
@@ -589,11 +589,13 @@ namespace ILGPU.Runtime.OpenCL
         /// <summary cref="DisposeBase.Dispose(bool)"/>
         protected override void Dispose(bool disposing)
         {
+            if (contextPtr != IntPtr.Zero)
+            {
+                CLException.ThrowIfFailed(
+                    CLAPI.ReleaseContext(contextPtr));
+                contextPtr = IntPtr.Zero;
+            }
             base.Dispose(disposing);
-
-            CLException.ThrowIfFailed(
-                CLAPI.ReleaseContext(contextPtr));
-            contextPtr = IntPtr.Zero;
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/OpenCL/CLAcceleratorId.cs
+++ b/Src/ILGPU/Runtime/OpenCL/CLAcceleratorId.cs
@@ -248,6 +248,7 @@ namespace ILGPU.Runtime.OpenCL
                 CLAPI.ReleaseDevice(DeviceId);
                 DeviceId = IntPtr.Zero;
             }
+            base.Dispose(disposing);
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/OpenCL/CLAcceleratorId.cs
+++ b/Src/ILGPU/Runtime/OpenCL/CLAcceleratorId.cs
@@ -243,8 +243,11 @@ namespace ILGPU.Runtime.OpenCL
         /// <summary cref="DisposeBase.Dispose(bool)"/>
         protected override void Dispose(bool disposing)
         {
-            CLAPI.ReleaseDevice(DeviceId);
-            DeviceId = IntPtr.Zero;
+            if (DeviceId != IntPtr.Zero)
+            {
+                CLAPI.ReleaseDevice(DeviceId);
+                DeviceId = IntPtr.Zero;
+            }
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/OpenCL/CLKernel.cs
+++ b/Src/ILGPU/Runtime/OpenCL/CLKernel.cs
@@ -140,6 +140,7 @@ namespace ILGPU.Runtime.OpenCL
                     CLAPI.ReleaseProgram(programPtr));
                 programPtr = IntPtr.Zero;
             }
+            base.Dispose(disposing);
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/OpenCL/CLKernel.cs
+++ b/Src/ILGPU/Runtime/OpenCL/CLKernel.cs
@@ -128,12 +128,18 @@ namespace ILGPU.Runtime.OpenCL
         /// <summary cref="DisposeBase.Dispose(bool)"/>
         protected override void Dispose(bool disposing)
         {
-            CLException.ThrowIfFailed(
-                CLAPI.ReleaseKernel(kernelPtr) |
-                CLAPI.ReleaseProgram(programPtr));
-
-            programPtr = IntPtr.Zero;
-            kernelPtr = IntPtr.Zero;
+            if (kernelPtr != IntPtr.Zero)
+            {
+                CLException.ThrowIfFailed(
+                    CLAPI.ReleaseKernel(kernelPtr));
+                kernelPtr = IntPtr.Zero;
+            }
+            if (programPtr != IntPtr.Zero)
+            {
+                CLException.ThrowIfFailed(
+                    CLAPI.ReleaseProgram(programPtr));
+                programPtr = IntPtr.Zero;
+            }
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/OpenCL/CLMemoryBuffer.cs
+++ b/Src/ILGPU/Runtime/OpenCL/CLMemoryBuffer.cs
@@ -138,9 +138,12 @@ namespace ILGPU.Runtime.OpenCL
         /// <summary cref="DisposeBase.Dispose(bool)"/>
         protected override void Dispose(bool disposing)
         {
-            CLException.ThrowIfFailed(
-                CLAPI.ReleaseBuffer(NativePtr));
-            NativePtr = IntPtr.Zero;
+            if (NativePtr != IntPtr.Zero)
+            {
+                CLException.ThrowIfFailed(
+                    CLAPI.ReleaseBuffer(NativePtr));
+                NativePtr = IntPtr.Zero;
+            }
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/OpenCL/CLMemoryBuffer.cs
+++ b/Src/ILGPU/Runtime/OpenCL/CLMemoryBuffer.cs
@@ -144,6 +144,7 @@ namespace ILGPU.Runtime.OpenCL
                     CLAPI.ReleaseBuffer(NativePtr));
                 NativePtr = IntPtr.Zero;
             }
+            base.Dispose(disposing);
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/OpenCL/CLStream.cs
+++ b/Src/ILGPU/Runtime/OpenCL/CLStream.cs
@@ -64,9 +64,11 @@ namespace ILGPU.Runtime.OpenCL
         protected override void Dispose(bool disposing)
         {
             if (queuePtr != IntPtr.Zero)
+            {
                 CLException.ThrowIfFailed(
                     CLAPI.ReleaseCommandQueue(queuePtr));
-            queuePtr = IntPtr.Zero;
+                queuePtr = IntPtr.Zero;
+            }
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/OpenCL/CLStream.cs
+++ b/Src/ILGPU/Runtime/OpenCL/CLStream.cs
@@ -69,6 +69,7 @@ namespace ILGPU.Runtime.OpenCL
                     CLAPI.ReleaseCommandQueue(queuePtr));
                 queuePtr = IntPtr.Zero;
             }
+            base.Dispose(disposing);
         }
 
         #endregion

--- a/Src/ILGPU/Util/DisposeBase.cs
+++ b/Src/ILGPU/Util/DisposeBase.cs
@@ -59,6 +59,6 @@ namespace ILGPU.Util
         /// Frees allocated resources.
         /// </summary>
         /// <param name="disposing">True, iff the method is not called by the finalizer.</param>
-        protected abstract void Dispose(bool disposing);
+        protected virtual void Dispose(bool disposing) { }
     }
 }

--- a/Src/ILGPU/Util/DisposeBase.cs
+++ b/Src/ILGPU/Util/DisposeBase.cs
@@ -10,6 +10,7 @@
 // -----------------------------------------------------------------------------
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 
 namespace ILGPU.Util
@@ -24,15 +25,20 @@ namespace ILGPU.Util
         /// <summary>
         /// Triggers the 'dispose' functionality of this object.
         /// </summary>
+        [SuppressMessage("Design", "CA1063:Implement IDisposable Correctly",
+            Justification = "Using DisposeDriver(bool) as thread-safe alternative to Dispose(bool)")]
         public void Dispose()
         {
             DisposeDriver(true);
             GC.SuppressFinalize(this);
         }
 
+
         /// <summary>
         /// The custom finalizer for dispose-base objects.
         /// </summary>
+        [SuppressMessage("Design", "CA1063:Implement IDisposable Correctly",
+            Justification = "Using DisposeDriver(bool) as thread-safe alternative to Dispose(bool)")]
         ~DisposeBase()
         {
             DisposeDriver(false);
@@ -54,17 +60,5 @@ namespace ILGPU.Util
         /// </summary>
         /// <param name="disposing">True, iff the method is not called by the finalizer.</param>
         protected abstract void Dispose(bool disposing);
-
-        /// <summary>
-        /// Disposes the given object and sets its object reference to null.
-        /// </summary>
-        /// <typeparam name="T">The type of the object to dispose.</typeparam>
-        /// <param name="object">The object to dispose.</param>
-        public static void Dispose<T>(ref T @object)
-            where T : class, IDisposable
-        {
-            @object?.Dispose();
-            @object = null;
-        }
     }
 }


### PR DESCRIPTION
hi @m4rs-mt. OK, I've gone through the implementation of `IDisposable` in ILGPU and made some changes to remove all the warnings.

A number of the changes will break the existing ILGPU v0.6.0 API.

- [ ] Removed DisposeBase
  The `DisposeBase` utility class was removed because in the `DisposeBase:Dispose(ref object)` static method was not understood by the FXCop analyzers. In addition, there were only a handful of places that needed the `object?.Dispose()` and `object = null` functionality.

  `IDisposable.Dispose` should be safe to call multiple times. Added an `alreadyDisposed` flag to many classes. This did not necessarily have to use `Interlocked.CompareExchange` everywhere, but I could not be sure which needed to be thread-safe. Also ensured that native handles are reset to `IntPtr.Zero`.

- [ ] Removed unnecessary IDisposable interface from AcceleratorId
  Never disposed anyway

- [x] Removed unnecessary IDisposable interface from AssemblyDebugInformation
  Do not need to hold onto the MetadataReaderProvider

- [ ] Added finalizer only to classes with unmanaged resources
  Finalizers are expensive, and should only be implemented by classes that require them.

- [x] Use auto-implemented property (instead of private member variables)
  `DisposeBase.Dispose(ref object)` required the private member variable to be writable. After removing `DisposeBase`, some member variables did not need to be changed (only set in the constructor).
