### PR TITLE
Updated ComputeRelativeSizeOf to calculate size of more than one element

### DIFF
--- a/Src/ILGPU/Interop.cs
+++ b/Src/ILGPU/Interop.cs
@@ -70,9 +70,10 @@ namespace ILGPU
         /// <typeparam name="TSecond">
         /// The base type that should be represented with <typeparamref name="TFirst"/>.
         /// </typeparam>
+        /// <param name="numSecondElements">The number of <typeparamref name="TSecond"/> elements to be stored.</param>
         /// <returns>
-        /// The number of required <typeparamref name="TFirst"/> instances to store an
-        /// instance of type <typeparamref name="TSecond"/>.
+        /// The number of required <typeparamref name="TFirst"/> instances to store <paramref name="numSecondElements"/>
+        /// instances of type <typeparamref name="TSecond"/>.
         /// </returns>
         [SuppressMessage(
            "Microsoft.Design",
@@ -80,17 +81,17 @@ namespace ILGPU
             Justification = "The type is required for the computation of the " +
             "field offset")]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int ComputeRelativeSizeOf<TFirst, TSecond>()
+        public static int ComputeRelativeSizeOf<TFirst, TSecond>(int numSecondElements = 1)
             where TFirst : unmanaged
             where TSecond : unmanaged
         {
+            if (numSecondElements < 1)
+                throw new ArgumentOutOfRangeException(nameof(numSecondElements));
+
             var firstSize = SizeOf<TFirst>();
             var secondSize = SizeOf<TSecond>();
 
-            int count = 1;
-            if (firstSize < secondSize)
-                count = IntrinsicMath.DivRoundUp(secondSize, firstSize);
-            return count;
+            return IntrinsicMath.DivRoundUp(secondSize * numSecondElements, firstSize);
         }
 
         /// <summary>

--- a/Src/ILGPU/Interop.cs
+++ b/Src/ILGPU/Interop.cs
@@ -70,10 +70,9 @@ namespace ILGPU
         /// <typeparam name="TSecond">
         /// The base type that should be represented with <typeparamref name="TFirst"/>.
         /// </typeparam>
-        /// <param name="numSecondElements">The number of <typeparamref name="TSecond"/> elements to be stored.</param>
         /// <returns>
-        /// The number of required <typeparamref name="TFirst"/> instances to store <paramref name="numSecondElements"/>
-        /// instances of type <typeparamref name="TSecond"/>.
+        /// The number of required <typeparamref name="TFirst"/> instances to store an
+        /// instance of type <typeparamref name="TSecond"/>.
         /// </returns>
         [SuppressMessage(
            "Microsoft.Design",
@@ -81,7 +80,30 @@ namespace ILGPU
             Justification = "The type is required for the computation of the " +
             "field offset")]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int ComputeRelativeSizeOf<TFirst, TSecond>(int numSecondElements = 1)
+        [Obsolete("Use ComputeRelativeSizeOf<TFirst, TSecond>(int) instead")]
+        public static int ComputeRelativeSizeOf<TFirst, TSecond>()
+            where TFirst : unmanaged
+            where TSecond : unmanaged =>
+            ComputeRelativeSizeOf<TFirst, TSecond>(1);
+
+        /// <summary>
+        /// Computes number of elements of type <typeparamref name="TFirst"/>
+        /// that are required to store a type <typeparamref name="TSecond"/> in
+        /// unmanaged memory.
+        /// </summary>
+        /// <typeparam name="TFirst">
+        /// The type that should represent type <typeparamref name="TSecond"/>.
+        /// </typeparam>
+        /// <typeparam name="TSecond">
+        /// The base type that should be represented with <typeparamref name="TFirst"/>.
+        /// </typeparam>
+        /// <param name="numSecondElements">The number of <typeparamref name="TSecond"/> elements to be stored.</param>
+        /// <returns>
+        /// The number of required <typeparamref name="TFirst"/> instances to store <paramref name="numSecondElements"/>
+        /// instances of type <typeparamref name="TSecond"/>.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int ComputeRelativeSizeOf<TFirst, TSecond>(int numSecondElements)
             where TFirst : unmanaged
             where TSecond : unmanaged
         {


### PR DESCRIPTION
First step in reducing the amount of memory required when calculating the size of a temporary buffer for data types smaller than an `int`.

For example, when calling `TempViewManager.Allocate<Int16>(length: 33)`, this will internally call `ComputeRelativeSizeof<int, Int16>()`. The size of `int` is 4 bytes, and the size of `Int16` is 2 bytes. The minimum required bytes to store 33 Int16s is 66 bytes.

Based on the original code, the relative size is 1 int, and we would then allocate 33 ints (132 bytes).

With the modified code, by calling `ComputeRelativeSizeof<int, Int16>(length: 33)`, we only need to allocate 17 ints (68 bytes).