### PR TITLE
Added support for reverse control-flow analyses using unique exit blocks.

### DIFF
--- a/Src/ILGPU/Frontend/CodeGenerator/CodeGenerator.cs
+++ b/Src/ILGPU/Frontend/CodeGenerator/CodeGenerator.cs
@@ -269,6 +269,10 @@ namespace ILGPU.Frontend
             }
 
             SSABuilder.AssertAllSealed();
+
+            // Ensure that we have a unique exit block
+            MethodBuilder.EnsureUniqueExitBlock();
+
             return MethodBuilder.Method;
         }
 

--- a/Src/ILGPU/IR/BasicBlockCollection.cs
+++ b/Src/ILGPU/IR/BasicBlockCollection.cs
@@ -354,13 +354,15 @@ namespace ILGPU.IR
             // Compute new block order
             var newBlocks = ImmutableArray.CreateBuilder<BasicBlock>(Count);
             TOtherOrder otherOrder = default;
+            var visitor = new TraversalCollectionVisitor<
+                ImmutableArray<BasicBlock>.Builder>(newBlocks);
             otherOrder.Traverse<
-                ImmutableArray<BasicBlock>.Builder,
+                TraversalCollectionVisitor<ImmutableArray<BasicBlock>.Builder>,
                 BasicBlock.SuccessorsProvider<TOtherDirection>,
                 TOtherDirection,
                 BasicBlock.LinkCollection>(
                 newEntryBlock,
-                newBlocks,
+                ref visitor,
                 new BasicBlock.SuccessorsProvider<TOtherDirection>());
 
             // Return updated block collection

--- a/Src/ILGPU/IR/Construction/Method.Builder.cs
+++ b/Src/ILGPU/IR/Construction/Method.Builder.cs
@@ -407,13 +407,15 @@ namespace ILGPU.IR
                 // Compute new block order
                 var newBlocks = ImmutableArray.CreateBuilder<BasicBlock>(blockCounter);
                 TOrder order = default;
+                var visitor = new TraversalCollectionVisitor<
+                    ImmutableArray<BasicBlock>.Builder>(newBlocks);
                 order.Traverse<
-                    ImmutableArray<BasicBlock>.Builder,
+                    TraversalCollectionVisitor<ImmutableArray<BasicBlock>.Builder>,
                     BasicBlock.TerminatorSuccessorsProvider,
                     Forwards,
                     ImmutableArray<BasicBlock>>(
                     EntryBlock,
-                    newBlocks,
+                    ref visitor,
                     new BasicBlock.TerminatorSuccessorsProvider());
 
                 // Return new block collection

--- a/Src/ILGPU/IR/IRContext.cs
+++ b/Src/ILGPU/IR/IRContext.cs
@@ -464,14 +464,9 @@ namespace ILGPU.IR
                         methodMapping,
                         sourceMethod.Blocks);
 
-                    // Create appropriate return instructions
-                    var exitBlocks = rebuilder.Rebuild();
-                    foreach (var (blockBuilder, returnValue) in exitBlocks)
-                    {
-                        blockBuilder.CreateReturn(
-                            returnValue.Location,
-                            returnValue);
-                    }
+                    // Create an appropriate return instruction
+                    var (exitBlock, exitValue) = rebuilder.Rebuild();
+                    exitBlock.CreateReturn(exitValue.Location, exitValue);
                 }
                 Verifier.Verify(targetMethod);
             }

--- a/Src/ILGPU/IR/Verifier.cs
+++ b/Src/ILGPU/IR/Verifier.cs
@@ -286,13 +286,11 @@ namespace ILGPU.IR
                 var exitBlock = Method.Blocks.FindExitBlock();
                 Assert(Method, exitBlock != null);
 
-                // TODO: enable this code in the future once we support unique exit
-                // blocks:
-                // foreach (var block in Method.Blocks)
-                // {
-                //     if (block.Successors.Count < 1)
-                //         Assert(block, block == exitBlock);
-                // }
+                foreach (var block in Method.Blocks)
+                {
+                    if (block.Successors.Count < 1)
+                        Assert(block, block == exitBlock);
+                }
             }
 
             /// <summary>


### PR DESCRIPTION
Currently, methods within the ILGPU IR can have several exit blocks. This requires sophisticated case distinctions in many common reverse control-flow analyses. This PR adds support for these analyses by introducing unique exit blocks for all functions. (see #121)