### PR TITLE
Fixed invalid debug and trace assertions.

### DIFF
--- a/Src/ILGPU.Tests/Configurations.txt
+++ b/Src/ILGPU.Tests/Configurations.txt
@@ -1,5 +1,6 @@
 ﻿ArrayViews: Debug, Release, O2
 Arrays: Debug, Release, O2
+DebugTests: Debug, Release, O2
 DisassemblerTests: Debug, Release, O2
 EnumValues: Debug, Release, O2
 KernelEntryPoints: Debug, Release, O2

--- a/Src/ILGPU.Tests/DebugTests.cs
+++ b/Src/ILGPU.Tests/DebugTests.cs
@@ -1,4 +1,7 @@
-﻿using System.Diagnostics;
+﻿// Enforce DEBUG mode in all cases to preserve Debug calls
+#define DEBUG
+
+using System.Diagnostics;
 using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
@@ -16,6 +19,7 @@ namespace ILGPU.Tests
             ArrayView<int> data)
         {
             Debug.Assert(data[index] >= 0);
+            Trace.Assert(data[index] >= 0);
         }
 
         [Theory]
@@ -37,6 +41,7 @@ namespace ILGPU.Tests
             ArrayView<int> data)
         {
             Debug.Assert(data[index] >= 0, "Invalid kernel argument");
+            Trace.Assert(data[index] >= 0, "Invalid kernel argument");
         }
 
         [Theory]
@@ -58,7 +63,10 @@ namespace ILGPU.Tests
             ArrayView<int> data)
         {
             if (data[index] < 0)
+            {
                 Debug.Fail("Invalid kernel argument < 0");
+                Trace.Fail("Invalid kernel argument < 0");
+            }
         }
 
         [Theory]

--- a/Src/ILGPU.Tests/Generic/TestContext.cs
+++ b/Src/ILGPU.Tests/Generic/TestContext.cs
@@ -24,7 +24,7 @@ namespace ILGPU.Tests
             Action<Context> prepareContext,
             Func<Context, Accelerator> createAccelerator)
         {
-            Context = new Context(level);
+            Context = new Context(ContextFlags.EnableAssertions, level);
             prepareContext?.Invoke(Context);
             Accelerator = createAccelerator(Context);
         }

--- a/Src/ILGPU/Frontend/Intrinsic/Intrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/Intrinsics.cs
@@ -208,7 +208,7 @@ namespace ILGPU.Frontend.Intrinsic
 
             return context.Method.Name switch
             {
-                nameof(Debug.Write) when context.NumArguments == 1 =>
+                nameof(Debug.Assert) when context.NumArguments == 2 =>
                     builder.CreateDebug(location, DebugKind.Trace, context[0]),
                 nameof(Debug.Fail) when context.NumArguments == 1 =>
                     builder.CreateDebug(location, DebugKind.AssertFailed, context[0]),

--- a/Src/ILGPU/Frontend/Intrinsic/RemappedIntrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/RemappedIntrinsics.cs
@@ -83,7 +83,17 @@ namespace ILGPU.Frontend.Intrinsic
             RegisterMathRemappings();
 
             // Remap debug assert
-            var debugType = typeof(Debug);
+            AddDebugRemapping(remappedType, typeof(Debug));
+            AddDebugRemapping(remappedType, typeof(Trace));
+        }
+
+        /// <summary>
+        /// Registers a new debug mapping.
+        /// </summary>
+        /// <param name="remappedType">The remapped intrinsics type.</param>
+        /// <param name="debugType">The debug type.</param>
+        private static void AddDebugRemapping(Type remappedType, Type debugType)
+        {
             AddDebugRemapping(
                 remappedType,
                 nameof(DebugAssertCondition),

--- a/Src/ILGPU/IR/ILocation.cs
+++ b/Src/ILGPU/IR/ILocation.cs
@@ -35,11 +35,6 @@ namespace ILGPU.IR
     public static class Locations
     {
         /// <summary>
-        /// The parent location data key in the scope of an exception dictionary.
-        /// </summary>
-        public const string DataKey = "Source";
-
-        /// <summary>
         /// Constructs a new exception of the given type based on the given
         /// message, the formatting arguments and the current sequence point.
         /// information.
@@ -59,10 +54,7 @@ namespace ILGPU.IR
             message = (location?.FormatErrorMessage(
                 message ?? ErrorMessages.InternalCompilerError))
                 ?? ErrorMessages.InternalCompilerError;
-            var result = Activator.CreateInstance(typeof(TException), message)
-                as TException;
-            result.Data.Add(DataKey, location);
-            return result;
+            return Activator.CreateInstance(typeof(TException), message) as TException;
         }
 
         /// <summary>


### PR DESCRIPTION
This PR fixes internal compiler errors related to `Trace.Assert` and `Debug.Assert` instructions. It also enables all `DebugOperation` tests for all platforms.