### PR TITLE
Fixed emitting OpenCL floating point constants with suffix

### DIFF
--- a/Src/ILGPU.Tests/CompareFloatOperations.tt
+++ b/Src/ILGPU.Tests/CompareFloatOperations.tt
@@ -18,6 +18,20 @@ var operationConfigurations = new (string, string)[]
         ("Equal", "=="),
         ("NotEqual", "!="),
     };
+
+// Test name and format string
+//  {0} is the type name e.g. float or double
+//  {1} is the type suffix e.g. f
+var floatLimits = new (string, string)[]
+    {
+        ("PositiveInfinity", "{0}.PositiveInfinity"),
+        ("NegativeInfinity", "{0}.NegativeInfinity"),
+        ("MaxValue", "{0}.MaxValue"),
+        ("MinValue", "{0}.MinValue"),
+        ("Epsilon", "{0}.Epsilon"),
+        ("Precision9", "123456.789{1}"),
+        ("Precision17", "1.0000000000000002{1}"),
+    };
 #>
 namespace ILGPU.Tests
 {
@@ -65,6 +79,38 @@ namespace ILGPU.Tests
             var result = left <#= infix #> right ? 1 : 0;
             var reference = Enumerable.Repeat(result, length).ToArray();
             Verify(c, reference);
+        }
+
+<#      } #>
+<# } #>
+
+<# foreach (var (typeName, type, suffix) in FloatTypes) { #>
+<#      foreach (var (limitName, limitFormat) in floatLimits) { #>
+<#          var baseName = "_" + limitName + "_" + type.Name; #>
+<#          var testName = "Constant" + baseName; #>
+<#          var kernelName = "ConstantKernel" + testName; #>
+<#          var testValue = string.Format(limitFormat, typeName, suffix); #>
+        internal static void <#= kernelName #>(
+            Index1 index,
+            ArrayView<<#= typeName #>> input,
+            ArrayView<int> output)
+        {
+            output[index] = input[index] == <#= testValue #> ? 1 : 0;
+        }
+
+        [Fact]
+        [KernelMethod(nameof(<#= kernelName #>))]
+        public void <#= testName #>()
+        {
+            var inputArray = new [] { 0.0<#= suffix #>, <#= testValue #> };
+            var expected = inputArray.Select(x => x == <#= testValue #> ? 1 : 0).ToArray();
+
+            using var input = Accelerator.Allocate<<#= typeName #>>(inputArray.Length);
+            using var output = Accelerator.Allocate<int>(inputArray.Length);
+            input.CopyFrom(inputArray, 0, 0, inputArray.Length);
+
+            Execute(input.Length, input.View, output.View);
+            Verify(output, expected);
         }
 
 <#      } #>

--- a/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Emitter.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Emitter.cs
@@ -28,6 +28,20 @@ namespace ILGPU.Backends.OpenCL
         /// </summary>
         public struct StatementEmitter : IDisposable
         {
+            #region Static
+
+            /// <summary>
+            /// Indicates char tokens in a formatted floating-point literal that
+            /// do not require a ".0f" suffix.
+            /// </summary>
+            private static readonly char[] FormattedFloatLiteralTokens =
+            {
+                '.',
+                'E'
+            };
+
+            #endregion
+
             #region Instance
 
             private readonly StringBuilder stringBuilder;
@@ -456,9 +470,17 @@ namespace ILGPU.Backends.OpenCL
                 }
                 else
                 {
-                    stringBuilder.Append(
-                        value.ToString(CultureInfo.InvariantCulture));
-                    if (value % 1.0f == 0.0f)
+                    // In C#, the floating point value "1.0f" can be shortened to "1f".
+                    // However, in the C programming language, it is necessary to include
+                    // the ".0f" suffix. However, if the stringified value already
+                    // contains a decimal point, or the exponent notation, appending the
+                    // "f" suffix is sufficient.
+                    var formattedValue =
+                        value.ToString("G9", CultureInfo.InvariantCulture);
+                    stringBuilder.Append(formattedValue);
+
+                    var idx = formattedValue.IndexOfAny(FormattedFloatLiteralTokens);
+                    if (idx == -1)
                         stringBuilder.Append(".0f");
                     else
                         stringBuilder.Append('f');
@@ -486,7 +508,7 @@ namespace ILGPU.Backends.OpenCL
                 else
                 {
                     stringBuilder.Append(
-                        value.ToString(CultureInfo.InvariantCulture));
+                        value.ToString("G17", CultureInfo.InvariantCulture));
                 }
             }
 


### PR DESCRIPTION
When the constant `float.MaxValue` is appended into the source of an OpenCL kernel, it incorrectly becomes `3.40282347E+38.0f`. The check `if (value % 1.0f == 0.0f)` appears to be insufficient to detect that the scientific notation is being used.

In addition, floating point values have up to 9 digits of precision, but the `Single.ToString` method defaults to 7 digits. [The documentation](https://docs.microsoft.com/en-us/dotnet/api/system.single.tostring) recommends using the G9 format.