### PR TITLE
Check style during CI run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,17 +17,18 @@ jobs:
             Foreach ($file in Get-ChildItem -Path Src -Filter $pattern -Recurse -File) {
               If (-Not (Select-String -Path $file -Pattern "^// disable: max_line_length" -Quiet)) {
                 $index = 1
-            	  Foreach($line in Get-Content $file)
-            	  {
-            		  If ($line.Length -gt 90) {
+                Foreach ($line in Get-Content $file)
+                {
+                  If ($line.Length -gt 90) {
                     Write-Host "${file}:${index}: line too long ($($line.Length) > 90 characters)"
                     $found = $true
                   }
                   $index++
-            		}
-            	}
+                }
+              }
             }
           }
+          
           If ($found) {
             Exit 1
           }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
           $found = $false
           Foreach ($pattern in "*.cs","*.tt") {
             Foreach ($file in Get-ChildItem -Path Src -Filter $pattern -Recurse -File) {
-              If (-Not (Select-String -Path $file -Pattern "^// disable: max_line_length" -Quiet)) {
+              If (-Not (($file.Directory.Name -Eq "Resources") -Or (Select-String -Path $file -Pattern "^// disable: max_line_length" -Quiet))) {
                 $index = 1
                 Foreach ($line in Get-Content $file)
                 {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,33 @@ on:
   pull_request:
 
 jobs:
+  check-style:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Check line length
+        run: |
+          $found = $false
+          Foreach ($pattern in "*.cs","*.tt") {
+            Foreach ($file in Get-ChildItem -Path Src -Filter $pattern -Recurse -File) {
+              If (-Not (Select-String -Path $file -Pattern "^// disable: max_line_length" -Quiet)) {
+                $index = 1
+            	  Foreach($line in Get-Content $file)
+            	  {
+            		  If ($line.Length -gt 90) {
+                    Write-Host "${file}:${index}: line too long ($($line.Length) > 90 characters)"
+                    $found = $true
+                  }
+                  $index++
+            		}
+            	}
+            }
+          }
+          If ($found) {
+            Exit 1
+          }
+
   build-and-test:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     strategy:
@@ -48,7 +75,7 @@ jobs:
 
   publish-nuget:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: build-and-test
+    needs: [check-style, build-and-test]
     runs-on: windows-latest
     steps:
       - name: Download NuGet package artifact


### PR DESCRIPTION
This PR adds a CI job to check the coding style. This job runs in parallel with the other build-and-test jobs, and the publish-nuget job depends on it too.

Currently this is only checking the length of lines (< 90 characters). In the future, we might want to use [StyleCop](https://github.com/StyleCop/StyleCop) to enforce the style in the IDE and during build.