### PR TITLE
Added support for custom type sizes.

### DIFF
--- a/Src/ILGPU.Tests/Generic/TestData.cs
+++ b/Src/ILGPU.Tests/Generic/TestData.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.InteropServices;
 using Xunit.Abstractions;
 
 #pragma warning disable CA1815 // Override equals and operator equals on value types
@@ -350,6 +351,68 @@ namespace ILGPU.Tests
 
         public void Serialize(IXunitSerializationInfo info) =>
             Value.Serialize(info);
+    }
+
+    [StructLayout(LayoutKind.Sequential, Size = 1024)]
+    public struct CustomSizeStruct : IXunitSerializable
+    {
+        public byte Data;
+
+        public void Deserialize(IXunitSerializationInfo info) =>
+            Data = info.GetValue<byte>(nameof(Data));
+
+        public void Serialize(IXunitSerializationInfo info) =>
+            info.AddValue(nameof(Data), Data);
+    }
+
+    public unsafe struct ShortFixedBufferStruct : IXunitSerializable
+    {
+        public const int Length = 7;
+
+        public fixed short Data[Length];
+
+        public ShortFixedBufferStruct(short data)
+        {
+            for (int i = 0; i < Length; ++i)
+                Data[i] = data;
+        }
+
+        public void Deserialize(IXunitSerializationInfo info)
+        {
+            for (int i = 0; i < Length; ++i)
+                Data[i] = info.GetValue<short>(nameof(Data) + i);
+        }
+
+        public void Serialize(IXunitSerializationInfo info)
+        {
+            for (int i = 0; i < Length; ++i)
+                info.AddValue(nameof(Data) + i, Data[i]);
+        }
+    }
+
+    public unsafe struct LongFixedBufferStruct : IXunitSerializable
+    {
+        public const int Length = 19;
+
+        public fixed long Data[Length];
+
+        public LongFixedBufferStruct(long data)
+        {
+            for (int i = 0; i < Length; ++i)
+                Data[i] = data;
+        }
+
+        public void Deserialize(IXunitSerializationInfo info)
+        {
+            for (int i = 0; i < Length; ++i)
+                Data[i] = info.GetValue<long>(nameof(Data) + i);
+        }
+
+        public void Serialize(IXunitSerializationInfo info)
+        {
+            for (int i = 0; i < Length; ++i)
+                info.AddValue(nameof(Data) + i, Data[i]);
+        }
     }
 
     #endregion

--- a/Src/ILGPU.Tests/ILGPU.Tests.csproj
+++ b/Src/ILGPU.Tests/ILGPU.Tests.csproj
@@ -8,10 +8,12 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <LangVersion>latest</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <LangVersion>latest</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/ILGPU.Tests/SizeOfValues.cs
+++ b/Src/ILGPU.Tests/SizeOfValues.cs
@@ -41,7 +41,13 @@ namespace ILGPU.Tests
             { default(TestStruct<float, TestStruct<EmptyStruct, sbyte>>) },
             { default(DeepStructure<TestStruct<int>>) },
             { default(
-                TestStruct<int, TestStruct<float, TestStruct<EmptyStruct, sbyte>>>) }
+                TestStruct<int, TestStruct<float, TestStruct<EmptyStruct, sbyte>>>) },
+            { default(ShortFixedBufferStruct) },
+            { default(LongFixedBufferStruct) },
+            { default(TestStruct<EmptyStruct, ShortFixedBufferStruct>) },
+            { default(TestStruct<ShortFixedBufferStruct, LongFixedBufferStruct>) },
+            { default(TestStruct<float, TestStruct<ShortFixedBufferStruct, sbyte>>) },
+            { default(TestStruct<float, TestStruct<LongFixedBufferStruct, byte>>) },
         };
 
         internal static void SizeOfKernel<T>(

--- a/Src/ILGPU.Tests/StructureValues.cs
+++ b/Src/ILGPU.Tests/StructureValues.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Configuration;
 using System.Diagnostics.CodeAnalysis;
+using System.Text;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -56,7 +58,30 @@ namespace ILGPU.Tests
                     }
                 }
             } },
-            { new DeepStructure<EmptyStruct>() }
+            { new DeepStructure<EmptyStruct>() },
+            { new TestStruct<CustomSizeStruct, long>()
+            {
+                Val0 = new CustomSizeStruct()
+                {
+                    Data = byte.MaxValue,
+                },
+                Val1 = ushort.MaxValue,
+                Val2 = long.MinValue,
+            } },
+            { new ShortFixedBufferStruct(short.MaxValue) },
+            { new LongFixedBufferStruct(long.MaxValue) },
+            { new TestStruct<EmptyStruct, ShortFixedBufferStruct>()
+            {
+                Val0 = default,
+                Val1 = ushort.MaxValue,
+                Val2 = new ShortFixedBufferStruct(short.MaxValue),
+            } },
+            { new TestStruct<ShortFixedBufferStruct, LongFixedBufferStruct>()
+            {
+                Val0 = new ShortFixedBufferStruct(short.MinValue),
+                Val1 = ushort.MaxValue,
+                Val2 = new LongFixedBufferStruct(long.MinValue),
+            } },
         };
 
         internal static void StructureInteropKernel<T>(

--- a/Src/ILGPU/IR/Types/IRTypeContext.cs
+++ b/Src/ILGPU/IR/Types/IRTypeContext.cs
@@ -127,6 +127,11 @@ namespace ILGPU.IR.Types
         /// </summary>
         public StructureType RootType { get; }
 
+        /// <summary>
+        /// Returns a custom padding type that is used to pad structure values.
+        /// </summary>
+        public TypeNode PaddingType => GetPrimitiveType(BasicValueType.Int8);
+
         #endregion
 
         #region Methods
@@ -197,7 +202,7 @@ namespace ILGPU.IR.Types
         /// <param name="capacity">The initial capacity.</param>
         /// <returns>The created structure builder.</returns>
         public StructureType.Builder CreateStructureType(int capacity) =>
-            new StructureType.Builder(this, capacity);
+            new StructureType.Builder(this, capacity, 0);
 
         /// <summary>
         /// Creates a new structure type.
@@ -383,11 +388,15 @@ namespace ILGPU.IR.Types
                             ErrorMessages.NotSupportedType,
                             type));
                 }
-                var typeInfo = GetTypeInfo(type);
 
-                var builder = CreateStructureType(typeInfo.NumFlattendedFields);
+                var typeInfo = GetTypeInfo(type);
+                var builder = new StructureType.Builder(
+                    this,
+                    typeInfo.NumFlattendedFields,
+                    typeInfo.Size);
                 foreach (var field in typeInfo.Fields)
                     builder.Add(CreateTypeInternal(field.FieldType, addressSpace));
+
                 return Map(
                     type,
                     addressSpace,

--- a/Src/ILGPU/Resources/ErrorMessages.Designer.cs
+++ b/Src/ILGPU/Resources/ErrorMessages.Designer.cs
@@ -583,6 +583,15 @@ namespace ILGPU.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The type &apos;{0}&apos; has an unsupported structure layout.
+        /// </summary>
+        internal static string NotSupportedStructureLayout {
+            get {
+                return ResourceManager.GetString("NotSupportedStructureLayout", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Not supported type &apos;{0}&apos;.
         /// </summary>
         internal static string NotSupportedType {

--- a/Src/ILGPU/Resources/ErrorMessages.resx
+++ b/Src/ILGPU/Resources/ErrorMessages.resx
@@ -312,4 +312,7 @@
   <data name="LocationTypeMessage" xml:space="preserve">
     <value>'{0}' related to type {1} (managed type '{2}')</value>
   </data>
+  <data name="NotSupportedStructureLayout" xml:space="preserve">
+    <value>The type '{0}' has an unsupported structure layout</value>
+  </data>
 </root>


### PR DESCRIPTION
This PR adds support for structures with a custom type size (e.g. defined via `[StructLayout(..., Size = X)]`). Moreover, it adds basic support for fixed-size buffers within structure types.

Note that this PR provides the essential functionality required to implement #87 and #111.