### PR TITLE
Fixed invalid placement of allocation nodes in LowerArrays.

### DIFF
--- a/Src/ILGPU/IR/Transformations/LowerArrays.cs
+++ b/Src/ILGPU/IR/Transformations/LowerArrays.cs
@@ -93,10 +93,10 @@ namespace ILGPU.IR.Transformations
             // Allocate a memory array in the entry block
             var methodBuilder = builder.MethodBuilder;
             var entryBlock = methodBuilder[methodBuilder.EntryBlock];
-            entryBlock.InsertPosition = 0;
             var arrayLength = entryBlock.ComputeArrayLength(
                 location,
                 value.Extent);
+            entryBlock.SetupInsertPosition(value);
             var newArray = entryBlock.CreateStaticAllocaArray(
                 location,
                 arrayLength,


### PR DESCRIPTION
In special situations, `LowerArrays` can place allocation nodes in the wrong places. This PR solves this problem, which can occur in `PTX` and `OpenCL` backends.