### PR TITLE
Fixed invalid intrinsic provider initialization in backend.

### DIFF
--- a/Src/ILGPU/Backends/Backend.cs
+++ b/Src/ILGPU/Backends/Backend.cs
@@ -741,9 +741,7 @@ namespace ILGPU.Backends
             BackendFlags backendFlags,
             ArgumentMapper argumentMapper)
             : base(context, backendType, backendFlags, argumentMapper)
-        {
-            IntrinsicProvider = context.IntrinsicManager.CreateProvider<TDelegate>(this);
-        }
+        { }
 
         #endregion
 
@@ -752,11 +750,24 @@ namespace ILGPU.Backends
         /// <summary>
         /// Returns the current intrinsic provider.
         /// </summary>
-        public IntrinsicImplementationProvider<TDelegate> IntrinsicProvider { get; }
+        public IntrinsicImplementationProvider<TDelegate> IntrinsicProvider
+        {
+            get;
+            private set;
+        }
 
         #endregion
 
         #region Methods
+
+        /// <summary>
+        /// Initializes the current intrinsic provider.
+        /// </summary>
+        protected void InitIntrinsicProvider()
+        {
+            IntrinsicProvider?.Dispose();
+            IntrinsicProvider = Context.IntrinsicManager.CreateProvider<TDelegate>(this);
+        }
 
         /// <summary>
         /// Initializes the associated kernel transformers.

--- a/Src/ILGPU/Backends/OpenCL/CLBackend.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLBackend.cs
@@ -68,6 +68,7 @@ namespace ILGPU.Backends.OpenCL
         {
             Vendor = vendor;
 
+            InitIntrinsicProvider();
             InitializeKernelTransformers(
                 IntrinsicSpecializerFlags.None,
                 builder =>

--- a/Src/ILGPU/Backends/PTX/PTXBackend.cs
+++ b/Src/ILGPU/Backends/PTX/PTXBackend.cs
@@ -80,6 +80,7 @@ namespace ILGPU.Backends.PTX
             Architecture = architecture;
             InstructionSet = instructionSet;
 
+            InitIntrinsicProvider();
             InitializeKernelTransformers(
                 Context.HasFlags(ContextFlags.EnableAssertions) ?
                 IntrinsicSpecializerFlags.EnableAssertions :


### PR DESCRIPTION
The current `Backend` constructor initializes the associated `IntrinsicProvider` instance in an improper way. This results in all intrinsics being mapped invalidly to the wrong implementations. 