### PR TITLE
New (Value|Block|Node) Lists to reduce the number of heap allocations

### DIFF
--- a/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Values.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Values.cs
@@ -400,7 +400,7 @@ namespace ILGPU.Backends.OpenCL
         {
             var target = Allocate(value);
             Declare(target);
-            for (int i = 0, e = value.NumFields; i < e; ++i)
+            for (int i = 0, e = value.Count; i < e; ++i)
             {
                 using var statement = BeginStatement(target, i);
                 statement.AppendArgument(Load(value[i]));

--- a/Src/ILGPU/Backends/PTX/PTXCodeGenerator.Values.cs
+++ b/Src/ILGPU/Backends/PTX/PTXCodeGenerator.Values.cs
@@ -33,7 +33,7 @@ namespace ILGPU.Backends.PTX
 
             Builder.AppendLine("\t.reg .b32 temp_param_reg;");
 
-            for (int i = 0, e = methodCall.NumArguments; i < e; ++i)
+            for (int i = 0, e = methodCall.Count; i < e; ++i)
             {
                 var argument = methodCall.Nodes[i];
                 var paramName = CallParamName + i;
@@ -64,7 +64,7 @@ namespace ILGPU.Backends.PTX
             }
             Builder.Append(GetMethodName(target));
             Builder.AppendLine(", (");
-            for (int i = 0, e = methodCall.NumArguments; i < e; ++i)
+            for (int i = 0, e = methodCall.Count; i < e; ++i)
             {
                 Builder.Append("\t\t");
                 Builder.Append(CallParamName);
@@ -605,8 +605,8 @@ namespace ILGPU.Backends.PTX
         /// <summary cref="IBackendCodeGenerator.GenerateCode(StructureValue)"/>
         public void GenerateCode(StructureValue value)
         {
-            var childRegisters = ImmutableArray.CreateBuilder<Register>(value.NumFields);
-            for (int i = 0, e = value.NumFields; i < e; ++i)
+            var childRegisters = ImmutableArray.CreateBuilder<Register>(value.Count);
+            for (int i = 0, e = value.Count; i < e; ++i)
                 childRegisters.Add(Load(value[i]));
             Bind(
                 value,

--- a/Src/ILGPU/Backends/PhiBindings.cs
+++ b/Src/ILGPU/Backends/PhiBindings.cs
@@ -193,10 +193,10 @@ namespace ILGPU.Backends
                     allocator.Allocate(block, phi);
 
                     // Determine predecessor mapping
-                    phi.Assert(block.Predecessors.Count == phi.Nodes.Length);
+                    phi.Assert(block.Predecessors.Length == phi.Nodes.Length);
 
                     // Assign values to their appropriate blocks
-                    for (int i = 0, e = phi.Nodes.Length; i < e; ++i)
+                    for (int i = 0, e = phi.Count; i < e; ++i)
                     {
                         var argumentBlock = phi.Sources[i];
                         mapping[argumentBlock].Add((phi[i], phi));

--- a/Src/ILGPU/Frontend/Block.cs
+++ b/Src/ILGPU/Frontend/Block.cs
@@ -15,10 +15,11 @@ using ILGPU.IR.Types;
 using ILGPU.IR.Values;
 using ILGPU.Resources;
 using ILGPU.Util;
-using System.Collections.Immutable;
+using System;
 using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using ValueList = ILGPU.Util.InlineList<ILGPU.IR.Values.ValueReference>;
 
 namespace ILGPU.Frontend
 {
@@ -111,7 +112,7 @@ namespace ILGPU.Frontend
         /// <param name="count">The number of expected branch targets.</param>
         /// <returns>The resolved branch targets.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ImmutableArray<BasicBlock> GetBuilderTerminator(int count)
+        public ReadOnlySpan<BasicBlock> GetBuilderTerminator(int count)
         {
             var targets = ((BuilderTerminator)Terminator).Targets;
             Terminator.Assert(targets.Length == count);
@@ -225,15 +226,14 @@ namespace ILGPU.Frontend
         /// <param name="location">The current location.</param>
         /// <param name="methodBase">The method to use for the argument types.</param>
         /// <param name="instanceValue">The instance value (if available).</param>
-        public ImmutableArray<ValueReference> PopMethodArgs(
+        public ValueList PopMethodArgs(
             Location location,
             MethodBase methodBase,
             Value instanceValue)
         {
             var parameters = methodBase.GetParameters();
             var parameterOffset = methodBase.GetParameterOffset();
-            var result = ImmutableArray.CreateBuilder<ValueReference>(
-                parameters.Length + parameterOffset);
+            var result = ValueList.Create(parameters.Length + parameterOffset);
 
             // Handle main params
             for (int i = parameters.Length - 1; i >= 0; --i)
@@ -275,7 +275,7 @@ namespace ILGPU.Frontend
             }
 
             result.Reverse();
-            return result.MoveToImmutable();
+            return result;
         }
 
         /// <summary>

--- a/Src/ILGPU/Frontend/CodeGenerator/ControlFlow.cs
+++ b/Src/ILGPU/Frontend/CodeGenerator/ControlFlow.cs
@@ -10,6 +10,7 @@
 // ---------------------------------------------------------------------------------------
 
 using ILGPU.IR.Values;
+using ILGPU.Util;
 
 namespace ILGPU.Frontend
 {
@@ -107,10 +108,11 @@ namespace ILGPU.Frontend
             var targets = Block.GetBuilderTerminator(branchTargets.Count);
 
             var switchValue = Block.PopInt(Location, ConvertFlags.TargetUnsigned);
+            var targetList = targets.ToInlineList();
             Builder.CreateSwitchBranch(
                 Location,
                 switchValue,
-                targets);
+                ref targetList);
         }
     }
 }

--- a/Src/ILGPU/Frontend/CodeGenerator/Objects.cs
+++ b/Src/ILGPU/Frontend/CodeGenerator/Objects.cs
@@ -68,7 +68,7 @@ namespace ILGPU.Frontend
 
             // Invoke constructor for type
             var values = Block.PopMethodArgs(Location, method, alloca);
-            CreateCall(constructor, values);
+            CreateCall(constructor, ref values);
 
             // Push created instance on the stack
             Block.Push(CreateLoad(

--- a/Src/ILGPU/Frontend/Intrinsic/AcceleratorIntrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/AcceleratorIntrinsics.cs
@@ -48,12 +48,13 @@ namespace ILGPU.Frontend.Intrinsic
         /// <param name="attribute">The intrinsic attribute.</param>
         /// <returns>The resulting value.</returns>
         private static ValueReference HandleAcceleratorOperation(
-            in InvocationContext context,
+            ref InvocationContext context,
             AcceleratorIntrinsicAttribute attribute)
         {
-            var builder = context.Builder;
-            Debug.Assert(attribute.IntrinsicKind == AcceleratorIntrinsicKind.CurrentType);
-            return builder.CreateAcceleratorTypeValue(context.Location);
+            Debug.Assert(
+                attribute.IntrinsicKind == AcceleratorIntrinsicKind.CurrentType);
+            return context.Builder.CreateAcceleratorTypeValue(
+                context.Location);
         }
     }
 }

--- a/Src/ILGPU/Frontend/Intrinsic/AtomicIntrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/AtomicIntrinsics.cs
@@ -63,7 +63,7 @@ namespace ILGPU.Frontend.Intrinsic
         /// <param name="attribute">The intrinsic attribute.</param>
         /// <returns>The resulting value.</returns>
         private static ValueReference HandleAtomicOperation(
-            in InvocationContext context,
+            ref InvocationContext context,
             AtomicIntrinsicAttribute attribute) =>
             attribute.IntrinsicKind == AtomicIntrinsicKind.CompareExchange
             ? context.Builder.CreateAtomicCAS(

--- a/Src/ILGPU/Frontend/Intrinsic/GridIntrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/GridIntrinsics.cs
@@ -59,7 +59,7 @@ namespace ILGPU.Frontend.Intrinsic
         /// <param name="attribute">The intrinsic attribute.</param>
         /// <returns>The resulting value.</returns>
         private static ValueReference HandleGridOperation(
-            in InvocationContext context,
+            ref InvocationContext context,
             GridIntrinsicAttribute attribute)
         {
             var builder = context.Builder;

--- a/Src/ILGPU/Frontend/Intrinsic/GroupIntrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/GroupIntrinsics.cs
@@ -53,7 +53,7 @@ namespace ILGPU.Frontend.Intrinsic
         /// <param name="attribute">The intrinsic attribute.</param>
         /// <returns>The resulting value.</returns>
         private static ValueReference HandleGroupOperation(
-            in InvocationContext context,
+            ref InvocationContext context,
             GroupIntrinsicAttribute attribute)
         {
             var builder = context.Builder;

--- a/Src/ILGPU/Frontend/Intrinsic/InteropIntrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/InteropIntrinsics.cs
@@ -53,7 +53,7 @@ namespace ILGPU.Frontend.Intrinsic
         /// <param name="attribute">The intrinsic attribute.</param>
         /// <returns>The resulting value.</returns>
         private static ValueReference HandleInterop(
-            in InvocationContext context,
+            ref InvocationContext context,
             InteropIntrinsicAttribute attribute)
         {
             var builder = context.Builder;
@@ -62,14 +62,14 @@ namespace ILGPU.Frontend.Intrinsic
                 InteropIntrinsicKind.SizeOf => builder.CreateSizeOf(
                     context.Location,
                     builder.CreateType(context.GetMethodGenericArguments()[0])),
-                InteropIntrinsicKind.OffsetOf => CreateOffsetOf(context),
+                InteropIntrinsicKind.OffsetOf => CreateOffsetOf(ref context),
                 InteropIntrinsicKind.FloatAsInt => builder.CreateFloatAsIntCast(
                     context.Location,
                     context[0]),
                 InteropIntrinsicKind.IntAsFloat => builder.CreateIntAsFloatCast(
                     context.Location,
                     context[0]),
-                _ => throw context.GetNotSupportedException(
+                _ => throw context.Location.GetNotSupportedException(
                     ErrorMessages.NotSupportedInteropIntrinsic,
                     attribute.IntrinsicKind.ToString()),
             };
@@ -79,7 +79,7 @@ namespace ILGPU.Frontend.Intrinsic
         /// Creates a new offset-of computation.
         /// </summary>
         /// <param name="context">The current invocation context.</param>
-        private static ValueReference CreateOffsetOf(in InvocationContext context)
+        private static ValueReference CreateOffsetOf(ref InvocationContext context)
         {
             var builder = context.Builder;
             var typeInfo = builder.Context.TypeContext.GetTypeInfo(

--- a/Src/ILGPU/Frontend/Intrinsic/MathIntrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/MathIntrinsics.cs
@@ -102,7 +102,7 @@ namespace ILGPU.Frontend.Intrinsic
         /// <param name="attribute">The intrinsic attribute.</param>
         /// <returns>The resulting value.</returns>
         private static ValueReference HandleMathOperation(
-            in InvocationContext context,
+            ref InvocationContext context,
             MathIntrinsicAttribute attribute)
         {
             switch (context.NumArguments)
@@ -123,7 +123,7 @@ namespace ILGPU.Frontend.Intrinsic
                         (BinaryArithmeticKind)kindIndex,
                         attribute.IntrinsicFlags);
                 default:
-                    throw context.GetNotSupportedException(
+                    throw context.Location.GetNotSupportedException(
                         ErrorMessages.NotSupportedMathIntrinsic,
                         context.NumArguments.ToString());
             }

--- a/Src/ILGPU/Frontend/Intrinsic/MemoryBarrierIntrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/MemoryBarrierIntrinsics.cs
@@ -42,7 +42,7 @@ namespace ILGPU.Frontend.Intrinsic
         /// <param name="attribute">The intrinsic attribute.</param>
         /// <returns>The resulting value.</returns>
         private static ValueReference HandleMemoryBarrierOperation(
-            in InvocationContext context,
+            ref InvocationContext context,
             MemoryBarrierIntrinsicAttribute attribute) =>
             context.Builder.CreateMemoryBarrier(
                 context.Location,

--- a/Src/ILGPU/Frontend/Intrinsic/RemappedIntrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/RemappedIntrinsics.cs
@@ -41,8 +41,7 @@ namespace ILGPU.Frontend.Intrinsic
         /// <summary>
         /// Represents a basic remapper for compiler-specific device functions.
         /// </summary>
-        public delegate InvocationContext? DeviceFunctionRemapper(
-            in InvocationContext context);
+        public delegate void DeviceFunctionRemapper(ref InvocationContext context);
 
         /// <summary>
         /// Stores function remappers.
@@ -128,8 +127,7 @@ namespace ILGPU.Frontend.Intrinsic
                 parameters,
                 null);
             AddRemapping(debugMethod,
-                (in InvocationContext context) =>
-                    context.Remap(targetMethod, context.Arguments));
+                (ref InvocationContext context) => context.Method = targetMethod);
         }
 
         #endregion
@@ -166,8 +164,7 @@ namespace ILGPU.Frontend.Intrinsic
 
             AddRemapping(
                 mathFunc,
-                (in InvocationContext context) =>
-                    context.Remap(gpuMathFunc, context.Arguments));
+                (ref InvocationContext context) => context.Method = gpuMathFunc);
         }
 
         /// <summary>
@@ -195,14 +192,8 @@ namespace ILGPU.Frontend.Intrinsic
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void RemapIntrinsic(ref InvocationContext context)
         {
-            if (FunctionRemappers.TryGetValue(
-                context.Method,
-                out DeviceFunctionRemapper remapper))
-            {
-                var newContext = remapper(context);
-                if (newContext.HasValue)
-                    context = newContext.Value;
-            }
+            if (FunctionRemappers.TryGetValue(context.Method, out var remapper))
+                remapper(ref context);
         }
 
         /// <summary>

--- a/Src/ILGPU/Frontend/Intrinsic/SharedMemoryIntrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/SharedMemoryIntrinsics.cs
@@ -51,7 +51,7 @@ namespace ILGPU.Frontend.Intrinsic
         /// <param name="attribute">The intrinsic attribute.</param>
         /// <returns>The resulting value.</returns>
         private static ValueReference HandleSharedMemoryOperation(
-            in InvocationContext context,
+            ref InvocationContext context,
             SharedMemoryIntrinsicAttribute attribute)
         {
             var builder = context.Builder;
@@ -85,7 +85,7 @@ namespace ILGPU.Frontend.Intrinsic
                         alloca,
                         alloca.ArrayLength);
             }
-            throw context.GetNotSupportedException(
+            throw context.Location.GetNotSupportedException(
                 ErrorMessages.NotSupportedSharedMemoryIntrinsic,
                 attribute.IntrinsicKind.ToString());
         }

--- a/Src/ILGPU/Frontend/Intrinsic/UtilityIntrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/UtilityIntrinsics.cs
@@ -47,7 +47,7 @@ namespace ILGPU.Frontend.Intrinsic
         /// <param name="attribute">The intrinsic attribute.</param>
         /// <returns>The resulting value.</returns>
         private static ValueReference HandleUtilityOperation(
-            in InvocationContext context,
+            ref InvocationContext context,
             UtilityIntrinsicAttribute attribute) =>
             context.Builder.CreatePredicate(
                 context.Location,

--- a/Src/ILGPU/Frontend/Intrinsic/ViewIntrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/ViewIntrinsics.cs
@@ -60,7 +60,7 @@ namespace ILGPU.Frontend.Intrinsic
         /// <param name="attribute">The intrinsic attribute.</param>
         /// <returns>The resulting value.</returns>
         private static ValueReference HandleViewOperation(
-            in InvocationContext context,
+            ref InvocationContext context,
             ViewIntrinsicAttribute attribute)
         {
             var builder = context.Builder;
@@ -123,7 +123,7 @@ namespace ILGPU.Frontend.Intrinsic
                             context[paramOffset++],
                             new FieldAccess(0))),
                 ViewIntrinsicKind.AsLinearView => instanceValue,
-                _ => throw context.GetNotSupportedException(
+                _ => throw context.Location.GetNotSupportedException(
                     ErrorMessages.NotSupportedViewIntrinsic,
                     attribute.IntrinsicKind.ToString()),
             };

--- a/Src/ILGPU/Frontend/Intrinsic/WarpIntrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/WarpIntrinsics.cs
@@ -63,7 +63,7 @@ namespace ILGPU.Frontend.Intrinsic
         /// <param name="attribute">The intrinsic attribute.</param>
         /// <returns>The resulting value.</returns>
         private static ValueReference HandleWarpOperation(
-            in InvocationContext context,
+            ref InvocationContext context,
             WarpIntrinsicAttribute attribute)
         {
             var builder = context.Builder;
@@ -103,7 +103,7 @@ namespace ILGPU.Frontend.Intrinsic
                         context[1],
                         BroadcastKind.WarpLevel);
                 default:
-                    throw context.GetNotSupportedException(
+                    throw context.Location.GetNotSupportedException(
                         ErrorMessages.NotSupportedWarpIntrinsic,
                         attribute.IntrinsicKind.ToString());
             }

--- a/Src/ILGPU/ILGPU.csproj
+++ b/Src/ILGPU/ILGPU.csproj
@@ -45,7 +45,8 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
-        <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
+        <PackageReference Include="System.Memory" Version="4.5.4" />
+        <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
         <PackageReference Include="System.Reflection.Metadata" Version="1.8.0" />
     </ItemGroup>
 

--- a/Src/ILGPU/IR/Analyses/LoopInfo.cs
+++ b/Src/ILGPU/IR/Analyses/LoopInfo.cs
@@ -145,7 +145,7 @@ namespace ILGPU.IR.Analyses
             // outside the current SCC and one is from the
             // inside of the current SCC
             inductionVariable = default;
-            int numOperands = phiValue.Nodes.Length;
+            int numOperands = phiValue.Count;
             if (numOperands != 2)
                 return false;
 

--- a/Src/ILGPU/IR/Analyses/SCCs.cs
+++ b/Src/ILGPU/IR/Analyses/SCCs.cs
@@ -275,7 +275,7 @@ namespace ILGPU.IR.Analyses
                 var visited = new HashSet<BasicBlock>();
                 foreach (var node in nodes)
                 {
-                    if (node.GetSuccessors<TDirection>().Count < 2)
+                    if (node.GetSuccessors<TDirection>().Length < 2)
                         continue;
 
                     // Check for exit targets

--- a/Src/ILGPU/IR/BasicBlockCollection.cs
+++ b/Src/ILGPU/IR/BasicBlockCollection.cs
@@ -250,7 +250,7 @@ namespace ILGPU.IR
             // Traverse all blocks to find a block without a successor
             foreach (var block in this)
             {
-                if (block.GetSuccessors<TDirection>().Count < 1)
+                if (block.GetSuccessors<TDirection>().Length < 1)
                 {
                     EntryBlock.Assert(exitBlock is null);
                     exitBlock = block;
@@ -270,7 +270,7 @@ namespace ILGPU.IR
             // Traverse all blocks to find a block without a successor
             foreach (var block in this)
             {
-                if (block.GetSuccessors<TDirection>().Count < 1)
+                if (block.GetSuccessors<TDirection>().Length < 1)
                     return block;
             }
 
@@ -385,8 +385,7 @@ namespace ILGPU.IR
             otherOrder.Traverse<
                 TraversalCollectionVisitor<ImmutableArray<BasicBlock>.Builder>,
                 BasicBlock.SuccessorsProvider<TOtherDirection>,
-                TOtherDirection,
-                BasicBlock.LinkCollection>(
+                TOtherDirection>(
                 newEntryBlock,
                 ref visitor,
                 new BasicBlock.SuccessorsProvider<TOtherDirection>());

--- a/Src/ILGPU/IR/Construction/BasicBlock.Builder.cs
+++ b/Src/ILGPU/IR/Construction/BasicBlock.Builder.cs
@@ -13,13 +13,14 @@ using ILGPU.IR.Construction;
 using ILGPU.IR.Types;
 using ILGPU.IR.Values;
 using ILGPU.Util;
+using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
+using ValueList = ILGPU.Util.InlineList<ILGPU.IR.Values.ValueReference>;
 
 namespace ILGPU.IR
 {
@@ -289,7 +290,7 @@ namespace ILGPU.IR
             /// <param name="remapper">The remapper to use.</param>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public void RemapPhiArguments<TArgumentRemapper>(
-                ImmutableArray<BasicBlock> blocks,
+                ReadOnlySpan<BasicBlock> blocks,
                 TArgumentRemapper remapper)
                 where TArgumentRemapper : PhiValue.IArgumentRemapper
             {
@@ -441,10 +442,12 @@ namespace ILGPU.IR
                 int oldPosition = InsertPosition;
                 SetupInsertPosition(value);
 
+                var arguments = ValueList.Empty;
+                value.Nodes.CopyTo(ref arguments);
                 var call = CreateCall(
                     value.Location,
                     implementationMethod,
-                    value.Nodes);
+                    ref arguments);
                 value.Replace(call);
                 Remove(value);
 

--- a/Src/ILGPU/IR/Construction/IRRebuilder.cs
+++ b/Src/ILGPU/IR/Construction/IRRebuilder.cs
@@ -271,7 +271,7 @@ namespace ILGPU.IR.Construction
             foreach (var (sourcePhi, targetPhiBuilder) in phiMapping)
             {
                 // Append all phi arguments
-                for (int i = 0, e = sourcePhi.Nodes.Length; i < e; ++i)
+                for (int i = 0, e = sourcePhi.Count; i < e; ++i)
                 {
                     var argument = sourcePhi.Nodes[i];
                     var newBlock = blockMapping[sourcePhi.Sources[i]];

--- a/Src/ILGPU/IR/Construction/Method.Builder.cs
+++ b/Src/ILGPU/IR/Construction/Method.Builder.cs
@@ -483,8 +483,7 @@ namespace ILGPU.IR
                 order.Traverse<
                     TraversalCollectionVisitor<ImmutableArray<BasicBlock>.Builder>,
                     BasicBlock.TerminatorSuccessorsProvider,
-                    Forwards,
-                    ImmutableArray<BasicBlock>>(
+                    Forwards>(
                     EntryBlock,
                     ref visitor,
                     new BasicBlock.TerminatorSuccessorsProvider());
@@ -515,8 +514,7 @@ namespace ILGPU.IR
                 order.Traverse<
                     ExitBlockVisitor,
                     BasicBlock.TerminatorSuccessorsProvider,
-                    Forwards,
-                    ImmutableArray<BasicBlock>>(
+                    Forwards>(
                     EntryBlock,
                     ref visitor,
                     new BasicBlock.TerminatorSuccessorsProvider());

--- a/Src/ILGPU/IR/Construction/Methods.cs
+++ b/Src/ILGPU/IR/Construction/Methods.cs
@@ -11,27 +11,41 @@
 
 using ILGPU.IR.Types;
 using ILGPU.IR.Values;
-using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
+using ValueList = ILGPU.Util.InlineList<ILGPU.IR.Values.ValueReference>;
 
 namespace ILGPU.IR.Construction
 {
     partial class IRBuilder
     {
         /// <summary>
-        /// Creates a new call node.
+        /// Creates a new call node builder.
         /// </summary>
         /// <param name="location">The current location.</param>
         /// <param name="target">The jump target.</param>
-        /// <param name="arguments">The target arguments.</param>
-        /// <returns>A function call.</returns>
-        public ValueReference CreateCall(
+        /// <returns>A call builder.</returns>
+        public MethodCall.Builder CreateCall(Location location, Method target) =>
+            new MethodCall.Builder(this, location, target);
+
+        /// <summary>
+        /// Creates a new method call.
+        /// </summary>
+        /// <param name="location">The current location.</param>
+        /// <param name="target">The method target.</param>
+        /// <param name="values">The argument values.</param>
+        /// <returns>The created method call value.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal MethodCall CreateCall(
             Location location,
             Method target,
-            ImmutableArray<ValueReference> arguments) =>
-            Append(new MethodCall(
+            ref ValueList values)
+        {
+            location.AssertNotNull(target);
+            return Append(new MethodCall(
                 GetInitializer(location),
                 target,
-                arguments));
+                ref values));
+        }
 
         /// <summary>
         /// Creates a new phi node builder.
@@ -39,14 +53,27 @@ namespace ILGPU.IR.Construction
         /// <param name="location">The current location.</param>
         /// <param name="type">The given node type.</param>
         /// <returns>The created phi builder.</returns>
-        public PhiValue.Builder CreatePhi(Location location, TypeNode type)
+        public PhiValue.Builder CreatePhi(Location location, TypeNode type) =>
+            CreatePhi(location, type, 0);
+
+        /// <summary>
+        /// Creates a new phi node builder.
+        /// </summary>
+        /// <param name="location">The current location.</param>
+        /// <param name="type">The given node type.</param>
+        /// <param name="capacity">The initial capacity.</param>
+        /// <returns>The created phi builder.</returns>
+        public PhiValue.Builder CreatePhi(
+            Location location,
+            TypeNode type,
+            int capacity)
         {
             location.AssertNotNull(type);
 
             var phiNode = CreatePhiValue(new PhiValue(
                 GetInitializer(location),
                 type));
-            return new PhiValue.Builder(phiNode);
+            return new PhiValue.Builder(phiNode, capacity);
         }
 
         /// <summary>

--- a/Src/ILGPU/IR/Construction/SSABuilder.cs
+++ b/Src/ILGPU/IR/Construction/SSABuilder.cs
@@ -328,9 +328,9 @@ namespace ILGPU.IR.Construction
                 TVariable var,
                 ref MarkerProvider markerProvider)
             {
-                Block.Assert(Block.Predecessors.Count > 0);
+                Block.Assert(Block.Predecessors.Length > 0);
                 Value value;
-                if (Block.Predecessors.Count == 1 && IsSealed)
+                if (Block.Predecessors.Length == 1 && IsSealed)
                 {
                     var valueContainer = Parent[Block.Predecessors[0]];
                     value = valueContainer.GetValue(var, ref markerProvider);
@@ -395,7 +395,7 @@ namespace ILGPU.IR.Construction
                     phiBuilder.AddArgument(predecessor, value);
                 }
                 incompletePhi.Location.Assert(
-                    phiBuilder.Count == Block.Predecessors.Count);
+                    phiBuilder.Count == Block.Predecessors.Length);
                 var phiValue = phiBuilder.Seal();
                 return phiValue.TryRemoveTrivialPhi(Parent.MethodBuilder);
             }

--- a/Src/ILGPU/IR/Construction/Structures.cs
+++ b/Src/ILGPU/IR/Construction/Structures.cs
@@ -14,6 +14,7 @@ using ILGPU.IR.Values;
 using ILGPU.Resources;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using ValueList = ILGPU.Util.InlineList<ILGPU.IR.Values.ValueReference>;
 
 namespace ILGPU.IR.Construction
 {
@@ -118,6 +119,17 @@ namespace ILGPU.IR.Construction
         /// Creates a new dynamic structure instance.
         /// </summary>
         /// <param name="location">The current location.</param>
+        /// <param name="values">The initial values.</param>
+        /// <returns>The created structure instance.</returns>
+        public ValueReference CreateDynamicStructure(
+            Location location,
+            ref ValueList values) =>
+            new StructureValue.DynamicBuilder(this, location, ref values).Seal();
+
+        /// <summary>
+        /// Creates a new dynamic structure instance.
+        /// </summary>
+        /// <param name="location">The current location.</param>
         /// <param name="item1">The first item.</param>
         /// <param name="item2">The second item.</param>
         /// <returns>The created structure instance value.</returns>
@@ -175,7 +187,7 @@ namespace ILGPU.IR.Construction
         /// </summary>
         /// <param name="builder">The structure instance builder.</param>
         /// <returns>The created structure instance value.</returns>
-        internal ValueReference FinishStructureBuilder<TBuilder>(in TBuilder builder)
+        internal ValueReference FinishStructureBuilder<TBuilder>(ref TBuilder builder)
             where TBuilder : struct, StructureValue.IInternalBuilder
         {
             if (builder.Count < 1)
@@ -184,11 +196,12 @@ namespace ILGPU.IR.Construction
                 return builder[0];
 
             // Construct structure instance
-            var values = builder.Seal(out var structureType);
+            var values = ValueList.Empty;
+            var structureType = builder.Seal(ref values);
             return Append(new StructureValue(
                 GetInitializer(builder.Location),
                 structureType,
-                values));
+                ref values));
         }
 
         /// <summary>

--- a/Src/ILGPU/IR/IRContext.cs
+++ b/Src/ILGPU/IR/IRContext.cs
@@ -26,6 +26,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using ValueList = ILGPU.Util.InlineList<ILGPU.IR.Values.ValueReference>;
 
 namespace ILGPU.IR
 {
@@ -448,15 +449,15 @@ namespace ILGPU.IR
                 {
                     using var builder = targetMethod.CreateBuilder();
                     // Build new parameters to match the old ones
-                    var parameterArguments = ImmutableArray.CreateBuilder<
-                        ValueReference>(sourceMethod.NumParameters);
+                    var parameterArguments = ValueList.Create(
+                        sourceMethod.NumParameters);
                     foreach (var param in sourceMethod.Parameters)
                     {
                         var newParam = builder.AddParameter(param.Type, param.Name);
                         parameterArguments.Add(newParam);
                     }
                     var parameterMapping = sourceMethod.CreateParameterMapping(
-                        parameterArguments.MoveToImmutable());
+                        parameterArguments);
 
                     // Rebuild the source function into this context
                     var rebuilder = builder.CreateRebuilder<IRRebuilder.CloneMode>(

--- a/Src/ILGPU/IR/Method.cs
+++ b/Src/ILGPU/IR/Method.cs
@@ -191,7 +191,7 @@ namespace ILGPU.IR
         /// <summary>
         /// Represents a parameter mapping.
         /// </summary>
-        public readonly struct ParameterMapping
+        public readonly ref struct ParameterMapping
         {
             #region Instance
 
@@ -202,12 +202,10 @@ namespace ILGPU.IR
             /// <param name="arguments">The parameter arguments.</param>
             internal ParameterMapping(
                 Method method,
-                ImmutableArray<ValueReference> arguments)
+                ReadOnlySpan<ValueReference> arguments)
             {
-                Debug.Assert(method != null, "Invalid method");
-                Debug.Assert(
-                    arguments.Length == method.Parameters.Count,
-                    "Invalid arguments");
+                method.AssertNotNull(method);
+                method.Assert(arguments.Length == method.Parameters.Count);
 
                 Method = method;
                 Arguments = arguments;
@@ -225,19 +223,19 @@ namespace ILGPU.IR
             /// <summary>
             /// Returns the associated arguments.
             /// </summary>
-            public ImmutableArray<ValueReference> Arguments { get; }
+            public ReadOnlySpan<ValueReference> Arguments { get; }
 
             /// <summary>
             /// Returns the value that is assigned to the given parameter.
             /// </summary>
             /// <param name="parameter">The parameter to map to a value.</param>
             /// <returns>The mapped value.</returns>
-            public ValueReference this[Parameter parameter]
+            public readonly ValueReference this[Parameter parameter]
             {
                 get
                 {
-                    Debug.Assert(parameter != null, "Invalid parameter");
-                    Debug.Assert(parameter.Method == Method, "Invalid parameter");
+                    Method.AssertNotNull(parameter);
+                    Method.Assert(parameter.Method == Method);
 
                     return Arguments[parameter.Index];
                 }
@@ -540,11 +538,9 @@ namespace ILGPU.IR
         /// <param name="arguments">The argument values.</param>
         /// <returns>The created parameter mapping.</returns>
         public ParameterMapping CreateParameterMapping(
-            ImmutableArray<ValueReference> arguments)
+            in ReadOnlySpan<ValueReference> arguments)
         {
-            Debug.Assert(
-                arguments.Length == Parameters.Count,
-                "Invalid number of arguments");
+            this.Assert(arguments.Length == Parameters.Count);
             return new ParameterMapping(this, arguments);
         }
 

--- a/Src/ILGPU/IR/Node.cs
+++ b/Src/ILGPU/IR/Node.cs
@@ -10,7 +10,6 @@
 // ---------------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
 
@@ -85,18 +84,15 @@ namespace ILGPU.IR
         /// Infers the location (if required) of the current node.
         /// </summary>
         /// <typeparam name="T">The element type.</typeparam>
-        /// <typeparam name="TList">The list type.</typeparam>
         /// <param name="elements">Elements we can infer the location from.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected void InferLocation<T, TList>(TList elements)
+        protected void InferLocation<T>(ReadOnlySpan<T> elements)
             where T : INode
-            where TList : IReadOnlyList<T>
         {
             if (Location.IsKnown)
                 return;
-
-            for (int i = 0, e = elements.Count; i < e; ++i)
-                Location = Location.Merge(Location, elements[i].Location);
+            foreach (var element in elements)
+                Location = Location.Merge(Location, element.Location);
         }
 
         /// <summary>

--- a/Src/ILGPU/IR/Transformations/LowerStructures.cs
+++ b/Src/ILGPU/IR/Transformations/LowerStructures.cs
@@ -151,7 +151,7 @@ namespace ILGPU.IR.Transformations
             public PhiValue Seal(SSABuilder<FieldRef> ssaBuilder)
             {
                 // Wire all phi arguments
-                for (int i = 0, e = SourcePhi.Nodes.Length; i < e; ++i)
+                for (int i = 0, e = SourcePhi.Count; i < e; ++i)
                 {
                     // Get the predecessor block and its associated value
                     var pred = SourcePhi.Sources[i];
@@ -443,8 +443,7 @@ namespace ILGPU.IR.Transformations
             MethodCall call)
         {
             // Check for structure arguments that need to be rebuilt
-            var newArgs = ImmutableArray.CreateBuilder<ValueReference>(
-                call.NumArguments);
+            var callBuilder = context.Builder.CreateCall(call.Location, call.Target);
             foreach (Value argument in call)
             {
                 Value newArgument = argument;
@@ -455,15 +454,11 @@ namespace ILGPU.IR.Transformations
                         argumentType,
                         argument);
                 }
-                newArgs.Add(newArgument);
+                callBuilder.Add(newArgument);
             }
 
             // Create new call node
-            var newCall = context.Builder.CreateCall(
-                call.Location,
-                call.Target,
-                newArgs.MoveToImmutable());
-
+            var newCall = callBuilder.Seal();
             context.ReplaceAndRemove(call, newCall);
 
             // Convert the return value

--- a/Src/ILGPU/IR/Transformations/SimplifyControlFlow.cs
+++ b/Src/ILGPU/IR/Transformations/SimplifyControlFlow.cs
@@ -35,7 +35,7 @@ namespace ILGPU.IR.Transformations
             BasicBlock root,
             ref BasicBlockSet visited)
         {
-            if (root.Successors.Count != 1 || visited.Contains(root))
+            if (root.Successors.Length != 1 || visited.Contains(root))
                 return false;
 
             // Mark node as seen
@@ -52,7 +52,7 @@ namespace ILGPU.IR.Transformations
 
                 // We cannot merge jump targets in div. control-flow or in the case
                 // of a block that we have already seen
-                if (nextBlock.Predecessors.Count > 1 || visited.Contains(nextBlock))
+                if (nextBlock.Predecessors.Length > 1 || visited.Contains(nextBlock))
                     break;
 
                 // Mark next block as seen
@@ -65,7 +65,7 @@ namespace ILGPU.IR.Transformations
                 // Return true as we have changed the IR
                 result = true;
             }
-            while (successors.Count == 1);
+            while (successors.Length == 1);
 
             // Return the success status
             return result;

--- a/Src/ILGPU/IR/Transformations/UnreachableCodeElimination.cs
+++ b/Src/ILGPU/IR/Transformations/UnreachableCodeElimination.cs
@@ -12,8 +12,8 @@
 using ILGPU.IR.Analyses.TraversalOrders;
 using ILGPU.IR.Rewriting;
 using ILGPU.IR.Values;
+using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
 
 namespace ILGPU.IR.Transformations
@@ -56,7 +56,7 @@ namespace ILGPU.IR.Transformations
             /// scope.
             /// </summary>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public readonly bool CanRemap(ImmutableArray<BasicBlock> blocks)
+            public readonly bool CanRemap(in ReadOnlySpan<BasicBlock> blocks)
             {
                 foreach (var block in blocks)
                 {

--- a/Src/ILGPU/IR/ValueBuilder.cs
+++ b/Src/ILGPU/IR/ValueBuilder.cs
@@ -1,0 +1,147 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                        Copyright (c) 2016-2020 Marcel Koester
+//                                    www.ilgpu.net
+//
+// File: ValueBuilder.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+
+using ILGPU.IR.Construction;
+using ILGPU.IR.Values;
+using System.Diagnostics.CodeAnalysis;
+
+namespace ILGPU.IR
+{
+    /// <summary>
+    /// An abstract value builder.
+    /// </summary>
+    public interface IValueBuilder
+    {
+        /// <summary>
+        /// Returns the parent IR builder.
+        /// </summary>
+        IRBuilder IRBuilder { get; }
+
+        /// <summary>
+        /// Returns the current location.
+        /// </summary>
+        Location Location { get; }
+
+        /// <summary>
+        /// The number of field values.
+        /// </summary>
+        int Count { get; }
+
+        /// <summary>
+        /// Returns the value that corresponds to the given field access.
+        /// </summary>
+        /// <param name="access">The field access.</param>
+        /// <returns>The resolved field type.</returns>
+        ValueReference this[FieldAccess access] { get; }
+
+        /// <summary>
+        /// Adds the given value to the instance builder.
+        /// </summary>
+        /// <param name="value">The value to add.</param>
+        void Add(Value value);
+
+        /// <summary>
+        /// Constructs a new value that represents the current value builder.
+        /// </summary>
+        /// <returns>The resulting value reference.</returns>
+        ValueReference Seal();
+    }
+
+    /// <summary>
+    /// Extensions for <see cref="IValueBuilder"/> instances.
+    /// </summary>
+    public static class ValueBuilder
+    {
+        /// <summary>
+        /// Constructs a new <see cref="ValueBuilder{TBuilder}"/> wrapper.
+        /// </summary>
+        /// <typeparam name="TBuilder">The builder type.</typeparam>
+        /// <param name="valueBuilder">The value builder instance.</param>
+        /// <returns>The created wrapper class.</returns>
+        public static ValueBuilder<TBuilder> ToValueBuilder<TBuilder>(
+            this TBuilder valueBuilder)
+            where TBuilder : IValueBuilder =>
+            new ValueBuilder<TBuilder>(valueBuilder);
+    }
+
+    /// <summary>
+    /// A wrapped <see cref="IValueBuilder"/> that wraps value-based builder structures.
+    /// </summary>
+    /// <typeparam name="TBuilder">The structure-based builder type.</typeparam>
+    public class ValueBuilder<TBuilder> : IValueBuilder
+        where TBuilder : IValueBuilder
+    {
+        /// <summary>
+        /// The nested builder.
+        /// </summary>
+        [SuppressMessage(
+            "Style",
+            "IDE0044:Add readonly modifier",
+            Justification = "Cannot be readonly since it will be updated in place.")]
+        private TBuilder nestedBuilder;
+
+        /// <summary>
+        /// Constructs a new value builder.
+        /// </summary>
+        /// <param name="builder">The underlying builder structure.</param>
+        public ValueBuilder(TBuilder builder)
+        {
+            nestedBuilder = builder;
+        }
+
+        /// <summary>
+        /// Returns the parent IR builder.
+        /// </summary>
+        public IRBuilder IRBuilder => nestedBuilder.IRBuilder;
+
+        /// <summary>
+        /// Returns the current location.
+        /// </summary>
+        public Location Location => nestedBuilder.Location;
+
+        /// <summary>
+        /// The number of field values.
+        /// </summary>
+        public int Count => nestedBuilder.Count;
+
+        /// <summary>
+        /// Returns the value that corresponds to the given field access.
+        /// </summary>
+        /// <param name="access">The field access.</param>
+        /// <returns>The resolved field type.</returns>
+        public ValueReference this[FieldAccess access] => nestedBuilder[access];
+
+        /// <summary>
+        /// Returns a reference to the nested builder.
+        /// </summary>
+        public ref TBuilder Builder => ref nestedBuilder;
+
+        /// <summary>
+        /// Adds the given value to the instance builder.
+        /// </summary>
+        /// <param name="value">The value to add.</param>
+        public void Add(Value value) => nestedBuilder.Add(value);
+
+        /// <summary>
+        /// Constructs a new value that represents the current value builder.
+        /// </summary>
+        /// <returns>The resulting value reference.</returns>
+        public ValueReference Seal() => nestedBuilder.Seal();
+
+        /// <summary>
+        /// Constructs a new value that represents the current value builder and returns
+        /// 
+        /// </summary>
+        /// <returns>The resulting value reference.</returns>
+        public T SealAs<T>()
+            where T : Value => Seal().ResolveAs<T>();
+    }
+}

--- a/Src/ILGPU/IR/Values/Arithmetic.cs
+++ b/Src/ILGPU/IR/Values/Arithmetic.cs
@@ -13,7 +13,6 @@ using ILGPU.IR.Construction;
 using ILGPU.IR.Types;
 using ILGPU.Util;
 using System;
-using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
@@ -281,17 +280,11 @@ namespace ILGPU.IR.Values
         /// Constructs a new arithmetic value.
         /// </summary>
         /// <param name="initializer">The value initializer.</param>
-        /// <param name="operands">The operands.</param>
         /// <param name="flags">The operation flags.</param>
-        internal ArithmeticValue(
-            in ValueInitializer initializer,
-            ImmutableArray<ValueReference> operands,
-            ArithmeticFlags flags)
+        internal ArithmeticValue(in ValueInitializer initializer, ArithmeticFlags flags)
             : base(initializer)
         {
             Flags = flags;
-
-            Seal(operands);
         }
 
         #endregion
@@ -359,12 +352,11 @@ namespace ILGPU.IR.Values
             ValueReference value,
             UnaryArithmeticKind kind,
             ArithmeticFlags flags)
-            : base(
-                  initializer,
-                  ImmutableArray.Create(value),
-                  flags)
+            : base(initializer, flags)
         {
             Kind = kind;
+
+            Seal(value);
         }
 
         #endregion
@@ -451,10 +443,7 @@ namespace ILGPU.IR.Values
             ValueReference right,
             BinaryArithmeticKind kind,
             ArithmeticFlags flags)
-            : base(
-                  initializer,
-                  ImmutableArray.Create(left, right),
-                  flags)
+            : base(initializer, flags)
         {
             Debug.Assert(
                 left.Type == right.Type ||
@@ -463,6 +452,7 @@ namespace ILGPU.IR.Values
                 right.BasicValueType == BasicValueType.Int32, "Invalid types");
 
             Kind = kind;
+            Seal(left, right);
         }
 
         #endregion
@@ -578,16 +568,14 @@ namespace ILGPU.IR.Values
             ValueReference third,
             TernaryArithmeticKind kind,
             ArithmeticFlags flags)
-            : base(
-                  initializer,
-                  ImmutableArray.Create(first, second, third),
-                  flags)
+            : base(initializer, flags)
         {
             Debug.Assert(
                 first.Type == second.Type &&
                 second.Type == third.Type, "Invalid types");
 
             Kind = kind;
+            Seal(first, second, third);
         }
 
         #endregion

--- a/Src/ILGPU/IR/Values/ArrayValues.cs
+++ b/Src/ILGPU/IR/Values/ArrayValues.cs
@@ -11,7 +11,6 @@
 
 using ILGPU.IR.Construction;
 using ILGPU.IR.Types;
-using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
 
 namespace ILGPU.IR.Values
@@ -37,7 +36,7 @@ namespace ILGPU.IR.Values
             : base(initializer)
         {
             ArrayType = arrayType;
-            Seal(ImmutableArray.Create(extent));
+            Seal(extent);
         }
 
         #endregion
@@ -104,11 +103,8 @@ namespace ILGPU.IR.Values
         /// Constructs a new abstract structure operation.
         /// </summary>
         /// <param name="initializer">The value initializer.</param>
-        /// <param name="values">All child values.</param>
-        internal ArrayOperationValue(
-            in ValueInitializer initializer,
-            ImmutableArray<ValueReference> values)
-            : base(initializer, values)
+        internal ArrayOperationValue(in ValueInitializer initializer)
+            : base(initializer)
         { }
 
         #endregion
@@ -178,10 +174,10 @@ namespace ILGPU.IR.Values
         internal GetArrayExtent(
             in ValueInitializer initializer,
             ValueReference arrayValue)
-            : base(
-                initializer,
-                ImmutableArray.Create(arrayValue))
-        { }
+            : base(initializer)
+        {
+            Seal(arrayValue);
+        }
 
         #endregion
 
@@ -234,10 +230,10 @@ namespace ILGPU.IR.Values
             in ValueInitializer initializer,
             ValueReference arrayValue,
             ValueReference arrayIndex)
-            : base(
-                initializer,
-                ImmutableArray.Create(arrayValue, arrayIndex))
-        { }
+            : base(initializer)
+        {
+            Seal(arrayValue, arrayIndex);
+        }
 
         #endregion
 
@@ -292,10 +288,10 @@ namespace ILGPU.IR.Values
             ValueReference arrayValue,
             ValueReference arrayIndex,
             ValueReference value)
-            : base(
-                  initializer,
-                  ImmutableArray.Create(arrayValue, arrayIndex, value))
-        { }
+            : base(initializer)
+        {
+            Seal(arrayValue, arrayIndex, value);
+        }
 
         #endregion
 

--- a/Src/ILGPU/IR/Values/Atomic.cs
+++ b/Src/ILGPU/IR/Values/Atomic.cs
@@ -13,7 +13,6 @@ using ILGPU.IR.Construction;
 using ILGPU.IR.Types;
 using ILGPU.Util;
 using System;
-using System.Collections.Immutable;
 using System.Diagnostics;
 
 namespace ILGPU.IR.Values
@@ -46,19 +45,9 @@ namespace ILGPU.IR.Values
         /// Constructs a new abstract atomic value.
         /// </summary>
         /// <param name="initializer">The value initializer.</param>
-        /// <param name="target">The target.</param>
-        /// <param name="value">The value to store.</param>
-        /// <param name="arguments">Additional arguments.</param>
         /// <param name="flags">The operation flags.</param>
-        internal AtomicValue(
-            in ValueInitializer initializer,
-            ValueReference target,
-            ValueReference value,
-            ImmutableArray<ValueReference> arguments,
-            AtomicFlags flags)
-            : base(
-                  initializer,
-                  ImmutableArray.Create(target, value).AddRange(arguments))
+        internal AtomicValue(in ValueInitializer initializer, AtomicFlags flags)
+            : base(initializer)
 
         {
             Flags = flags;
@@ -169,16 +158,12 @@ namespace ILGPU.IR.Values
             ValueReference value,
             AtomicKind kind,
             AtomicFlags flags)
-            : base(
-                  initializer,
-                  target,
-                  value,
-                  ImmutableArray<ValueReference>.Empty,
-                  flags)
+            : base(initializer, flags)
         {
             Debug.Assert(value.Type == (target.Type as PointerType).ElementType);
 
             Kind = kind;
+            Seal(target, value);
         }
 
         #endregion
@@ -246,15 +231,12 @@ namespace ILGPU.IR.Values
             ValueReference value,
             ValueReference compareValue,
             AtomicFlags flags)
-            : base(
-                  initializer,
-                  target,
-                  value,
-                  ImmutableArray.Create(compareValue),
-                  flags)
+            : base(initializer, flags)
         {
             Debug.Assert(value.Type == (target.Type as PointerType).ElementType);
             Debug.Assert(value.Type == compareValue.Type);
+
+            Seal(target, value, compareValue);
         }
 
         #endregion

--- a/Src/ILGPU/IR/Values/Cast.cs
+++ b/Src/ILGPU/IR/Values/Cast.cs
@@ -11,7 +11,6 @@
 
 using ILGPU.IR.Construction;
 using ILGPU.IR.Types;
-using System.Collections.Immutable;
 
 namespace ILGPU.IR.Values
 {
@@ -32,7 +31,7 @@ namespace ILGPU.IR.Values
             ValueReference value)
             : base(initializer)
         {
-            Seal(ImmutableArray.Create(value));
+            Seal(value);
         }
 
         #endregion

--- a/Src/ILGPU/IR/Values/ClassValues.cs
+++ b/Src/ILGPU/IR/Values/ClassValues.cs
@@ -10,7 +10,6 @@
 // ---------------------------------------------------------------------------------------
 
 using ILGPU.IR.Types;
-using System.Collections.Immutable;
 
 namespace ILGPU.IR.Values
 {
@@ -43,11 +42,8 @@ namespace ILGPU.IR.Values
         /// Constructs a new abstract object operation.
         /// </summary>
         /// <param name="initializer">The value initializer.</param>
-        /// <param name="values">All child values.</param>
-        internal ClassOperationValue(
-            in ValueInitializer initializer,
-            ImmutableArray<ValueReference> values)
-            : base(initializer, values)
+        internal ClassOperationValue(in ValueInitializer initializer)
+            : base(initializer)
         { }
 
         #endregion

--- a/Src/ILGPU/IR/Values/Compare.cs
+++ b/Src/ILGPU/IR/Values/Compare.cs
@@ -151,7 +151,7 @@ namespace ILGPU.IR.Values
             Kind = kind;
             Flags = flags;
 
-            Seal(ImmutableArray.Create(left, right));
+            Seal(left, right);
         }
 
         #endregion

--- a/Src/ILGPU/IR/Values/Constants.cs
+++ b/Src/ILGPU/IR/Values/Constants.cs
@@ -13,7 +13,6 @@ using ILGPU.IR.Construction;
 using ILGPU.IR.Types;
 using ILGPU.Util;
 using System;
-using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
@@ -36,7 +35,7 @@ namespace ILGPU.IR.Values
             TypeNode constantType)
             : base(initializer, constantType)
         {
-            Seal(ImmutableArray<ValueReference>.Empty);
+            Seal();
         }
 
         #endregion

--- a/Src/ILGPU/IR/Values/Convert.cs
+++ b/Src/ILGPU/IR/Values/Convert.cs
@@ -13,7 +13,6 @@ using ILGPU.IR.Construction;
 using ILGPU.IR.Types;
 using ILGPU.Util;
 using System;
-using System.Collections.Immutable;
 
 namespace ILGPU.IR.Values
 {
@@ -90,7 +89,7 @@ namespace ILGPU.IR.Values
         {
             Flags = flags;
 
-            Seal(ImmutableArray.Create(value));
+            Seal(value);
         }
 
         #endregion

--- a/Src/ILGPU/IR/Values/Debug.cs
+++ b/Src/ILGPU/IR/Values/Debug.cs
@@ -11,7 +11,6 @@
 
 using ILGPU.IR.Construction;
 using ILGPU.IR.Types;
-using System.Collections.Immutable;
 
 namespace ILGPU.IR.Values
 {
@@ -49,11 +48,10 @@ namespace ILGPU.IR.Values
             in ValueInitializer initializer,
             DebugKind kind,
             ValueReference message)
-            : base(
-                  initializer,
-                  ImmutableArray.Create(message))
+            : base(initializer)
         {
             Kind = kind;
+            Seal(message);
         }
 
         #endregion

--- a/Src/ILGPU/IR/Values/HandleValue.cs
+++ b/Src/ILGPU/IR/Values/HandleValue.cs
@@ -34,6 +34,7 @@ namespace ILGPU.IR.Values
         {
             this.AssertNotNull(handle);
             Handle = handle;
+            Seal();
         }
 
         #endregion

--- a/Src/ILGPU/IR/Values/Memory.cs
+++ b/Src/ILGPU/IR/Values/Memory.cs
@@ -11,7 +11,6 @@
 
 using ILGPU.IR.Construction;
 using ILGPU.IR.Types;
-using System.Collections.Immutable;
 using System.Diagnostics;
 
 namespace ILGPU.IR.Values
@@ -27,14 +26,9 @@ namespace ILGPU.IR.Values
         /// Constructs a new memory value.
         /// </summary>
         /// <param name="initializer">The value initializer.</param>
-        /// <param name="values">All child values.</param>
-        internal MemoryValue(
-            in ValueInitializer initializer,
-            ImmutableArray<ValueReference> values)
+        internal MemoryValue(in ValueInitializer initializer)
             : base(initializer)
-        {
-            Seal(values);
-        }
+        { }
 
         #endregion
     }
@@ -59,9 +53,7 @@ namespace ILGPU.IR.Values
             ValueReference arrayLength,
             TypeNode allocaType,
             MemoryAddressSpace addressSpace)
-            : base(
-                  initializer,
-                  ImmutableArray.Create(arrayLength))
+            : base(initializer)
         {
             Debug.Assert(
                 addressSpace == MemoryAddressSpace.Local ||
@@ -71,6 +63,7 @@ namespace ILGPU.IR.Values
             AllocaType = allocaType;
             AddressSpace = addressSpace;
 
+            Seal(arrayLength);
             InvalidateType();
         }
 
@@ -188,11 +181,10 @@ namespace ILGPU.IR.Values
         internal MemoryBarrier(
             in ValueInitializer initializer,
             MemoryBarrierKind kind)
-            : base(
-                  initializer,
-                  ImmutableArray<ValueReference>.Empty)
+            : base(initializer)
         {
             Kind = kind;
+            Seal();
         }
 
         #endregion
@@ -253,10 +245,10 @@ namespace ILGPU.IR.Values
         internal Load(
             in ValueInitializer initializer,
             ValueReference source)
-            : base(
-                  initializer,
-                  ImmutableArray.Create(source))
-        { }
+            : base(initializer)
+        {
+            Seal(source);
+        }
 
         #endregion
 
@@ -320,10 +312,10 @@ namespace ILGPU.IR.Values
             in ValueInitializer initializer,
             ValueReference target,
             ValueReference value)
-            : base(
-                  initializer,
-                  ImmutableArray.Create(target, value))
-        { }
+            : base(initializer)
+        {
+            Seal(target, value);
+        }
 
         #endregion
 

--- a/Src/ILGPU/IR/Values/MethodCall.cs
+++ b/Src/ILGPU/IR/Values/MethodCall.cs
@@ -23,6 +23,83 @@ namespace ILGPU.IR.Values
     [ValueKind(ValueKind.MethodCall)]
     public sealed class MethodCall : Value
     {
+        #region Nested Types
+
+        /// <summary>
+        /// An instance builder for method calls.
+        /// </summary>
+        public struct Builder
+        {
+            #region Instance
+
+            private ValueList builder;
+
+            /// <summary>
+            /// Initializes a new call builder.
+            /// </summary>
+            /// <param name="irBuilder">The current IR builder.</param>
+            /// <param name="location">The current location.</param>
+            /// <param name="target">The target method to call.</param>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            internal Builder(IRBuilder irBuilder, Location location, Method target)
+            {
+                builder = ValueList.Create(target.NumParameters);
+                IRBuilder = irBuilder;
+                Location = location;
+                Target = target;
+            }
+
+            #endregion
+
+            #region Properties
+
+            /// <summary>
+            /// Returns the parent builder.
+            /// </summary>
+            public IRBuilder IRBuilder { get; }
+
+            /// <summary>
+            /// Returns the current location.
+            /// </summary>
+            public Location Location { get; }
+
+            /// <summary>
+            /// Returns the call target.
+            /// </summary>
+            public Method Target { get; }
+
+            /// <summary>
+            /// The number of arguments.
+            /// </summary>
+            public int Count => builder.Count;
+
+            #endregion
+
+            #region Methods
+
+            /// <summary>
+            /// Adds the given value to the call builder.
+            /// </summary>
+            /// <param name="value">The value to add.</param>
+            public void Add(Value value)
+            {
+                IRBuilder.AssertNotNull(value);
+                builder.Add(value);
+            }
+
+            /// <summary>
+            /// Constructs a new value that represents the current method call.
+            /// </summary>
+            /// <returns>The resulting value reference.</returns>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public MethodCall Seal() =>
+                IRBuilder.CreateCall(Location, Target, ref builder);
+
+            #endregion
+        }
+
+        #endregion
+
         #region Instance
 
         /// <summary>
@@ -66,14 +143,11 @@ namespace ILGPU.IR.Values
             IRBuilder builder,
             IRRebuilder rebuilder)
         {
-            var args = ImmutableArray.CreateBuilder<ValueReference>(Nodes.Length);
-            foreach (var arg in Nodes)
-                args.Add(rebuilder.Rebuild(arg));
             var target = rebuilder.LookupCallTarget(Target);
-            return builder.CreateCall(
-                Location,
-                target,
-                args.ToImmutable());
+            var call = builder.CreateCall(Location, target);
+            foreach (var arg in Nodes)
+                call.Add(rebuilder.Rebuild(arg));
+            return call.Seal();
         }
 
         /// <summary cref="Value.Accept"/>

--- a/Src/ILGPU/IR/Values/MethodCall.cs
+++ b/Src/ILGPU/IR/Values/MethodCall.cs
@@ -11,7 +11,8 @@
 
 using ILGPU.IR.Construction;
 using ILGPU.IR.Types;
-using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
+using ValueList = ILGPU.Util.InlineList<ILGPU.IR.Values.ValueReference>;
 
 namespace ILGPU.IR.Values
 {
@@ -33,11 +34,11 @@ namespace ILGPU.IR.Values
         internal MethodCall(
             in ValueInitializer initializer,
             Method target,
-            ImmutableArray<ValueReference> arguments)
+            ref ValueList arguments)
             : base(initializer)
         {
             Target = target;
-            Seal(arguments);
+            Seal(ref arguments);
         }
 
         #endregion
@@ -51,11 +52,6 @@ namespace ILGPU.IR.Values
         /// Returns the call target.
         /// </summary>
         public Method Target { get; }
-
-        /// <summary>
-        /// Returns the number of the associated arguments.
-        /// </summary>
-        public int NumArguments => Nodes.Length;
 
         #endregion
 

--- a/Src/ILGPU/IR/Values/Parameter.cs
+++ b/Src/ILGPU/IR/Values/Parameter.cs
@@ -11,7 +11,6 @@
 
 using ILGPU.IR.Construction;
 using ILGPU.IR.Types;
-using System.Collections.Immutable;
 
 namespace ILGPU.IR.Values
 {
@@ -38,7 +37,7 @@ namespace ILGPU.IR.Values
         {
             ParameterType = type;
             Name = name ?? "param";
-            Seal(ImmutableArray<ValueReference>.Empty);
+            Seal();
         }
 
         #endregion

--- a/Src/ILGPU/IR/Values/PointerValues.cs
+++ b/Src/ILGPU/IR/Values/PointerValues.cs
@@ -11,7 +11,6 @@
 
 using ILGPU.IR.Construction;
 using ILGPU.IR.Types;
-using System.Collections.Immutable;
 
 namespace ILGPU.IR.Values
 {
@@ -64,7 +63,7 @@ namespace ILGPU.IR.Values
             ValueReference length)
             : base(initializer)
         {
-            Seal(ImmutableArray.Create(source, offset, length));
+            Seal(source, offset, length);
         }
 
         #endregion
@@ -138,7 +137,7 @@ namespace ILGPU.IR.Values
             ValueReference elementIndex)
             : base(initializer)
         {
-            Seal(ImmutableArray.Create(sourceView, elementIndex));
+            Seal(sourceView, elementIndex);
         }
 
         #endregion
@@ -239,7 +238,7 @@ namespace ILGPU.IR.Values
             : base(initializer)
         {
             FieldSpan = fieldSpan;
-            Seal(ImmutableArray.Create(source));
+            Seal(source);
         }
 
         #endregion

--- a/Src/ILGPU/IR/Values/Predicate.cs
+++ b/Src/ILGPU/IR/Values/Predicate.cs
@@ -11,7 +11,6 @@
 
 using ILGPU.IR.Construction;
 using ILGPU.IR.Types;
-using System.Collections.Immutable;
 using System.Diagnostics;
 
 namespace ILGPU.IR.Values
@@ -27,24 +26,9 @@ namespace ILGPU.IR.Values
         /// Constructs a new conditional node.
         /// </summary>
         /// <param name="initializer">The value initializer.</param>
-        /// <param name="condition">The condition.</param>
-        /// <param name="arguments">The condition arguments.</param>
-        internal Conditional(
-            in ValueInitializer initializer,
-            ValueReference condition,
-            ImmutableArray<ValueReference> arguments)
+        internal Conditional(in ValueInitializer initializer)
             : base(initializer)
-        {
-            this.Assert(arguments.Length > 0);
-            Arguments = arguments;
-
-            var builder = ImmutableArray.CreateBuilder<ValueReference>(
-                arguments.Length + 1);
-            builder.Add(condition);
-            builder.AddRange(arguments);
-            Seal(builder.MoveToImmutable());
-        }
-
+        { }
         #endregion
 
         #region Properties
@@ -54,18 +38,20 @@ namespace ILGPU.IR.Values
         /// </summary>
         public ValueReference Condition => this[0];
 
-        /// <summary>
-        /// Returns the arguments.
-        /// </summary>
-        public ImmutableArray<ValueReference> Arguments { get; }
-
         #endregion
 
         #region Methods
 
+        /// <summary>
+        /// Returns the i-th argument.
+        /// </summary>
+        /// <param name="index">The argument index.</param>
+        /// <returns>The i-th argument value.</returns>
+        public ValueReference GetArgument(int index) => this[index + 1];
+
         /// <summary cref="Value.ComputeType(in ValueInitializer)"/>
         protected override TypeNode ComputeType(in ValueInitializer initializer) =>
-            Arguments[0].Type;
+            GetArgument(0).Type;
 
         #endregion
     }
@@ -90,15 +76,13 @@ namespace ILGPU.IR.Values
             ValueReference condition,
             ValueReference trueValue,
             ValueReference falseValue)
-            : base(
-                  initializer,
-                  condition,
-                  ImmutableArray.Create(trueValue, falseValue))
+            : base(initializer)
         {
             Debug.Assert(
                 condition.Type.IsPrimitiveType &&
                 condition.Type.BasicValueType == BasicValueType.Int1,
                 "Invalid boolean predicate");
+            Seal(condition, trueValue, falseValue);
         }
 
         #endregion

--- a/Src/ILGPU/IR/Values/StructureValues.cs
+++ b/Src/ILGPU/IR/Values/StructureValues.cs
@@ -17,6 +17,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text;
+using ValueList = ILGPU.Util.InlineList<ILGPU.IR.Values.ValueReference>;
 
 namespace ILGPU.IR.Values
 {
@@ -770,7 +771,7 @@ namespace ILGPU.IR.Values
         {
             #region Instance
 
-            private readonly ImmutableArray<ValueReference>.Builder builder;
+            private ValueList builder;
 
             /// <summary>
             /// Initializes a new instance builder.
@@ -784,8 +785,7 @@ namespace ILGPU.IR.Values
                 StructureType parent)
             {
                 location.AssertNotNull(parent);
-                builder = ImmutableArray.CreateBuilder<ValueReference>(
-                    parent.NumFields);
+                builder = ValueList.Create(parent.NumFields);
                 IRBuilder = irBuilder;
                 Location = location;
                 Parent = parent;
@@ -884,7 +884,7 @@ namespace ILGPU.IR.Values
         {
             #region Instance
 
-            private readonly ImmutableArray<ValueReference>.Builder builder;
+            private ValueList builder;
 
             /// <summary>
             /// Initializes a new instance builder.
@@ -991,11 +991,11 @@ namespace ILGPU.IR.Values
         internal StructureValue(
             in ValueInitializer initializer,
             StructureType structureType,
-            ImmutableArray<ValueReference> fieldValues)
+            ref ValueList fieldValues)
             : base(initializer)
         {
             StructureType = structureType;
-            Seal(fieldValues);
+            Seal(ref fieldValues);
         }
 
         #endregion
@@ -1009,11 +1009,6 @@ namespace ILGPU.IR.Values
         /// Returns the structure type.
         /// </summary>
         public StructureType StructureType { get; }
-
-        /// <summary>
-        /// Returns the number of field values.
-        /// </summary>
-        public int NumFields => Nodes.Length;
 
         #endregion
 
@@ -1033,7 +1028,7 @@ namespace ILGPU.IR.Values
         {
             if (!fieldSpan.HasSpan)
                 return this[fieldSpan.Index];
-            else if (fieldSpan.Index == 0 && fieldSpan.Span == NumFields)
+            else if (fieldSpan.Index == 0 && fieldSpan.Span == Count)
                 return this;
 
             var resultType = StructureType.Get(builder, fieldSpan)
@@ -1143,7 +1138,7 @@ namespace ILGPU.IR.Values
             FieldSpan fieldSpan)
             : base(initializer, fieldSpan)
         {
-            Seal(ImmutableArray.Create(structValue));
+            Seal(structValue);
         }
 
         #endregion
@@ -1205,7 +1200,7 @@ namespace ILGPU.IR.Values
             ValueReference value)
             : base(initializer, fieldSpan)
         {
-            Seal(ImmutableArray.Create(structValue, value));
+            Seal(structValue, value);
         }
 
         #endregion

--- a/Src/ILGPU/IR/Values/Threads.cs
+++ b/Src/ILGPU/IR/Values/Threads.cs
@@ -11,8 +11,6 @@
 
 using ILGPU.IR.Construction;
 using ILGPU.IR.Types;
-using System.Collections.Immutable;
-using System.Diagnostics;
 
 namespace ILGPU.IR.Values
 {
@@ -27,11 +25,8 @@ namespace ILGPU.IR.Values
         /// Constructs a new generic barrier operation.
         /// </summary>
         /// <param name="initializer">The value initializer.</param>
-        /// <param name="values">Additional values.</param>
-        internal BarrierOperation(
-            in ValueInitializer initializer,
-            ImmutableArray<ValueReference> values)
-            : base(initializer, values)
+        internal BarrierOperation(in ValueInitializer initializer)
+            : base(initializer)
         { }
 
         #endregion
@@ -86,14 +81,11 @@ namespace ILGPU.IR.Values
             in ValueInitializer initializer,
             ValueReference predicate,
             PredicateBarrierKind kind)
-            : base(
-                  initializer,
-                  ImmutableArray.Create(predicate))
+            : base(initializer)
         {
-            Debug.Assert(
-                predicate.BasicValueType == BasicValueType.Int1,
-                "Invalid predicate");
+            Location.Assert(predicate.BasicValueType == BasicValueType.Int1);
             Kind = kind;
+            Seal(predicate);
         }
 
         #endregion
@@ -180,11 +172,10 @@ namespace ILGPU.IR.Values
         internal Barrier(
             in ValueInitializer initializer,
             BarrierKind barrierKind)
-            : base(
-                  initializer,
-                  ImmutableArray<ValueReference>.Empty)
+            : base(initializer)
         {
             Kind = barrierKind;
+            Seal();
         }
 
         #endregion
@@ -246,11 +237,8 @@ namespace ILGPU.IR.Values
         /// Constructs a new communication operation.
         /// </summary>
         /// <param name="initializer">The value initializer.</param>
-        /// <param name="values">The values.</param>
-        internal ThreadValue(
-            in ValueInitializer initializer,
-            ImmutableArray<ValueReference> values)
-            : base(initializer, values)
+        internal ThreadValue(in ValueInitializer initializer)
+            : base(initializer)
         { }
 
         #endregion
@@ -301,11 +289,10 @@ namespace ILGPU.IR.Values
             ValueReference value,
             ValueReference origin,
             BroadcastKind broadcastKind)
-            : base(
-                  initializer,
-                  ImmutableArray.Create(value, origin))
+            : base(initializer)
         {
             Kind = broadcastKind;
+            Seal(value, origin);
         }
 
         #endregion
@@ -392,13 +379,11 @@ namespace ILGPU.IR.Values
         /// Constructs a new shuffle operation.
         /// </summary>
         /// <param name="initializer">The value initializer.</param>
-        /// <param name="values">The values.</param>
         /// <param name="shuffleKind">The operation kind.</param>
         internal ShuffleOperation(
             in ValueInitializer initializer,
-            ImmutableArray<ValueReference> values,
             ShuffleKind shuffleKind)
-            : base(initializer, values)
+            : base(initializer)
         {
             Kind = shuffleKind;
         }
@@ -447,11 +432,10 @@ namespace ILGPU.IR.Values
             ValueReference variable,
             ValueReference origin,
             ShuffleKind kind)
-            : base(
-                  initializer,
-                  ImmutableArray.Create(variable, origin),
-                  kind)
-        { }
+            : base(initializer, kind)
+        {
+            Seal(variable, origin);
+        }
 
         #endregion
 
@@ -509,11 +493,10 @@ namespace ILGPU.IR.Values
             ValueReference origin,
             ValueReference width,
             ShuffleKind kind)
-            : base(
-                  initializer,
-                  ImmutableArray.Create(variable, origin, width),
-                  kind)
-        { }
+            : base(initializer, kind)
+        {
+            Seal(variable, origin, width);
+        }
 
         #endregion
 

--- a/Src/ILGPU/IR/Values/ValueReference.cs
+++ b/Src/ILGPU/IR/Values/ValueReference.cs
@@ -10,8 +10,8 @@
 // ---------------------------------------------------------------------------------------
 
 using ILGPU.IR.Types;
+using ILGPU.Util;
 using System;
-using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
 
@@ -28,6 +28,31 @@ namespace ILGPU.IR.Values
     /// </remarks>
     public struct ValueReference : IValue, IEquatable<ValueReference>
     {
+        #region Nested Types
+
+        /// <summary>
+        /// A value reference formatter.
+        /// </summary>
+        public readonly struct ToReferenceFormatter :
+            InlineList.IFormatter<Value>,
+            InlineList.IFormatter<ValueReference>
+        {
+            /// <summary>
+            /// Formats a value by returning its reference string.
+            /// </summary>
+            readonly string InlineList.IFormatter<Value>.Format(Value item) =>
+                item.ToReferenceString();
+
+            /// <summary>
+            /// Formats a value reference by returning its reference string.
+            /// </summary>
+            readonly string InlineList.IFormatter<ValueReference>.Format(
+                ValueReference item) =>
+                item.ToString();
+        }
+
+        #endregion
+
         #region Instance
 
         /// <summary>
@@ -83,7 +108,7 @@ namespace ILGPU.IR.Values
         /// <summary>
         /// Returns all child nodes of the latest node.
         /// </summary>
-        public ImmutableArray<ValueReference> Nodes => Resolve().Nodes;
+        public ReadOnlySpan<ValueReference> Nodes => Resolve().Nodes;
 
         /// <summary>
         /// Returns all uses of the latest node.
@@ -114,7 +139,8 @@ namespace ILGPU.IR.Values
         /// Returns an enumerator to enumerate all child nodes.
         /// </summary>
         /// <returns>An enumerator to enumerate all child nodes.</returns>
-        public Value.Enumerator GetEnumerator() => Resolve().GetEnumerator();
+        public ReadOnlySpan<ValueReference>.Enumerator GetEnumerator() =>
+            Resolve().GetEnumerator();
 
         /// <summary>
         /// Accepts a node visitor.

--- a/Src/ILGPU/IR/Values/View.cs
+++ b/Src/ILGPU/IR/Values/View.cs
@@ -11,7 +11,6 @@
 
 using ILGPU.IR.Construction;
 using ILGPU.IR.Types;
-using System.Collections.Immutable;
 using System.Diagnostics;
 
 namespace ILGPU.IR.Values
@@ -39,7 +38,7 @@ namespace ILGPU.IR.Values
             Debug.Assert(
                 length.BasicValueType == BasicValueType.Int32,
                 "Invalid length");
-            Seal(ImmutableArray.Create(pointer, length));
+            Seal(pointer, length);
         }
 
         #endregion
@@ -124,7 +123,7 @@ namespace ILGPU.IR.Values
             ValueReference view)
             : base(initializer)
         {
-            Seal(ImmutableArray.Create(view));
+            Seal(view);
         }
 
         #endregion

--- a/Src/ILGPU/IR/Verifier.cs
+++ b/Src/ILGPU/IR/Verifier.cs
@@ -288,7 +288,7 @@ namespace ILGPU.IR
 
                 foreach (var block in Method.Blocks)
                 {
-                    if (block.Successors.Count < 1)
+                    if (block.Successors.Length < 1)
                         Assert(block, block == exitBlock);
                 }
             }

--- a/Src/ILGPU/Runtime/SpecializationCache.cs
+++ b/Src/ILGPU/Runtime/SpecializationCache.cs
@@ -138,8 +138,7 @@ namespace ILGPU.Runtime
                 var blockBuilder = methodBuilder.EntryBlockBuilder;
 
                 // Append all parameters
-                var targetValues = ImmutableArray.CreateBuilder<ValueReference>(
-                    kernelMethod.NumParameters);
+                var callBuilder = blockBuilder.CreateCall(location, kernelMethod);
                 var specializedParameters = Entry.Parameters.SpecializedParameters;
                 int paramOffset = Entry.KernelIndexParameterOffset;
                 for (
@@ -165,18 +164,15 @@ namespace ILGPU.Runtime
                             managedArgument,
                             managedArgument.GetType());
 
-                        targetValues.Add(irValue);
+                        callBuilder.Add(irValue);
                         ++specialParamIdx;
                     }
                     else
                     {
-                        targetValues.Add(newParam);
+                        callBuilder.Add(newParam);
                     }
                 }
-                blockBuilder.CreateCall(
-                    location,
-                    kernelMethod,
-                    targetValues.MoveToImmutable());
+                callBuilder.Seal();
                 blockBuilder.CreateReturn(location);
             }
             return targetMethod;

--- a/Src/ILGPU/Util/InlineList.cs
+++ b/Src/ILGPU/Util/InlineList.cs
@@ -1,0 +1,551 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                        Copyright (c) 2016-2020 Marcel Koester
+//                                    www.ilgpu.net
+//
+// File: InlineList.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace ILGPU.Util
+{
+    /// <summary>
+    /// An inline array list that has to be passed by reference to avoid unnecessary
+    /// heap allocations.
+    /// </summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    [SuppressMessage(
+        "Usage",
+        "CA2231:Overload operator equals on overriding value type Equals",
+        Justification = "Overloading operators is not appropriate on this structure")]
+    public struct InlineList<T>
+    {
+        #region Static
+
+        /// <summary>
+        /// An empty inline list.
+        /// </summary>
+        public static readonly InlineList<T> Empty = new InlineList<T>(0);
+
+        /// <summary>
+        /// Creates a new inline list with the given capacity and storage capacity.
+        /// </summary>
+        /// <param name="capacity">The capacity.</param>
+        /// <returns>The new inline list.</returns>
+        public static InlineList<T> Create(int capacity) =>
+            new InlineList<T>(capacity);
+
+        /// <summary>
+        /// Creates a new inline list with the given item.
+        /// </summary>
+        /// <param name="item">The first item.</param>
+        /// <returns>The created inline list.</returns>
+        public static InlineList<T> Create(T item)
+        {
+            var result = Create(1);
+            result.Add(item);
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a new inline list with the given items.
+        /// </summary>
+        /// <param name="item1">The first item.</param>
+        /// <param name="item2">The second item.</param>
+        /// <returns>The created inline list.</returns>
+        public static InlineList<T> Create(T item1, T item2)
+        {
+            var result = Create(2);
+            result.Add(item1);
+            result.Add(item2);
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a new inline list from the given list.
+        /// </summary>
+        /// <typeparam name="TList">The list type.</typeparam>
+        /// <param name="list">The source list.</param>
+        /// <returns>The new inline list.</returns>
+        public static InlineList<T> Create<TList>(TList list)
+            where TList : IReadOnlyList<T>
+        {
+            var result = Create(list.Count);
+            for (int i = 0, e = list.Count; i < e; ++i)
+                result.Add(list[i]);
+            return result;
+        }
+
+        #endregion
+
+        #region Instance
+
+        private T[] items;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private InlineList(int capacity)
+        {
+            items = capacity < 1
+                ? Array.Empty<T>()
+                : new T[capacity];
+            Count = 0;
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Returns the number of items.
+        /// </summary>
+        public int Count
+        {
+            readonly get;
+            private set;
+        }
+
+        /// <summary>
+        /// The total capacity.
+        /// </summary>
+        public readonly int Capacity => items.Length;
+
+        /// <summary>
+        /// Returns a reference to the i-th item.
+        /// </summary>
+        /// <param name="index">The item index.</param>
+        /// <returns>The item reference.</returns>
+        public readonly ref T this[int index]
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                Debug.Assert(index >= 0 && index < Count, "Index out of range");
+                return ref items[index];
+            }
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Ensures that at least a single item can be stored.
+        /// </summary>
+        private void EnsureCapacity()
+        {
+            if (Count + 1 > Capacity)
+                Reserve(Math.Max(Capacity * 2, 2));
+        }
+
+        /// <summary>
+        /// Ensures that this list as at least the given capacity.
+        /// </summary>
+        /// <param name="capacity">The capacity to ensure.</param>
+        public void Reserve(int capacity)
+        {
+            Debug.Assert(capacity > 0, "Invalid capacity");
+            if (Capacity >= capacity)
+                return;
+
+            // Increase capacity
+            var newItems = new T[capacity];
+            Array.Copy(items, newItems, items.Length);
+            items = newItems;
+        }
+
+        /// <summary>
+        /// Adds the given item to this list.
+        /// </summary>
+        /// <param name="item">The item to add.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Add(T item)
+        {
+            EnsureCapacity();
+            items[Count] = item;
+            ++Count;
+        }
+
+        /// <summary>
+        /// Adds the given items to this list.
+        /// </summary>
+        /// <typeparam name="TList">The list type.</typeparam>
+        /// <param name="list">The source list.</param>
+        public void AddRange<TList>(TList list)
+            where TList : IReadOnlyList<T>
+        {
+            if (list.Count < 1)
+                return;
+            Reserve(Count + list.Count);
+            for (int i = 0, e = list.Count; i < e; ++i)
+                Add(list[i]);
+        }
+
+        /// <summary>
+        /// Adds the given items to this list.
+        /// </summary>
+        /// <param name="span">The source span.</param>
+        public void AddRange(in ReadOnlySpan<T> span)
+        {
+            if (span.Length < 1)
+                return;
+            Reserve(Count + span.Length);
+            foreach (var item in span)
+                Add(item);
+        }
+
+        /// <summary>
+        /// Clears all items.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Clear()
+        {
+            items = Array.Empty<T>();
+            Count = 0;
+        }
+
+        /// <summary>
+        /// Returns true if the given item is contained in this list.
+        /// </summary>
+        /// <param name="item">The item to look for.</param>
+        /// <param name="comparer">The comparer to use.</param>
+        /// <returns>True, if the given item contained in this list.</returns>
+        public readonly bool Contains<TComparer>(T item, TComparer comparer)
+            where TComparer : IEqualityComparer<T> =>
+            IndexOf(item, comparer) >= 0;
+
+        /// <summary>
+        /// Copies the internally stored items to the given array.
+        /// </summary>
+        /// <param name="array">The target array to copy to.</param>
+        /// <param name="arrayIndex">The base index.</param>
+        public readonly void CopyTo(T[] array, int arrayIndex) =>
+            Array.Copy(items, 0, array, arrayIndex, Count);
+
+        /// <summary>
+        /// Inserts the given item at the specified index.
+        /// </summary>
+        /// <param name="item">The item to insert.</param>
+        /// <param name="index">The target index.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Insert(T item, int index)
+        {
+            EnsureCapacity();
+            for (int i = Count; i >= index; --i)
+                items[i] = items[i - 1];
+            items[index] = item;
+            ++Count;
+        }
+
+        /// <summary>
+        /// Returns the index of the given item.
+        /// </summary>
+        /// <param name="item">The item to look for.</param>
+        /// <param name="comparer">The comparer to use.</param>
+        /// <returns>The index of the item or -1.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public readonly int IndexOf<TComparer>(T item, TComparer comparer)
+            where TComparer : IEqualityComparer<T>
+        {
+            for (int i = 0, e = Count; i < e; ++i)
+            {
+                if (comparer.Equals(items[i], item))
+                    return i;
+            }
+            return -1;
+        }
+
+        /// <summary>
+        /// Removes the given item from the list.
+        /// </summary>
+        /// <param name="item">The item to remove.</param>
+        /// <param name="comparer">The comparer to use.</param>
+        /// <returns>True, if the item could be removed from the list.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Remove<TComparer>(T item, TComparer comparer)
+            where TComparer : IEqualityComparer<T>
+        {
+            int index = IndexOf(item, comparer);
+            if (index < 0)
+                return false;
+            RemoveAt(index);
+            return true;
+        }
+
+        /// <summary>
+        /// Removes the item with the specified index.
+        /// </summary>
+        /// <param name="index">The item index.</param>
+        public void RemoveAt(int index)
+        {
+            for (int i = index, e = Count - 1; i < e; ++i)
+                items[i] = items[i + 1];
+            --Count;
+        }
+
+        /// <summary>
+        /// Reverses all items in this list.
+        /// </summary>
+        public void Reverse() => Array.Reverse(items);
+
+        /// <summary>
+        /// Moves the current items to the given target list.
+        /// </summary>
+        /// <param name="list">The target list to move to.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void MoveTo(ref InlineList<T> list)
+        {
+            list.items = items;
+            list.Count = Count;
+
+            Clear();
+        }
+
+        /// <summary>
+        /// Copies all items to the given target list.
+        /// </summary>
+        /// <param name="list">The target list.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public readonly void CopyTo(ref InlineList<T> list)
+        {
+            Array.Resize(ref list.items, Count);
+            list.Count = Count;
+            CopyTo(list.items, 0);
+        }
+
+        /// <summary>
+        /// Clones this inline list.
+        /// </summary>
+        /// <returns>A clone of the current inline list.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public readonly InlineList<T> Clone()
+        {
+            var result = Create(Count);
+            CopyTo(ref result);
+            return result;
+        }
+
+        /// <summary>
+        /// Slices a sub inline list out of this one.
+        /// </summary>
+        /// <param name="startIndex">The start index to begin slicing.</param>
+        /// <param name="count">The number of elements to slice.</param>
+        /// <returns>The new inline list.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public readonly InlineList<T> Slice(int startIndex, int count)
+        {
+            var result = Create(count);
+            SliceTo(startIndex, count, ref result);
+            return result;
+        }
+
+        /// <summary>
+        /// Slices a sub inline list out of this one into the given one.
+        /// </summary>
+        /// <param name="startIndex">The start index to begin slicing.</param>
+        /// <param name="count">The number of elements to slice.</param>
+        /// <param name="list">The target list.</param>
+        public readonly void SliceTo(
+            int startIndex,
+            int count,
+            ref InlineList<T> list)
+        {
+            list.Reserve(Count + count);
+            Array.Copy(items, startIndex, list.items, 0, count);
+        }
+
+        /// <summary>
+        /// Returns true if the given list is equal to the current list.
+        /// </summary>
+        /// <param name="other">The other list.</param>
+        /// <param name="comparer">The comparer to use.</param>
+        /// <returns>True, if the given list is equal to the current list.</returns>
+        public readonly bool Equals<TComparer>(InlineList<T> other, TComparer comparer)
+            where TComparer : IEqualityComparer<T>
+        {
+            if (other.Count != Count)
+                return false;
+            for (int i = 0; i < Count; ++i)
+            {
+                if (!comparer.Equals(items[i], other.items[i]))
+                    return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Converts this inline list into a span.
+        /// </summary>
+        /// <returns>The span.</returns>
+        public readonly Span<T> AsSpan() => new Span<T>(items, 0, Count);
+
+        /// <summary>
+        /// Converts this inline list into a read-only span.
+        /// </summary>
+        /// <returns>The read-only span.</returns>
+        public readonly ReadOnlySpan<T> AsReadOnlySpan() => AsSpan();
+
+        /// <summary>
+        /// Returns an enumerator to enumerate all items in this list.
+        /// </summary>
+        /// <returns>The enumerator.</returns>
+        /// <remarks>
+        /// CAUTION: iterating over this list can be dangerous, as the underlying inline
+        /// list might change and this instance is a structure value.
+        /// </remarks>
+        public readonly ReadOnlySpan<T>.Enumerator GetEnumerator() =>
+            AsReadOnlySpan().GetEnumerator();
+
+        #endregion
+
+        #region Object
+
+        /// <summary>
+        /// Returns the string representation of this list.
+        /// </summary>
+        /// <returns>The string representation of this list.</returns>
+        public readonly string ToString<TFormatter>(TFormatter formatter)
+            where TFormatter : InlineList.IFormatter<T> =>
+            AsReadOnlySpan().ToString(formatter);
+
+        /// <summary>
+        /// Returns the string representation of this list.
+        /// </summary>
+        /// <returns>The string representation of this list.</returns>
+        public readonly override string ToString() =>
+            ToString(new InlineList.DefaultFormatter<T>());
+
+        #endregion
+
+        #region Operators
+
+        /// <summary>
+        /// Converts the given list into a span.
+        /// </summary>
+        /// <param name="list">The list to convert.</param>
+        public static explicit operator Span<T>(InlineList<T> list) =>
+            new Span<T>(list.items, 0, list.Count);
+
+        /// <summary>
+        /// Converts the given list into a read-only span.
+        /// </summary>
+        /// <param name="list">The list to convert.</param>
+        public static implicit operator ReadOnlySpan<T>(InlineList<T> list) =>
+            new ReadOnlySpan<T>(list.items, 0, list.Count);
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Inline list utility methods.
+    /// </summary>
+    public static class InlineList
+    {
+        #region Nested Types
+
+        /// <summary>
+        /// An abstract value formatter for inline lists.
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        public interface IFormatter<T>
+        {
+            /// <summary>
+            /// Formats the given item.
+            /// </summary>
+            /// <param name="item">The item to format.</param>
+            /// <returns>The formatted string representation.</returns>
+            string Format(T item);
+        }
+
+        /// <summary>
+        /// The default formatter that calls the <see cref="object.ToString()"/> method.
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        public readonly struct DefaultFormatter<T> : IFormatter<T>
+        {
+            /// <summary>
+            /// Formats the given item using <see cref="object.ToString()"/>.
+            /// </summary>
+            /// <param name="item">The item to format.</param>
+            /// <returns>The default string representation.</returns>
+            public readonly string Format(T item) => item.ToString();
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Creates a new inline list from the given span.
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <param name="span">The span instance.</param>
+        /// <returns>The created inline list.</returns>
+        public static InlineList<T> ToInlineList<T>(this ReadOnlySpan<T> span)
+        {
+            var result = InlineList<T>.Empty;
+            span.CopyTo(ref result);
+            return result;
+        }
+
+        /// <summary>
+        /// Copies the items from the given span to the inline list.
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <param name="span">The span instance.</param>
+        /// <param name="list">A reference to the inline list.</param>
+        public static void CopyTo<T>(
+            this ReadOnlySpan<T> span,
+            ref InlineList<T> list) =>
+            list.AddRange(span);
+
+        /// <summary>
+        /// Returns the string representation of the given span.
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <typeparam name="TFormatter">The formatter type.</typeparam>
+        /// <param name="span">The span instance.</param>
+        /// <param name="formatter">The custom formatter.</param>
+        /// <returns>The string representation of this list.</returns>
+        public static string ToString<T, TFormatter>(
+            this ReadOnlySpan<T> span,
+            TFormatter formatter)
+            where TFormatter : IFormatter<T>
+        {
+            if (span.Length < 1)
+            {
+                return string.Empty;
+            }
+            else if (span.Length < 3)
+            {
+                string result = formatter.Format(span[0]);
+                if (span.Length > 1)
+                    result += ", " + formatter.Format(span[1]);
+                if (span.Length > 2)
+                    result += ", " + formatter.Format(span[2]);
+                return result;
+            }
+            else
+            {
+                var result = new StringBuilder();
+                for (int i = 0, e = span.Length; i < e; ++i)
+                {
+                    result.Append(formatter.Format(span[i]));
+                    if (i + 1 < e)
+                        result.Append(", ");
+                }
+                return result.ToString();
+            }
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
As described in #109, ILGPU performs many temporary memory allocations, which leads to serious heap fragmentation, GC pressure, and runtime overhead. This PR implements a new `InlineList` structure to reduce the number of heap allocations and indirect memory accesses.

It also adds new package references to support `Span<T>` and `Memory<T>` types (see also #122).