### PR TITLE
Add automatic publishing of new versions to NuGet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,21 @@ jobs:
           nuget-version: '5.x'
       - name: Create NuGet package
         run: nuget pack .nuget/ILGPU.nuspec
-      - name: Upload NuGet package
+      - name: Upload NuGet package artifact
         if: runner.os == 'Windows'
         uses: actions/upload-artifact@v2
         with:
           name: nuget-package
           path: ILGPU.*.nupkg
+
+  publish-nuget:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: build-and-test
+    runs-on: windows-latest
+    steps:
+      - name: Download NuGet package artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: nuget-package
+      - name: Publish to NuGet
+        run: dotnet nuget push ILGPU.*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
This builds on the CI pipeline added in #117 and adds automatic publishing of releases to NuGet.

For this to work it will require going to Settings -> Secrets and then adding your NuGet API key as a new secret with name = "NUGET_API_KEY".

This will publish to NuGet whenever a tag is pushed that matches `v*`. Alternatively you could create releases through the GitHub UI, and in that case the action could be updated to run when a release is published instead with something like:
```
on:
  push:
  pull_request:
  release:
    types:
      - published
```
and then the condition for the job would be:
```
if: github.event_name == 'release'
```