### PR TITLE
Fixed OpenCL unary logical not operation on boolean

### DIFF
--- a/Src/ILGPU.Tests/UnaryIntOperations.tt
+++ b/Src/ILGPU.Tests/UnaryIntOperations.tt
@@ -10,7 +10,10 @@ using Xunit.Abstractions;
 <#
 var operationConfigurations = new (string, string, string, bool)[]
     {
-        ("Neg", "~", "", true),
+        ("Neg", "-", "", false),
+
+        ("BitwiseNot", "~", "", true),
+        ("BitwiseNot", "~", "", false),
 
         ("Abs", "IntrinsicMath.Abs(", ")", false),
     };

--- a/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Values.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Values.cs
@@ -72,7 +72,7 @@ namespace ILGPU.Backends.OpenCL
             statement.AppendCast(value.ArithmeticBasicValueType);
             var operation = CLInstructions.GetArithmeticOperation(
                 value.Kind,
-                value.ArithmeticBasicValueType.IsFloat(),
+                value.ArithmeticBasicValueType,
                 out bool isFunction);
 
             if (isFunction)

--- a/Src/ILGPU/Backends/OpenCL/CLInstructions.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLInstructions.cs
@@ -12,6 +12,7 @@
 using ILGPU.IR;
 using ILGPU.IR.Values;
 using ILGPU.Runtime.OpenCL;
+using ILGPU.Util;
 
 namespace ILGPU.Backends.OpenCL
 {
@@ -54,19 +55,18 @@ namespace ILGPU.Backends.OpenCL
         /// Resolves an unary arithmetic operation.
         /// </summary>
         /// <param name="kind">The arithmetic kind.</param>
-        /// <param name="isFloat">True, if this is a floating-point operation.</param>
+        /// <param name="basicValueType">The arithmetic basic value type.</param>
         /// <param name="isFunction">
         /// True, if the resolved operation is a function call.
         /// </param>
         /// <returns>The resolved arithmetic operation.</returns>
         public static string GetArithmeticOperation(
             UnaryArithmeticKind kind,
-            bool isFloat,
+            ArithmeticBasicValueType basicValueType,
             out bool isFunction)
         {
-            if (!UnaryArithmeticOperations.TryGetValue(
-                (kind, isFloat),
-                out var operation))
+            if (!UnaryCategoryLookup.TryGetValue(basicValueType, out var category) ||
+                !UnaryArithmeticOperations.TryGetValue((kind, category), out var operation))
             {
                 throw new NotSupportedIntrinsicException(kind.ToString());
             }


### PR DESCRIPTION
`ILGPU.Tests.OpenCL.CLBasicIfs.IfAndOr` fails because bitwise not `~` does not always work on a boolean - depends on the internal representation. Changed to logical not `!`.