### PR TITLE
Fixed invalid computation of nested VariableView instances.

### DIFF
--- a/Src/ILGPU/VariableView.cs
+++ b/Src/ILGPU/VariableView.cs
@@ -100,7 +100,7 @@ namespace ILGPU
 
             var rawView = BaseView.Cast<byte>();
             var subView = rawView.GetSubView(offsetInBytes);
-            var finalView = subView.Cast<TOther>();
+            var finalView = subView.Cast<TOther>().GetSubView(0, 1);
             return new VariableView<TOther>(finalView);
         }
 


### PR DESCRIPTION
The structure `VariableView` allows you to create low-level sub-views of specific elements within a parent structure value. This PR fixes an invalid view calculation within this implementation.