### PR TITLE
Fixed invalid alignment of vector loads.

### DIFF
--- a/Src/ILGPU/Backends/PTX/PTXBackend.cs
+++ b/Src/ILGPU/Backends/PTX/PTXBackend.cs
@@ -168,7 +168,7 @@ namespace ILGPU.Backends.PTX
                 ? PointerAlignments.Create(
                     backendContext.KernelMethod,
                     DefaultGlobalMemoryAlignment)
-                : PointerAlignments.Empty;
+                : null;
 
             data = new PTXCodeGenerator.GeneratorArgs(
                 this,

--- a/Src/ILGPU/Backends/PTX/PTXCodeGenerator.Emitter.cs
+++ b/Src/ILGPU/Backends/PTX/PTXCodeGenerator.Emitter.cs
@@ -659,21 +659,27 @@ namespace ILGPU.Backends.PTX
         /// to resolve the correct offset in bytes within a structure.
         /// </summary>
         /// <typeparam name="TEmitter">The emitter type.</typeparam>
+        /// <param name="pointerValue">The pointer to get the alignment for.</param>
+        /// <param name="safeAlignment">The safe minimum alignment in bytes.</param>
         /// <param name="command">The generic command to emit.</param>
         /// <param name="emitter">The current emitter.</param>
         /// <param name="register">The involved register.</param>
-        /// <param name="alignment">The base alignment in bytes.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void EmitVectorizedCommand<TEmitter>(
+            Value pointerValue,
+            int safeAlignment,
             string command,
             in TEmitter emitter,
-            Register register,
-            int alignment)
+            Register register)
             where TEmitter : IVectorizedCommandEmitter
         {
-            if (register is CompoundRegister compoundRegister)
+            if (PointerAlignments != null &&
+                register is CompoundRegister compoundRegister)
             {
                 // Check the provided alignment value to create vectorized instructions
+                int alignment = PointerAlignments.GetAlignment(
+                    pointerValue,
+                    safeAlignment);
                 var ranges = compoundRegister.Type.VectorizableFields;
                 for (int i = 0, e = ranges.Count; i < e; ++i)
                 {

--- a/Src/ILGPU/Backends/PTX/PTXCodeGenerator.Values.cs
+++ b/Src/ILGPU/Backends/PTX/PTXCodeGenerator.Values.cs
@@ -439,15 +439,12 @@ namespace ILGPU.Backends.PTX
             var sourceType = load.Source.Type as PointerType;
             var targetRegister = Allocate(load);
 
-            // Query alignment information to emit vectorized instructions
-            int alignment = PointerAlignments.GetAlignment(
-                load.Source,
-                sourceType.ElementType.Alignment);
             EmitVectorizedCommand(
+                load.Source,
+                sourceType.ElementType.Alignment,
                 PTXInstructions.LoadOperation,
                 new LoadEmitter(sourceType, address),
-                targetRegister,
-                alignment);
+                targetRegister);
         }
 
         /// <summary>
@@ -540,15 +537,12 @@ namespace ILGPU.Backends.PTX
             var targetType = store.Target.Type as PointerType;
             var value = Load(store.Value);
 
-            // Query alignment information to emit vectorized instructions
-            int baseAlignment = PointerAlignments.GetAlignment(
-                store.Target,
-                targetType.ElementType.Alignment);
             EmitVectorizedCommand(
+                store.Target,
+                targetType.ElementType.Alignment,
                 PTXInstructions.StoreOperation,
                 new StoreEmitter(targetType, address),
-                value,
-                baseAlignment);
+                value);
         }
 
         /// <summary cref="IBackendCodeGenerator.GenerateCode(LoadFieldAddress)"/>

--- a/Src/ILGPU/IR/Analyses/FixPointAnalysis.cs
+++ b/Src/ILGPU/IR/Analyses/FixPointAnalysis.cs
@@ -484,6 +484,8 @@ namespace ILGPU.IR.Analyses
             where TBlockDirection : struct, IControlFlowDirection
         {
             // Setup initial data mapping
+            var undefValue = blocks.Method.Context.UndefinedValue;
+            valueMapping[undefValue] = analysis.CreateData(undefValue);
             foreach (var block in blocks)
             {
                 foreach (Value value in block)

--- a/Src/ILGPU/IR/Analyses/PointerAlignments.cs
+++ b/Src/ILGPU/IR/Analyses/PointerAlignments.cs
@@ -84,14 +84,15 @@ namespace ILGPU.IR.Analyses
                 {
                     LoadFieldAddress lfa =>
                         AnalysisValue.Create(
-                            context[lfa.Source].Data +
-                            lfa.StructureType.GetOffset(lfa.FieldSpan.Access),
-                            lfa.Type),
+                            Math.Min(
+                                context[lfa.Source].Data,
+                                lfa.StructureType[lfa.FieldSpan.Access].Alignment),
+                                lfa.Type),
                     LoadElementAddress lea =>
                         AnalysisValue.Create(
-                            Math.Min(
+                            Math.Max(
                                 context[lea.Source].Data,
-                                (lea.Type as IAddressSpaceType).ElementType.Size),
+                                (lea.Type as IAddressSpaceType).ElementType.Alignment),
                             lea.Type),
                     _ => null,
                 };


### PR DESCRIPTION
Recent changes in the O2 pipeline may cause code generation problems in the PTX backend. This can result in invalid memory accesses using the newly emitted vector load instructions. This PR addresses two critical issues in this context and ensures that all tests pass (see also #159 and #158).

Steps to reproduce this issue: checkout the master branch and execute the `CudaStructureValues` tests on a NVIDIA Pascal GPU.