### PR TITLE
Add MacOS to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
   build-and-test:
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,12 @@ jobs:
       - name: CPU Tests
         run: dotnet test --configuration=Release ./Src/ILGPU.Tests.CPU
       - name: Set up NuGet
+        if: runner.os == 'Windows'
         uses: nuget/setup-nuget@v1
         with:
           nuget-version: '5.x'
       - name: Create NuGet package
+        if: runner.os == 'Windows'
         run: nuget pack .nuget/ILGPU.nuspec
       - name: Upload NuGet package artifact
         if: runner.os == 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
   build-and-test:
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-latest]
+        os: [ubuntu-18.04, windows-latest, macos-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Setup .NET Core SDK
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.300
       - name: Restore tools
         run: dotnet tool restore
         working-directory: ./Src

--- a/Src/ILGPU.Tests.CPU/ILGPU.Tests.CPU.csproj
+++ b/Src/ILGPU.Tests.CPU/ILGPU.Tests.CPU.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Src/ILGPU.Tests.Cuda/ILGPU.Tests.Cuda.csproj
+++ b/Src/ILGPU.Tests.Cuda/ILGPU.Tests.Cuda.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Src/ILGPU.Tests.OpenCL/ILGPU.Tests.OpenCL.csproj
+++ b/Src/ILGPU.Tests.OpenCL/ILGPU.Tests.OpenCL.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Src/ILGPU.Tests/ArrayViews.cs
+++ b/Src/ILGPU.Tests/ArrayViews.cs
@@ -381,7 +381,7 @@ namespace ILGPU.Tests
             data[index] = otherKernel[index];
         }
 
-        [WindowsOnlyTheory("Fails to create type information for ArrayView on Linux")]
+        [WindowsOnlyTheory("Fails to create type information for ArrayView on Unix")]
         [InlineData(1)]
         [InlineData(17)]
         [InlineData(1025)]

--- a/Src/ILGPU.Tests/ILGPU.Tests.csproj
+++ b/Src/ILGPU.Tests/ILGPU.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <StartupObject />
   </PropertyGroup>

--- a/Src/ILGPU.Tests/StructureValues.cs
+++ b/Src/ILGPU.Tests/StructureValues.cs
@@ -124,7 +124,7 @@ namespace ILGPU.Tests
             value.Val2[index] = val2;
         }
 
-        [WindowsOnlyTheory("Fails to create type information for ArrayView on Linux")]
+        [WindowsOnlyTheory("Fails to create type information for ArrayView on Unix")]
         [MemberData(nameof(StructureInteropData))]
         [KernelMethod(nameof(StructureViewInteropKernel))]
         public void StructureViewInterop<T>(T value)

--- a/Src/ILGPU/ILGPU.csproj
+++ b/Src/ILGPU/ILGPU.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net47;netcoreapp2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net47;netcoreapp2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks Condition="'$(OS)' == 'Unix'">netcoreapp2.0;netstandard2.1</TargetFrameworks>
         <OutputPath>../../Bin/$(Configuration)/</OutputPath>
         <DocumentationFile>../../Bin/$(Configuration)/ILGPU.xml</DocumentationFile>
         <Configurations>Debug;Release</Configurations>
@@ -46,13 +47,6 @@
         <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
         <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
         <PackageReference Include="System.Reflection.Metadata" Version="1.8.0" />
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(OS)' != 'Windows_NT'">
-        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Also addresses other related comments from @jgiannuzzi  on #117.

I wonder what people think about using -latest vs specific OS versions? I had copied what Parquet sharp used with ubuntu-18.04 and windows-latest but seems a bit inconsistent to fix the Ubuntu version and not Windows and Mac.

Am making this as a draft PR for now as the Mac build seems to be hanging at compiling the T4 templates so need to investigate what's happening there (https://github.com/adamreeve/ILGPU/runs/695667380?check_suite_focus=true).

Edit: Also looks like the MacOS hosts will need the 2.1 runtime installed.