### PR TITLE
Fixed issue with using IsNan intrinsic

### DIFF
--- a/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Values.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Values.cs
@@ -72,7 +72,7 @@ namespace ILGPU.Backends.OpenCL
             statement.AppendCast(value.ArithmeticBasicValueType);
             var operation = CLInstructions.GetArithmeticOperation(
                 value.Kind,
-                value.BasicValueType.IsFloat(),
+                value.ArithmeticBasicValueType.IsFloat(),
                 out bool isFunction);
 
             if (isFunction)

--- a/Src/ILGPU/Util/TypeExtensions.cs
+++ b/Src/ILGPU/Util/TypeExtensions.cs
@@ -364,6 +364,23 @@ namespace ILGPU.Util
         }
 
         /// <summary>
+        /// Returns true if the given arithmetic basic value type represents a float.
+        /// </summary>
+        /// <param name="value">The arithmetic basic value type.</param>
+        /// <returns>True, if the given arithmetic basic value represents a float.</returns>
+        public static bool IsFloat(this ArithmeticBasicValueType value)
+        {
+            switch (value)
+            {
+                case ArithmeticBasicValueType.Float32:
+                case ArithmeticBasicValueType.Float64:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
         /// Converts the given type into conversion target flags.
         /// </summary>
         /// <param name="type">The type to convert.</param>


### PR DESCRIPTION
In [`Arithmetic.cs`](https://github.com/m4rs-mt/ILGPU/blob/eee9e1bbfd8d652c2e6ff5956c8163cb7a94f7f3/Src/ILGPU/IR/Values/Arithmetic.cs#L370), the code changes the basic value type of IsNan to `Int1`.