### PR TITLE
Fix NuGet push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,4 +56,5 @@ jobs:
         with:
           name: nuget-package
       - name: Publish to NuGet
+        shell: bash
         run: dotnet nuget push ILGPU.*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
PowerShell would not do glob expansion for the command, and `dotnet nuget push` would thus not find a file named `ILGPU.*.nupkg`.