### PR TITLE
Changed CudaStream implementation to be non-blocking by default.

### DIFF
--- a/Src/ILGPU/Runtime/Cuda/CudaStream.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaStream.cs
@@ -49,7 +49,7 @@ namespace ILGPU.Runtime.Cuda
             CudaException.ThrowIfFailed(
                 CudaAPI.Current.CreateStream(
                     out streamPtr,
-                    StreamFlags.CU_STREAM_DEFAULT));
+                    StreamFlags.CU_STREAM_NON_BLOCKING));
         }
 
         #endregion


### PR DESCRIPTION
The current default behavior of a `CudaStream` instance is to "block" other streams. This is not consistent with the current semantics of an ILGPU `Stream` that is intended to express concurrent operations. 