### PR TITLE
Fixed OpenCL primitive type generation when using Force32BitFloats

### DIFF
--- a/Src/ILGPU/Backends/OpenCL/CLTypeGenerator.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLTypeGenerator.cs
@@ -173,6 +173,8 @@ namespace ILGPU.Backends.OpenCL
 
             foreach (var basicValueType in IRTypeContext.BasicValueTypes)
             {
+                if (basicValueType == BasicValueType.Float64 && TypeContext.Context.HasFlags(ContextFlags.Force32BitFloats))
+                    continue;
                 var primitiveType = typeContext.GetPrimitiveType(basicValueType);
                 mapping[primitiveType] = GetBasicValueType(basicValueType);
             }


### PR DESCRIPTION
When using `ContextFlags.Force32BitFloats`, the mapping gets populated with `mapping[Float32] = "float"`, and then incorrectly overridden with `mapping[Float32] = "double"`.

NB: There may be another potential problem in [IRTypeContext.cs](https://github.com/m4rs-mt/ILGPU/blob/eee9e1bbfd8d652c2e6ff5956c8163cb7a94f7f3/Src/ILGPU/IR/Types/IRTypeContext.cs#L421) - the `ClearCache` method does not have any logic to deal with `ContextFlags.Force32BitFloats`.

Related to #85