### PR TITLE
Fixed initialisation of GroupDivergentControlFlow unit test

### DIFF
--- a/Src/ILGPU.Tests/GroupOperations.cs
+++ b/Src/ILGPU.Tests/GroupOperations.cs
@@ -259,6 +259,7 @@ namespace ILGPU.Tests
             {
                 using var buffer = Accelerator.Allocate<int>(length * i);
                 buffer.MemSetToZero();
+                Accelerator.Synchronize();
 
                 var extent = new KernelConfig(length, i);
                 Execute(extent, buffer.View);

--- a/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Emitter.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Emitter.cs
@@ -425,22 +425,16 @@ namespace ILGPU.Backends.OpenCL
             /// Appends a constant.
             /// </summary>
             /// <param name="value">The constant to append.</param>
-            public void AppendConstant(long value)
-            {
-                AppendArgument();
+            public void AppendConstant(long value) =>
                 stringBuilder.Append(value);
-            }
 
             /// <summary>
             /// Appends a constant.
             /// </summary>
             /// <param name="value">The constant to append.</param>
             [CLSCompliant(false)]
-            public void AppendConstant(ulong value)
-            {
-                AppendArgument();
+            public void AppendConstant(ulong value) =>
                 stringBuilder.Append(value);
-            }
 
             /// <summary>
             /// Appends a constant.
@@ -448,8 +442,6 @@ namespace ILGPU.Backends.OpenCL
             /// <param name="value">The constant to append.</param>
             public void AppendConstant(float value)
             {
-                AppendArgument();
-
                 if (float.IsNaN(value))
                 {
                     stringBuilder.Append("NAN");
@@ -479,8 +471,6 @@ namespace ILGPU.Backends.OpenCL
             /// <param name="value">The constant to append.</param>
             public void AppendConstant(double value)
             {
-                AppendArgument();
-
                 if (double.IsNaN(value))
                 {
                     stringBuilder.Append("NAN");

--- a/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Terminators.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Terminators.cs
@@ -37,14 +37,24 @@ namespace ILGPU.Backends.OpenCL
             // See also EmitImplicitKernelIndex
 
             var condition = Load(branch.Condition);
-            AppendIndent();
-            Builder.Append("if (");
-            Builder.Append(condition.ToString());
-            Builder.AppendLine(")");
-            PushIndent();
-            GotoStatement(branch.TrueTarget);
-            PopIndent();
-            GotoStatement(branch.FalseTarget);
+            if (condition is ConstantVariable constantVariable)
+            {
+                if (constantVariable.Value.RawValue != 0)
+                    GotoStatement(branch.TrueTarget);
+                else
+                    GotoStatement(branch.FalseTarget);
+            }
+            else
+            {
+                AppendIndent();
+                Builder.Append("if (");
+                Builder.Append(condition.ToString());
+                Builder.AppendLine(")");
+                PushIndent();
+                GotoStatement(branch.TrueTarget);
+                PopIndent();
+                GotoStatement(branch.FalseTarget);
+            }
         }
 
         /// <summary cref="IBackendCodeGenerator.GenerateCode(SwitchBranch)"/>


### PR DESCRIPTION
Related to #106

NOTE: Includes PR #112

NOTE: My OpenCL accelerator appears to deadlock on these unit tests when `i >= 16`
Intel HD Graphics 630 on OpenCL v1.2
