### PR TITLE
Fixed inlining OpenCL constants on if statements and function arguments

### DIFF
--- a/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Emitter.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Emitter.cs
@@ -425,22 +425,16 @@ namespace ILGPU.Backends.OpenCL
             /// Appends a constant.
             /// </summary>
             /// <param name="value">The constant to append.</param>
-            public void AppendConstant(long value)
-            {
-                AppendArgument();
+            public void AppendConstant(long value) =>
                 stringBuilder.Append(value);
-            }
 
             /// <summary>
             /// Appends a constant.
             /// </summary>
             /// <param name="value">The constant to append.</param>
             [CLSCompliant(false)]
-            public void AppendConstant(ulong value)
-            {
-                AppendArgument();
+            public void AppendConstant(ulong value) =>
                 stringBuilder.Append(value);
-            }
 
             /// <summary>
             /// Appends a constant.
@@ -448,8 +442,6 @@ namespace ILGPU.Backends.OpenCL
             /// <param name="value">The constant to append.</param>
             public void AppendConstant(float value)
             {
-                AppendArgument();
-
                 if (float.IsNaN(value))
                 {
                     stringBuilder.Append("NAN");
@@ -479,8 +471,6 @@ namespace ILGPU.Backends.OpenCL
             /// <param name="value">The constant to append.</param>
             public void AppendConstant(double value)
             {
-                AppendArgument();
-
                 if (double.IsNaN(value))
                 {
                     stringBuilder.Append("NAN");

--- a/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Terminators.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Terminators.cs
@@ -37,14 +37,24 @@ namespace ILGPU.Backends.OpenCL
             // See also EmitImplicitKernelIndex
 
             var condition = Load(branch.Condition);
-            AppendIndent();
-            Builder.Append("if (");
-            Builder.Append(condition.ToString());
-            Builder.AppendLine(")");
-            PushIndent();
-            GotoStatement(branch.TrueTarget);
-            PopIndent();
-            GotoStatement(branch.FalseTarget);
+            if (condition is ConstantVariable constantVariable)
+            {
+                if (constantVariable.Value.RawValue != 0)
+                    GotoStatement(branch.TrueTarget);
+                else
+                    GotoStatement(branch.FalseTarget);
+            }
+            else
+            {
+                AppendIndent();
+                Builder.Append("if (");
+                Builder.Append(condition.ToString());
+                Builder.AppendLine(")");
+                PushIndent();
+                GotoStatement(branch.TrueTarget);
+                PopIndent();
+                GotoStatement(branch.FalseTarget);
+            }
         }
 
         /// <summary cref="IBackendCodeGenerator.GenerateCode(SwitchBranch)"/>


### PR DESCRIPTION
Fixed regression from commit 0609ea8b0a7be3dae746992c6c1e5dcaad54662e

`ILGPU.Tests.OpenCL.CLArrayViews_Debug.ArrayViewGetSubVariableView` kernel compilation failed because it generated code like `if (var20)` - `var20` was a constant, and never declared.

`ILGPU.Tests.OpenCL.CLGroupOperations_Debug.GroupDivergentControlFlow` kernel compilation failed because it generated code like `atomic_fetch_add ((atomic_int*)var12, , 1);` - appending the constant added a second/invalid comma.