### PR TITLE
Fixed invalid access to MethodCall parameters

### DIFF
--- a/Src/ILGPU/IR/Transformations/InferAddressSpaces.cs
+++ b/Src/ILGPU/IR/Transformations/InferAddressSpaces.cs
@@ -48,11 +48,14 @@ namespace ILGPU.IR.Transformations
                     case MethodCall call:
                         // We cannot remove casts to other address spaces in case of a
                         // method invocation if the address spaces do not match
-                        var targetParam = call.Target.Parameters[use.Index];
-                        if (targetParam.ParameterType is IAddressSpaceType paramType &&
-                            paramType.AddressSpace == targetSpace)
+                        if (call.Target.Parameters.Count > 0 && use.Index < call.Target.Parameters.Count)
                         {
-                            return false;
+                            var targetParam = call.Target.Parameters[use.Index];
+                            if (targetParam.ParameterType is IAddressSpaceType paramType &&
+                                paramType.AddressSpace == targetSpace)
+                            {
+                                return false;
+                            }
                         }
 
                         break;


### PR DESCRIPTION
Fixes the `IndexOutOfRangeException` from for https://github.com/m4rs-mt/ILGPU.Algorithms/issues/21

It some cases, it looks like the `Method` parameters are never populated. I'm not sure if this is intentional or an oversight.