### PR TITLE
Fixed invalid allocations in MemoryBufferCache.

### DIFF
--- a/Src/ILGPU.Tests/Configurations.txt
+++ b/Src/ILGPU.Tests/Configurations.txt
@@ -3,6 +3,7 @@ Arrays: Debug, Release
 EnumValues: Debug, Release
 KernelEntryPoints: Debug, Release
 MemoryBufferOperations : Debug, Release
+MemoryCacheOperations : Debug, Release
 SharedMemory: Debug, Release
 SizeOfValues: Debug, Release
 SpecializedKernels: Debug, Release

--- a/Src/ILGPU.Tests/MemoryCacheOperations.cs
+++ b/Src/ILGPU.Tests/MemoryCacheOperations.cs
@@ -1,0 +1,55 @@
+﻿using ILGPU.Runtime;
+using System.Diagnostics.CodeAnalysis;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ILGPU.Tests
+{
+    public abstract class MemoryCacheOperations : TestBase
+    {
+        protected MemoryCacheOperations(
+            ITestOutputHelper output,
+            TestContext testContext)
+            : base(output, testContext)
+        { }
+
+        public static TheoryData<object> AllocationTestData =>
+            SizeOfValues.SizeOfTestData;
+
+        [Theory]
+        [MemberData(nameof(AllocationTestData))]
+        [SuppressMessage(
+            "Usage",
+            "xUnit1026:Theory methods should use all of their parameters",
+            Justification = "Required for generic argument")]
+        public void Allocate<T>(T _)
+            where T : unmanaged
+        {
+            using var buffer = new MemoryBufferCache(Accelerator);
+
+            // Allocate several elements one after another
+            for (int i = 1; i <= 1024; i <<= 1)
+            {
+                var view = buffer.Allocate<T>(i);
+
+                Assert.Equal(view.Length, i);
+                Assert.Equal(view.LengthInBytes, Interop.SizeOf<T>() * i);
+
+                Assert.True(buffer.CacheSizeInBytes >= Interop.SizeOf<T>() * i);
+                Assert.True(buffer.GetCacheSize<T>() == i);
+            }
+
+            // "Allocate" the same elements in reverse order
+            for (int i = 1024; i >= 1; i >>= 1)
+            {
+                var view = buffer.Allocate<T>(i);
+
+                Assert.Equal(view.Length, i);
+                Assert.Equal(view.LengthInBytes, Interop.SizeOf<T>() * i);
+
+                Assert.True(buffer.CacheSizeInBytes >= Interop.SizeOf<T>() * i);
+                Assert.True(buffer.GetCacheSize<T>() >= i);
+            }
+        }
+    }
+}

--- a/Src/ILGPU/Runtime/MemoryBufferCache.cs
+++ b/Src/ILGPU/Runtime/MemoryBufferCache.cs
@@ -86,7 +86,8 @@ namespace ILGPU.Runtime
             Justification = "The generic parameter is required to compute the number " +
             "of elements of the given type that can be stored")]
         public Index1 GetCacheSize<T>()
-            where T : unmanaged => (cache?.Length ?? 0) * ArrayView<T>.ElementSize;
+            where T : unmanaged =>
+            (cache?.Length ?? 0) / Interop.SizeOf<T>();
 
         /// <summary>
         /// Allocates the given number of elements and returns an array view
@@ -107,7 +108,7 @@ namespace ILGPU.Runtime
             {
                 cache?.Dispose();
                 cache = Accelerator.Allocate<byte, Index1>(
-                    numElements * ArrayView<T>.ElementSize);
+                    numElements * Interop.SizeOf<T>());
             }
             Debug.Assert(numElements <= GetCacheSize<T>());
             return cache.View.Cast<T>().GetSubView(0, numElements).AsLinearView();


### PR DESCRIPTION
The use of the class `MemoryBufferCache` can lead to unintentional allocations on the device side. This PR solves these problems.