### PR TITLE
Increase the LogSize

### DIFF
--- a/Src/ILGPU/Runtime/OpenCL/API/CLAPI.cs
+++ b/Src/ILGPU/Runtime/OpenCL/API/CLAPI.cs
@@ -463,7 +463,7 @@ namespace ILGPU.Runtime.OpenCL.API
             IntPtr device,
             out string buildLog)
         {
-            const int LogSize = 4096;
+            const int LogSize = 32_000;
             var log = stackalloc sbyte[LogSize];
             var error = GetProgramBuildInfo(
                 program,

--- a/Src/ILGPU/Runtime/OpenCL/API/CLAPI.cs
+++ b/Src/ILGPU/Runtime/OpenCL/API/CLAPI.cs
@@ -464,7 +464,7 @@ namespace ILGPU.Runtime.OpenCL.API
             out string buildLog)
         {
             const int LogSize = 32_000;
-            var log = stackalloc sbyte[LogSize];
+            var log = new sbyte[LogSize];
             var error = GetProgramBuildInfo(
                 program,
                 device,


### PR DESCRIPTION
I have encounter open-cl bugs with AMD when running the test suits. I need logSize to be way bigger then usual, as it crashes when the LogSize is not big enough.