### PR TITLE
Add support for Group.BarrierPopCount on OpenCL

### DIFF
--- a/Src/ILGPU/Backends/PTX/PTXBackend.cs
+++ b/Src/ILGPU/Backends/PTX/PTXBackend.cs
@@ -83,13 +83,6 @@ namespace ILGPU.Backends.PTX
                 transformerBuilder.AddBackendOptimizations(
                     new PTXAcceleratorSpecializer(),
                     context.OptimizationLevel);
-
-                // Append further backend specific transformations in release mode
-                if (!context.HasFlags(ContextFlags.NoInlining))
-                    transformerBuilder.Add(new Inliner());
-                if (context.OptimizationLevel > OptimizationLevel.O0)
-                    transformerBuilder.Add(new SimplifyControlFlow());
-
                 builder.Add(transformerBuilder.ToTransformer());
             });
         }

--- a/Src/ILGPU/IR/Intrinsics/IntrinsicMatchers.tt
+++ b/Src/ILGPU/IR/Intrinsics/IntrinsicMatchers.tt
@@ -22,6 +22,7 @@ var matchers = new (string, string, string)[]
 var typedMatchers = new (string, string, string)[]
     {
         ("Broadcast", "Broadcast", "BroadcastKind"),
+        ("PredicateBarrier", "PredicateBarrier", "PredicateBarrierKind"),
         ("WarpShuffle", "WarpShuffle", "ShuffleKind"),
         ("SubWarpShuffle", "SubWarpShuffle", "ShuffleKind"),
         ("UnaryArithmetic", "UnaryArithmeticValue", "UnaryArithmeticKind"),

--- a/Src/ILGPU/IR/Transformations/Optimizer.cs
+++ b/Src/ILGPU/IR/Transformations/Optimizer.cs
@@ -124,6 +124,11 @@ namespace ILGPU.IR.Transformations
             // Apply final DCE phase in release mode
             if (level > OptimizationLevel.O0)
                 builder.Add(new DeadCodeElimination());
+
+            // Append further backend specific transformations in release mode
+            builder.Add(new Inliner());
+            if (level > OptimizationLevel.O0)
+                builder.Add(new SimplifyControlFlow());
         }
 
         /// <summary>


### PR DESCRIPTION
Using `Group.BarrierPopCount` in OpenCL throws an `InternalCompilerError`, since this function cannot be mapped to a 'native' OpenCL instruction directly. This PR adds a new intrinsic software implementation for OpenCL to implement this function (see also #98).