### PR TITLE
Fixed nested structure type generator

### DIFF
--- a/Src/ILGPU.Tests/Configurations.txt
+++ b/Src/ILGPU.Tests/Configurations.txt
@@ -24,3 +24,5 @@ ReinterpretCasts: Debug, Release
 BasicIfs: Debug, Release
 BasicLoops: Debug, Release
 BasicSwitches: Debug, Release
+
+TypeGenerator: Debug, Release

--- a/Src/ILGPU.Tests/TypeGenerator.cs
+++ b/Src/ILGPU.Tests/TypeGenerator.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ILGPU.Tests
+{
+    public abstract class TypeGenerator : TestBase
+    {
+        protected TypeGenerator(ITestOutputHelper output, ContextProvider contextProvider)
+            : base(output, contextProvider)
+        { }
+
+
+        public struct CompositeStruct
+        {
+            public CompositeStructComponent1 Field;
+        }
+
+        public struct CompositeStructComponent1
+        {
+            public CompositeStructComponent2 Field;
+        }
+
+        public struct CompositeStructComponent2
+        {
+            public int Field1;
+            public float Field2;
+        }
+        
+        public static void CompositeStructTypeKernel(Index index, CompositeStruct nestedStruct)
+        {
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [KernelMethod(nameof(CompositeStructTypeKernel))]
+        public void CompositeStructGeneratedCorrectly(int length)
+        {
+            Execute(
+                length,
+                new CompositeStruct()
+            );
+        }
+    }
+}

--- a/Src/ILGPU/Resources/ErrorMessages.Designer.cs
+++ b/Src/ILGPU/Resources/ErrorMessages.Designer.cs
@@ -608,5 +608,14 @@ namespace ILGPU.Resources {
                 return ResourceManager.GetString("NoUses", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Too many nested structure or circular referernce.
+        /// </summary>
+        internal static string TooManyNestedStructure {
+            get {
+                return ResourceManager.GetString("TooManyNestedStructure", resourceCulture);
+            }
+        }
     }
 }

--- a/Src/ILGPU/Resources/ErrorMessages.resx
+++ b/Src/ILGPU/Resources/ErrorMessages.resx
@@ -300,4 +300,7 @@
   <data name="NotSupportedDynamicSharedMemoryAllocations" xml:space="preserve">
     <value>Dynamic shared memory allocations are not supported by this accelerator</value>
   </data>
+  <data name="TooManyNestedStructure" xml:space="preserve">
+    <value>Too many nested structure or circular referernce</value>
+  </data>
 </root>


### PR DESCRIPTION
Issue: compile kernel code that contains a struct like this will generate invalid kernel code for OpenCL:

        public struct CompositeStruct
        {
            public CompositeStructComponent1 Field;
        }

        public struct CompositeStructComponent1
        {
            public CompositeStructComponent2 Field;
        }

        public struct CompositeStructComponent2
        {
            public int Field1;
            public float Field2;
        }

Generated kernel code:

	struct internal_type_10;
	struct internal_type_11;
	struct internal_type_12;
	struct internal_type_13;

	struct internal_type_10
	{
		int field_0;
	};
	struct internal_type_12
	{
		struct internal_type_13 field_0;
	};
	struct internal_type_11
	{
		struct internal_type_12 field_0;
	};
	struct internal_type_13
	{
		int field_0;
		float field_1;
	};


which will cause an error: 


	3:12:26: error: field has incomplete type 'struct internal_type_13'
			struct internal_type_13 field_0;
									^
	3:4:8: note: forward declaration of 'struct internal_type_13'
	struct internal_type_13;
		   ^


Suggested fix: the GetSerializedTypeList method should do a deep check when it is checking if a structure is referencing another structure.