### PR TITLE
FP16 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -251,6 +251,7 @@ Src/ILGPU/ArrayViews.cs
 Src/ILGPU/AtomicFunctions.cs
 Src/ILGPU/Backends/PTX/PTXIntrinsics.Generated.cs
 Src/ILGPU/Frontend/Intrinsic/RemappedIntrinsics.Generated.cs
+Src/ILGPU/HalfConversion.cs
 Src/ILGPU/IR/Construction/ArithmeticOperations.cs
 Src/ILGPU/IR/Construction/CompareOperations.cs
 Src/ILGPU/IR/Intrinsics/IntrinsicMatchers.cs

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ execute the Cuda test cases.
 
 # References
 
-* Parallel Thread Execution ISA 6.4
+* Parallel Thread Execution ISA 7.0
     - NVIDIA
 * A Graph-Based Higher-Order Intermediate Representation
     - Roland Leissa, Marcel Koester, and Sebastian Hack
@@ -54,6 +54,8 @@ execute the Cuda test cases.
     - Matthias Braun, Sebastian Buchwald, Sebastian Hack, Roland Leissa, Christoph Mallon and Andreas Zwinkau
 * A Simple, Fast Dominance Algorithm
     - Keith D. Cooper, Timothy J. Harvey and Ken Kennedy
+* Fast Half Float Conversions
+    - Jeroen van der Zijp
 
 # License information
 

--- a/Src/ILGPU.Tests/AtomicCASOperations.tt
+++ b/Src/ILGPU.Tests/AtomicCASOperations.tt
@@ -6,9 +6,6 @@
 using Xunit;
 using Xunit.Abstractions;
 
-<#
-var atomicTypes = AtomicNumericTypes;
-#>
 namespace ILGPU.Tests
 {
     public abstract class AtomicCASOperations : TestBase
@@ -17,7 +14,7 @@ namespace ILGPU.Tests
             : base(output, testContext)
         { }
 
-<# foreach (var type in atomicTypes) { #>
+<# foreach (var type in AtomicNumericTypes) { #>
 <#      var baseName = "_" + type.Name; #>
 <#      var casTestName = "AtomicOperationCAS" + baseName; #>
 <#      var casKernelName = "AtomicOperationKernelCAS" + baseName; #>

--- a/Src/ILGPU.Tests/AtomicOperations.tt
+++ b/Src/ILGPU.Tests/AtomicOperations.tt
@@ -8,7 +8,6 @@ using Xunit;
 using Xunit.Abstractions;
 
 <#
-var atomicTypes = AtomicNumericTypes;
 var operationConfigurations = new (string, bool)[]
     {
         ("Add",      true),
@@ -33,7 +32,7 @@ namespace ILGPU.Tests
         { }
 
 <# foreach (var (operationName, floatSupport) in operationConfigurations) { #>
-<#      foreach (var type in (floatSupport ? atomicTypes : DefaultIntTypes)) { #>
+<#      foreach (var type in (floatSupport ? AtomicNumericTypes : AtomicIntTypes)) { #>
 <#         var baseName = "_" + operationName + "_" + type.Name; #>
 <#         var testName = "AtomicOperation" + baseName; #>
 <#         var kernelName = "AtomicOperationKernel" + testName; #>

--- a/Src/ILGPU.Tests/ConvertIntOperations.tt
+++ b/Src/ILGPU.Tests/ConvertIntOperations.tt
@@ -35,9 +35,12 @@ namespace ILGPU.Tests
         }
 
         [Theory]
+<#      // Half conversions of these values is implementation specific in these cases #>
+<#      if (targetType != FloatTypes[0]) { #>
         [InlineData(<#= type.Type #>.MaxValue)]
         [InlineData(<#= type.Type #>.MinValue)]
         [InlineData(<#= type.Type #>.MinValue + 1)]
+<#      } #>
         [InlineData((<#= type.Type #>)0)]
         [InlineData((<#= type.Type #>)1)]
         [InlineData((<#= type.Type #>)31)]

--- a/Src/ILGPU/Backends/EntryPoints/ArgumentMapper.cs
+++ b/Src/ILGPU/Backends/EntryPoints/ArgumentMapper.cs
@@ -466,7 +466,7 @@ namespace ILGPU.Backends.EntryPoints
                 throw new ArgumentOutOfRangeException(nameof(type));
             }
 
-            if (type.IsPrimitive)
+            if (type.IsILGPUPrimitiveType())
                 return RegisterTypeMapping(type, type);
             else if (type.IsPointer)
                 return RegisterTypeMapping(type, typeof(void*));

--- a/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Emitter.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Emitter.cs
@@ -351,6 +351,9 @@ namespace ILGPU.Backends.OpenCL
                     case BasicValueType.Int64:
                         AppendConstant(value.UInt64Value);
                         break;
+                    case BasicValueType.Float16:
+                        AppendConstant(value.Float16Value);
+                        break;
                     case BasicValueType.Float32:
                         AppendConstant(value.Float32Value);
                         break;

--- a/Src/ILGPU/Backends/OpenCL/CLInstructions.Data.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLInstructions.Data.cs
@@ -276,6 +276,7 @@ namespace ILGPU.Backends.OpenCL
                 { ArithmeticBasicValueType.UInt32, CLUnaryCategory.Int },
                 { ArithmeticBasicValueType.UInt64, CLUnaryCategory.Int },
 
+                { ArithmeticBasicValueType.Float16, CLUnaryCategory.Float },
                 { ArithmeticBasicValueType.Float32, CLUnaryCategory.Float },
                 { ArithmeticBasicValueType.Float64, CLUnaryCategory.Float },
             };
@@ -315,7 +316,7 @@ namespace ILGPU.Backends.OpenCL
 
                 { (UnaryArithmeticKind.TanF, CLUnaryCategory.Float), ("tan", true) },
                 { (UnaryArithmeticKind.AtanF, CLUnaryCategory.Float), ("atan", true) },
-                { (UnaryArithmeticKind.AtanF, CLUnaryCategory.Float), ("tanh", true) },
+                { (UnaryArithmeticKind.TanhF, CLUnaryCategory.Float), ("tanh", true) },
 
                 { (UnaryArithmeticKind.ExpF, CLUnaryCategory.Float), ("exp", true) },
                 { (UnaryArithmeticKind.Exp2F, CLUnaryCategory.Float), ("exp2", true) },

--- a/Src/ILGPU/Backends/OpenCL/CLTypeGenerator.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLTypeGenerator.cs
@@ -70,6 +70,7 @@ namespace ILGPU.Backends.OpenCL
                 "short",
                 "int",
                 "long",
+                "half",
                 "float",
                 "double");
 
@@ -84,6 +85,7 @@ namespace ILGPU.Backends.OpenCL
                 "short",
                 "int",
                 "long",
+                "half",
                 "float",
                 "double",
                 "uchar",
@@ -102,6 +104,7 @@ namespace ILGPU.Backends.OpenCL
                 null,
                 "atomic_int",
                 "atomic_long",
+                null,
                 null,
                 null,
                 null,

--- a/Src/ILGPU/Backends/PTX/PTXCodeGenerator.cs
+++ b/Src/ILGPU/Backends/PTX/PTXCodeGenerator.cs
@@ -223,7 +223,7 @@ namespace ILGPU.Backends.PTX
             ImmutableArray.Create(
                 default, "pred",
                 "b8", "b16", "b32", "b64",
-                "f32", "f64");
+                "f16", "f32", "f64");
 
         /// <summary>
         /// Maps basic types to constant-loading target basic types.
@@ -234,7 +234,18 @@ namespace ILGPU.Backends.PTX
                 default, BasicValueType.Int1,
                 BasicValueType.Int16, BasicValueType.Int16,
                 BasicValueType.Int32, BasicValueType.Int64,
-                BasicValueType.Float32, BasicValueType.Float64);
+                BasicValueType.Int16, BasicValueType.Float32, BasicValueType.Float64);
+
+        /// <summary>
+        /// Maps basic types to constant-loading target basic types.
+        /// </summary>
+        private static readonly ImmutableArray<BasicValueType>
+            RegisterIOTypeRemapping =
+            ImmutableArray.Create(
+                default, BasicValueType.Int8,
+                BasicValueType.Int8, BasicValueType.Int16,
+                BasicValueType.Int32, BasicValueType.Int64,
+                BasicValueType.Int16, BasicValueType.Float32, BasicValueType.Float64);
 
         /// <summary>
         /// Resolves the PTX suffix for the given basic value type.
@@ -252,6 +263,15 @@ namespace ILGPU.Backends.PTX
         private static BasicValueType ResolveRegisterMovementType(
             BasicValueType basicValueType) =>
             RegisterMovementTypeRemapping[(int)basicValueType];
+
+        /// <summary>
+        /// Remaps the given basic type for global IO movement instructions.
+        /// </summary>
+        /// <param name="basicValueType">The basic value type.</param>
+        /// <returns>The remapped type.</returns>
+        private static BasicValueType ResolveIOType(
+            BasicValueType basicValueType) =>
+            RegisterIOTypeRemapping[(int)basicValueType];
 
         /// <summary>
         /// Returns a PTX compatible name for the given entity.
@@ -687,7 +707,8 @@ namespace ILGPU.Backends.PTX
                     int offset)
                 {
                     using var commandEmitter = codeGenerator.BeginCommand(command);
-                    commandEmitter.AppendSuffix(primitiveRegister.BasicValueType);
+                    commandEmitter.AppendSuffix(
+                        ResolveParameterBasicValueType(primitiveRegister.BasicValueType));
                     commandEmitter.AppendArgument(primitiveRegister);
                     commandEmitter.AppendRawValue(ParamName, offset);
                 }
@@ -755,7 +776,8 @@ namespace ILGPU.Backends.PTX
                     int offset)
                 {
                     using var commandEmitter = codeGenerator.BeginCommand(command);
-                    commandEmitter.AppendSuffix(primitiveRegister.BasicValueType);
+                    commandEmitter.AppendSuffix(
+                        ResolveParameterBasicValueType(primitiveRegister.BasicValueType));
                     commandEmitter.AppendRawValue(ParamName, offset);
                     commandEmitter.AppendArgument(primitiveRegister);
                 }

--- a/Src/ILGPU/Backends/PTX/PTXInstructions.Data.cs
+++ b/Src/ILGPU/Backends/PTX/PTXInstructions.Data.cs
@@ -145,6 +145,7 @@ namespace ILGPU.Backends.PTX
                 { BasicValueType.Int32, "selp.b32" },
                 { BasicValueType.Int64, "selp.b64" },
 
+                { BasicValueType.Float16, "selp.b16" },
                 { BasicValueType.Float32, "selp.b32" },
                 { BasicValueType.Float64, "selp.b64" },
             };
@@ -159,6 +160,7 @@ namespace ILGPU.Backends.PTX
                 { (CompareKind.Equal, ArithmeticBasicValueType.UInt16), "setp.eq.u16" },
                 { (CompareKind.Equal, ArithmeticBasicValueType.UInt32), "setp.eq.u32" },
                 { (CompareKind.Equal, ArithmeticBasicValueType.UInt64), "setp.eq.u64" },
+                { (CompareKind.Equal, ArithmeticBasicValueType.Float16), "setp.eq.f16" },
                 { (CompareKind.Equal, ArithmeticBasicValueType.Float32), "setp.eq.f32" },
                 { (CompareKind.Equal, ArithmeticBasicValueType.Float64), "setp.eq.f64" },
 
@@ -169,6 +171,7 @@ namespace ILGPU.Backends.PTX
                 { (CompareKind.NotEqual, ArithmeticBasicValueType.UInt16), "setp.ne.u16" },
                 { (CompareKind.NotEqual, ArithmeticBasicValueType.UInt32), "setp.ne.u32" },
                 { (CompareKind.NotEqual, ArithmeticBasicValueType.UInt64), "setp.ne.u64" },
+                { (CompareKind.NotEqual, ArithmeticBasicValueType.Float16), "setp.ne.f16" },
                 { (CompareKind.NotEqual, ArithmeticBasicValueType.Float32), "setp.ne.f32" },
                 { (CompareKind.NotEqual, ArithmeticBasicValueType.Float64), "setp.ne.f64" },
 
@@ -179,6 +182,7 @@ namespace ILGPU.Backends.PTX
                 { (CompareKind.LessThan, ArithmeticBasicValueType.UInt16), "setp.lo.u16" },
                 { (CompareKind.LessThan, ArithmeticBasicValueType.UInt32), "setp.lo.u32" },
                 { (CompareKind.LessThan, ArithmeticBasicValueType.UInt64), "setp.lo.u64" },
+                { (CompareKind.LessThan, ArithmeticBasicValueType.Float16), "setp.lt.f16" },
                 { (CompareKind.LessThan, ArithmeticBasicValueType.Float32), "setp.lt.f32" },
                 { (CompareKind.LessThan, ArithmeticBasicValueType.Float64), "setp.lt.f64" },
 
@@ -189,6 +193,7 @@ namespace ILGPU.Backends.PTX
                 { (CompareKind.LessEqual, ArithmeticBasicValueType.UInt16), "setp.ls.u16" },
                 { (CompareKind.LessEqual, ArithmeticBasicValueType.UInt32), "setp.ls.u32" },
                 { (CompareKind.LessEqual, ArithmeticBasicValueType.UInt64), "setp.ls.u64" },
+                { (CompareKind.LessEqual, ArithmeticBasicValueType.Float16), "setp.le.f16" },
                 { (CompareKind.LessEqual, ArithmeticBasicValueType.Float32), "setp.le.f32" },
                 { (CompareKind.LessEqual, ArithmeticBasicValueType.Float64), "setp.le.f64" },
 
@@ -199,6 +204,7 @@ namespace ILGPU.Backends.PTX
                 { (CompareKind.GreaterThan, ArithmeticBasicValueType.UInt16), "setp.hi.u16" },
                 { (CompareKind.GreaterThan, ArithmeticBasicValueType.UInt32), "setp.hi.u32" },
                 { (CompareKind.GreaterThan, ArithmeticBasicValueType.UInt64), "setp.hi.u64" },
+                { (CompareKind.GreaterThan, ArithmeticBasicValueType.Float16), "setp.gt.f16" },
                 { (CompareKind.GreaterThan, ArithmeticBasicValueType.Float32), "setp.gt.f32" },
                 { (CompareKind.GreaterThan, ArithmeticBasicValueType.Float64), "setp.gt.f64" },
 
@@ -209,6 +215,7 @@ namespace ILGPU.Backends.PTX
                 { (CompareKind.GreaterEqual, ArithmeticBasicValueType.UInt16), "setp.hs.u16" },
                 { (CompareKind.GreaterEqual, ArithmeticBasicValueType.UInt32), "setp.hs.u32" },
                 { (CompareKind.GreaterEqual, ArithmeticBasicValueType.UInt64), "setp.hs.u64" },
+                { (CompareKind.GreaterEqual, ArithmeticBasicValueType.Float16), "setp.ge.f16" },
                 { (CompareKind.GreaterEqual, ArithmeticBasicValueType.Float32), "setp.ge.f32" },
                 { (CompareKind.GreaterEqual, ArithmeticBasicValueType.Float64), "setp.ge.f64" },
             };
@@ -216,21 +223,27 @@ namespace ILGPU.Backends.PTX
         private static readonly Dictionary<(CompareKind, ArithmeticBasicValueType), string> CompareUnorderedFloatOperations =
             new Dictionary<(CompareKind, ArithmeticBasicValueType), string>()
             {
+                { (CompareKind.Equal, ArithmeticBasicValueType.Float16), "setp.equ.f16" },
                 { (CompareKind.Equal, ArithmeticBasicValueType.Float32), "setp.equ.f32" },
                 { (CompareKind.Equal, ArithmeticBasicValueType.Float64), "setp.equ.f64" },
 
+                { (CompareKind.NotEqual, ArithmeticBasicValueType.Float16), "setp.neu.f16" },
                 { (CompareKind.NotEqual, ArithmeticBasicValueType.Float32), "setp.neu.f32" },
                 { (CompareKind.NotEqual, ArithmeticBasicValueType.Float64), "setp.neu.f64" },
 
+                { (CompareKind.LessThan, ArithmeticBasicValueType.Float16), "setp.ltu.f16" },
                 { (CompareKind.LessThan, ArithmeticBasicValueType.Float32), "setp.ltu.f32" },
                 { (CompareKind.LessThan, ArithmeticBasicValueType.Float64), "setp.ltu.f64" },
 
+                { (CompareKind.LessEqual, ArithmeticBasicValueType.Float16), "setp.leu.f16" },
                 { (CompareKind.LessEqual, ArithmeticBasicValueType.Float32), "setp.leu.f32" },
                 { (CompareKind.LessEqual, ArithmeticBasicValueType.Float64), "setp.leu.f64" },
 
+                { (CompareKind.GreaterThan, ArithmeticBasicValueType.Float16), "setp.gtu.f16" },
                 { (CompareKind.GreaterThan, ArithmeticBasicValueType.Float32), "setp.gtu.f32" },
                 { (CompareKind.GreaterThan, ArithmeticBasicValueType.Float64), "setp.gtu.f64" },
 
+                { (CompareKind.GreaterEqual, ArithmeticBasicValueType.Float16), "setp.geu.f16" },
                 { (CompareKind.GreaterEqual, ArithmeticBasicValueType.Float32), "setp.geu.f32" },
                 { (CompareKind.GreaterEqual, ArithmeticBasicValueType.Float64), "setp.geu.f64" },
             };
@@ -245,6 +258,7 @@ namespace ILGPU.Backends.PTX
                 { (ArithmeticBasicValueType.Int8, ArithmeticBasicValueType.UInt16), "cvt.u16.s8" },
                 { (ArithmeticBasicValueType.Int8, ArithmeticBasicValueType.UInt32), "cvt.u32.s8" },
                 { (ArithmeticBasicValueType.Int8, ArithmeticBasicValueType.UInt64), "cvt.u64.s8" },
+                { (ArithmeticBasicValueType.Int8, ArithmeticBasicValueType.Float16), "cvt.rn.f16.s8" },
                 { (ArithmeticBasicValueType.Int8, ArithmeticBasicValueType.Float32), "cvt.rn.f32.s8" },
                 { (ArithmeticBasicValueType.Int8, ArithmeticBasicValueType.Float64), "cvt.rn.f64.s8" },
 
@@ -255,6 +269,7 @@ namespace ILGPU.Backends.PTX
                 { (ArithmeticBasicValueType.Int16, ArithmeticBasicValueType.UInt16), "cvt.u16.s16" },
                 { (ArithmeticBasicValueType.Int16, ArithmeticBasicValueType.UInt32), "cvt.u32.s16" },
                 { (ArithmeticBasicValueType.Int16, ArithmeticBasicValueType.UInt64), "cvt.u64.s16" },
+                { (ArithmeticBasicValueType.Int16, ArithmeticBasicValueType.Float16), "cvt.rn.f16.s16" },
                 { (ArithmeticBasicValueType.Int16, ArithmeticBasicValueType.Float32), "cvt.rn.f32.s16" },
                 { (ArithmeticBasicValueType.Int16, ArithmeticBasicValueType.Float64), "cvt.rn.f64.s16" },
 
@@ -265,6 +280,7 @@ namespace ILGPU.Backends.PTX
                 { (ArithmeticBasicValueType.Int32, ArithmeticBasicValueType.UInt16), "cvt.u16.s32" },
                 { (ArithmeticBasicValueType.Int32, ArithmeticBasicValueType.UInt32), "cvt.u32.s32" },
                 { (ArithmeticBasicValueType.Int32, ArithmeticBasicValueType.UInt64), "cvt.u64.s32" },
+                { (ArithmeticBasicValueType.Int32, ArithmeticBasicValueType.Float16), "cvt.rn.f16.s32" },
                 { (ArithmeticBasicValueType.Int32, ArithmeticBasicValueType.Float32), "cvt.rn.f32.s32" },
                 { (ArithmeticBasicValueType.Int32, ArithmeticBasicValueType.Float64), "cvt.rn.f64.s32" },
 
@@ -275,6 +291,7 @@ namespace ILGPU.Backends.PTX
                 { (ArithmeticBasicValueType.Int64, ArithmeticBasicValueType.UInt16), "cvt.u16.s64" },
                 { (ArithmeticBasicValueType.Int64, ArithmeticBasicValueType.UInt32), "cvt.u32.s64" },
                 { (ArithmeticBasicValueType.Int64, ArithmeticBasicValueType.UInt64), "cvt.u64.s64" },
+                { (ArithmeticBasicValueType.Int64, ArithmeticBasicValueType.Float16), "cvt.rn.f16.s64" },
                 { (ArithmeticBasicValueType.Int64, ArithmeticBasicValueType.Float32), "cvt.rn.f32.s64" },
                 { (ArithmeticBasicValueType.Int64, ArithmeticBasicValueType.Float64), "cvt.rn.f64.s64" },
 
@@ -285,6 +302,7 @@ namespace ILGPU.Backends.PTX
                 { (ArithmeticBasicValueType.UInt8, ArithmeticBasicValueType.UInt16), "cvt.u16.u8" },
                 { (ArithmeticBasicValueType.UInt8, ArithmeticBasicValueType.UInt32), "cvt.u32.u8" },
                 { (ArithmeticBasicValueType.UInt8, ArithmeticBasicValueType.UInt64), "cvt.u64.u8" },
+                { (ArithmeticBasicValueType.UInt8, ArithmeticBasicValueType.Float16), "cvt.rn.f16.u8" },
                 { (ArithmeticBasicValueType.UInt8, ArithmeticBasicValueType.Float32), "cvt.rn.f32.u8" },
                 { (ArithmeticBasicValueType.UInt8, ArithmeticBasicValueType.Float64), "cvt.rn.f64.u8" },
 
@@ -295,6 +313,7 @@ namespace ILGPU.Backends.PTX
                 { (ArithmeticBasicValueType.UInt16, ArithmeticBasicValueType.UInt8), "cvt.u8.u16" },
                 { (ArithmeticBasicValueType.UInt16, ArithmeticBasicValueType.UInt32), "cvt.u32.u16" },
                 { (ArithmeticBasicValueType.UInt16, ArithmeticBasicValueType.UInt64), "cvt.u64.u16" },
+                { (ArithmeticBasicValueType.UInt16, ArithmeticBasicValueType.Float16), "cvt.rn.f16.u16" },
                 { (ArithmeticBasicValueType.UInt16, ArithmeticBasicValueType.Float32), "cvt.rn.f32.u16" },
                 { (ArithmeticBasicValueType.UInt16, ArithmeticBasicValueType.Float64), "cvt.rn.f64.u16" },
 
@@ -305,6 +324,7 @@ namespace ILGPU.Backends.PTX
                 { (ArithmeticBasicValueType.UInt32, ArithmeticBasicValueType.UInt8), "cvt.u8.u32" },
                 { (ArithmeticBasicValueType.UInt32, ArithmeticBasicValueType.UInt16), "cvt.u16.u32" },
                 { (ArithmeticBasicValueType.UInt32, ArithmeticBasicValueType.UInt64), "cvt.u64.u32" },
+                { (ArithmeticBasicValueType.UInt32, ArithmeticBasicValueType.Float16), "cvt.rn.f16.u32" },
                 { (ArithmeticBasicValueType.UInt32, ArithmeticBasicValueType.Float32), "cvt.rn.f32.u32" },
                 { (ArithmeticBasicValueType.UInt32, ArithmeticBasicValueType.Float64), "cvt.rn.f64.u32" },
 
@@ -315,8 +335,20 @@ namespace ILGPU.Backends.PTX
                 { (ArithmeticBasicValueType.UInt64, ArithmeticBasicValueType.UInt8), "cvt.u8.u64" },
                 { (ArithmeticBasicValueType.UInt64, ArithmeticBasicValueType.UInt16), "cvt.u16.u64" },
                 { (ArithmeticBasicValueType.UInt64, ArithmeticBasicValueType.UInt32), "cvt.u32.u64" },
+                { (ArithmeticBasicValueType.UInt64, ArithmeticBasicValueType.Float16), "cvt.rn.f16.u64" },
                 { (ArithmeticBasicValueType.UInt64, ArithmeticBasicValueType.Float32), "cvt.rn.f32.u64" },
                 { (ArithmeticBasicValueType.UInt64, ArithmeticBasicValueType.Float64), "cvt.rn.f64.u64" },
+
+                { (ArithmeticBasicValueType.Float16, ArithmeticBasicValueType.Int8), "cvt.rzi.s8.f16" },
+                { (ArithmeticBasicValueType.Float16, ArithmeticBasicValueType.Int16), "cvt.rzi.s16.f16" },
+                { (ArithmeticBasicValueType.Float16, ArithmeticBasicValueType.Int32), "cvt.rzi.s32.f16" },
+                { (ArithmeticBasicValueType.Float16, ArithmeticBasicValueType.Int64), "cvt.rzi.s64.f16" },
+                { (ArithmeticBasicValueType.Float16, ArithmeticBasicValueType.UInt8), "cvt.rzi.u8.f16" },
+                { (ArithmeticBasicValueType.Float16, ArithmeticBasicValueType.UInt16), "cvt.rzi.u16.f16" },
+                { (ArithmeticBasicValueType.Float16, ArithmeticBasicValueType.UInt32), "cvt.rzi.u32.f16" },
+                { (ArithmeticBasicValueType.Float16, ArithmeticBasicValueType.UInt64), "cvt.rzi.u64.f16" },
+                { (ArithmeticBasicValueType.Float16, ArithmeticBasicValueType.Float32), "cvt.f32.f16" },
+                { (ArithmeticBasicValueType.Float16, ArithmeticBasicValueType.Float64), "cvt.f64.f16" },
 
                 { (ArithmeticBasicValueType.Float32, ArithmeticBasicValueType.Int8), "cvt.rzi.s8.f32" },
                 { (ArithmeticBasicValueType.Float32, ArithmeticBasicValueType.Int16), "cvt.rzi.s16.f32" },
@@ -326,6 +358,7 @@ namespace ILGPU.Backends.PTX
                 { (ArithmeticBasicValueType.Float32, ArithmeticBasicValueType.UInt16), "cvt.rzi.u16.f32" },
                 { (ArithmeticBasicValueType.Float32, ArithmeticBasicValueType.UInt32), "cvt.rzi.u32.f32" },
                 { (ArithmeticBasicValueType.Float32, ArithmeticBasicValueType.UInt64), "cvt.rzi.u64.f32" },
+                { (ArithmeticBasicValueType.Float32, ArithmeticBasicValueType.Float16), "cvt.rn.f16.f32" },
                 { (ArithmeticBasicValueType.Float32, ArithmeticBasicValueType.Float64), "cvt.f64.f32" },
 
                 { (ArithmeticBasicValueType.Float64, ArithmeticBasicValueType.Int8), "cvt.rzi.s8.f64" },
@@ -336,6 +369,7 @@ namespace ILGPU.Backends.PTX
                 { (ArithmeticBasicValueType.Float64, ArithmeticBasicValueType.UInt16), "cvt.rzi.u16.f64" },
                 { (ArithmeticBasicValueType.Float64, ArithmeticBasicValueType.UInt32), "cvt.rzi.u32.f64" },
                 { (ArithmeticBasicValueType.Float64, ArithmeticBasicValueType.UInt64), "cvt.rzi.u64.f64" },
+                { (ArithmeticBasicValueType.Float64, ArithmeticBasicValueType.Float16), "cvt.rn.f16.f64" },
                 { (ArithmeticBasicValueType.Float64, ArithmeticBasicValueType.Float32), "cvt.rn.f32.f64" },
             };
 
@@ -348,6 +382,7 @@ namespace ILGPU.Backends.PTX
                 { (UnaryArithmeticKind.Neg, ArithmeticBasicValueType.Int16), "neg.s16" },
                 { (UnaryArithmeticKind.Neg, ArithmeticBasicValueType.Int32), "neg.s32" },
                 { (UnaryArithmeticKind.Neg, ArithmeticBasicValueType.Int64), "neg.s64" },
+                { (UnaryArithmeticKind.Neg, ArithmeticBasicValueType.Float16), "neg.f16" },
                 { (UnaryArithmeticKind.Neg, ArithmeticBasicValueType.Float32), "neg.f32" },
                 { (UnaryArithmeticKind.Neg, ArithmeticBasicValueType.Float64), "neg.f64" },
 
@@ -359,6 +394,7 @@ namespace ILGPU.Backends.PTX
                 { (UnaryArithmeticKind.Not, ArithmeticBasicValueType.UInt16), "not.b16" },
                 { (UnaryArithmeticKind.Not, ArithmeticBasicValueType.UInt32), "not.b32" },
                 { (UnaryArithmeticKind.Not, ArithmeticBasicValueType.UInt64), "not.b64" },
+                { (UnaryArithmeticKind.Not, ArithmeticBasicValueType.Float16), "not.b16" },
                 { (UnaryArithmeticKind.Not, ArithmeticBasicValueType.Float32), "not.b32" },
                 { (UnaryArithmeticKind.Not, ArithmeticBasicValueType.Float64), "not.b64" },
 
@@ -368,6 +404,7 @@ namespace ILGPU.Backends.PTX
                 { (UnaryArithmeticKind.Abs, ArithmeticBasicValueType.Int16), "abs.s16" },
                 { (UnaryArithmeticKind.Abs, ArithmeticBasicValueType.Int32), "abs.s32" },
                 { (UnaryArithmeticKind.Abs, ArithmeticBasicValueType.Int64), "abs.s64" },
+                { (UnaryArithmeticKind.Abs, ArithmeticBasicValueType.Float16), "abs.f16" },
                 { (UnaryArithmeticKind.Abs, ArithmeticBasicValueType.Float32), "abs.f32" },
                 { (UnaryArithmeticKind.Abs, ArithmeticBasicValueType.Float64), "abs.f64" },
 
@@ -389,7 +426,12 @@ namespace ILGPU.Backends.PTX
                 { (UnaryArithmeticKind.SinF, ArithmeticBasicValueType.Float32), "sin.approx.f32" },
                 { (UnaryArithmeticKind.CosF, ArithmeticBasicValueType.Float32), "cos.approx.f32" },
 
+                { (UnaryArithmeticKind.TanhF, ArithmeticBasicValueType.Float16), "tanh.approx.f16" },
+                { (UnaryArithmeticKind.TanhF, ArithmeticBasicValueType.Float32), "tanh.approx.f32" },
+
                 { (UnaryArithmeticKind.Log2F, ArithmeticBasicValueType.Float32), "lg2.approx.f32" },
+
+                { (UnaryArithmeticKind.Exp2F, ArithmeticBasicValueType.Float16), "ex2.approx.f16" },
                 { (UnaryArithmeticKind.Exp2F, ArithmeticBasicValueType.Float32), "ex2.approx.f32" },
 
                 { (UnaryArithmeticKind.FloorF, ArithmeticBasicValueType.Float32), "cvt.rmi.f32.f32" },
@@ -429,6 +471,7 @@ namespace ILGPU.Backends.PTX
                 { (BinaryArithmeticKind.Add, ArithmeticBasicValueType.UInt16), "add.u16" },
                 { (BinaryArithmeticKind.Add, ArithmeticBasicValueType.UInt32), "add.u32" },
                 { (BinaryArithmeticKind.Add, ArithmeticBasicValueType.UInt64), "add.u64" },
+                { (BinaryArithmeticKind.Add, ArithmeticBasicValueType.Float16), "add.f16" },
                 { (BinaryArithmeticKind.Add, ArithmeticBasicValueType.Float32), "add.f32" },
                 { (BinaryArithmeticKind.Add, ArithmeticBasicValueType.Float64), "add.f64" },
 
@@ -439,6 +482,7 @@ namespace ILGPU.Backends.PTX
                 { (BinaryArithmeticKind.Sub, ArithmeticBasicValueType.UInt16), "sub.u16" },
                 { (BinaryArithmeticKind.Sub, ArithmeticBasicValueType.UInt32), "sub.u32" },
                 { (BinaryArithmeticKind.Sub, ArithmeticBasicValueType.UInt64), "sub.u64" },
+                { (BinaryArithmeticKind.Sub, ArithmeticBasicValueType.Float16), "sub.f16" },
                 { (BinaryArithmeticKind.Sub, ArithmeticBasicValueType.Float32), "sub.f32" },
                 { (BinaryArithmeticKind.Sub, ArithmeticBasicValueType.Float64), "sub.f64" },
 
@@ -449,6 +493,7 @@ namespace ILGPU.Backends.PTX
                 { (BinaryArithmeticKind.Mul, ArithmeticBasicValueType.UInt16), "mul.lo.u16" },
                 { (BinaryArithmeticKind.Mul, ArithmeticBasicValueType.UInt32), "mul.lo.u32" },
                 { (BinaryArithmeticKind.Mul, ArithmeticBasicValueType.UInt64), "mul.lo.u64" },
+                { (BinaryArithmeticKind.Mul, ArithmeticBasicValueType.Float16), "mul.f16" },
                 { (BinaryArithmeticKind.Mul, ArithmeticBasicValueType.Float32), "mul.f32" },
                 { (BinaryArithmeticKind.Mul, ArithmeticBasicValueType.Float64), "mul.f64" },
 
@@ -480,6 +525,7 @@ namespace ILGPU.Backends.PTX
                 { (BinaryArithmeticKind.And, ArithmeticBasicValueType.UInt16), "and.b16" },
                 { (BinaryArithmeticKind.And, ArithmeticBasicValueType.UInt32), "and.b32" },
                 { (BinaryArithmeticKind.And, ArithmeticBasicValueType.UInt64), "and.b64" },
+                { (BinaryArithmeticKind.And, ArithmeticBasicValueType.Float16), "and.b16" },
                 { (BinaryArithmeticKind.And, ArithmeticBasicValueType.Float32), "and.b32" },
                 { (BinaryArithmeticKind.And, ArithmeticBasicValueType.Float64), "and.b64" },
 
@@ -491,6 +537,7 @@ namespace ILGPU.Backends.PTX
                 { (BinaryArithmeticKind.Or, ArithmeticBasicValueType.UInt16), "or.b16" },
                 { (BinaryArithmeticKind.Or, ArithmeticBasicValueType.UInt32), "or.b32" },
                 { (BinaryArithmeticKind.Or, ArithmeticBasicValueType.UInt64), "or.b64" },
+                { (BinaryArithmeticKind.Or, ArithmeticBasicValueType.Float16), "or.b16" },
                 { (BinaryArithmeticKind.Or, ArithmeticBasicValueType.Float32), "or.b32" },
                 { (BinaryArithmeticKind.Or, ArithmeticBasicValueType.Float64), "or.b64" },
 
@@ -502,6 +549,7 @@ namespace ILGPU.Backends.PTX
                 { (BinaryArithmeticKind.Xor, ArithmeticBasicValueType.UInt16), "xor.b16" },
                 { (BinaryArithmeticKind.Xor, ArithmeticBasicValueType.UInt32), "xor.b32" },
                 { (BinaryArithmeticKind.Xor, ArithmeticBasicValueType.UInt64), "xor.b64" },
+                { (BinaryArithmeticKind.Xor, ArithmeticBasicValueType.Float16), "xor.b16" },
                 { (BinaryArithmeticKind.Xor, ArithmeticBasicValueType.Float32), "xor.b32" },
                 { (BinaryArithmeticKind.Xor, ArithmeticBasicValueType.Float64), "xor.b64" },
 
@@ -512,6 +560,7 @@ namespace ILGPU.Backends.PTX
                 { (BinaryArithmeticKind.Shl, ArithmeticBasicValueType.UInt16), "shl.b16" },
                 { (BinaryArithmeticKind.Shl, ArithmeticBasicValueType.UInt32), "shl.b32" },
                 { (BinaryArithmeticKind.Shl, ArithmeticBasicValueType.UInt64), "shl.b64" },
+                { (BinaryArithmeticKind.Shl, ArithmeticBasicValueType.Float16), "shl.b16" },
                 { (BinaryArithmeticKind.Shl, ArithmeticBasicValueType.Float32), "shl.b32" },
                 { (BinaryArithmeticKind.Shl, ArithmeticBasicValueType.Float64), "shl.b64" },
 
@@ -521,6 +570,7 @@ namespace ILGPU.Backends.PTX
                 { (BinaryArithmeticKind.Shr, ArithmeticBasicValueType.UInt16), "shr.u16" },
                 { (BinaryArithmeticKind.Shr, ArithmeticBasicValueType.UInt32), "shr.u32" },
                 { (BinaryArithmeticKind.Shr, ArithmeticBasicValueType.UInt64), "shr.u64" },
+                { (BinaryArithmeticKind.Shr, ArithmeticBasicValueType.Float16), "shr.b16" },
                 { (BinaryArithmeticKind.Shr, ArithmeticBasicValueType.Float32), "shr.b32" },
                 { (BinaryArithmeticKind.Shr, ArithmeticBasicValueType.Float64), "shr.b64" },
 
@@ -533,6 +583,7 @@ namespace ILGPU.Backends.PTX
                 { (BinaryArithmeticKind.Max, ArithmeticBasicValueType.UInt16), "max.u16" },
                 { (BinaryArithmeticKind.Max, ArithmeticBasicValueType.UInt32), "max.u32" },
                 { (BinaryArithmeticKind.Max, ArithmeticBasicValueType.UInt64), "max.u64" },
+                { (BinaryArithmeticKind.Max, ArithmeticBasicValueType.Float16), "max.f16" },
                 { (BinaryArithmeticKind.Max, ArithmeticBasicValueType.Float32), "max.f32" },
                 { (BinaryArithmeticKind.Max, ArithmeticBasicValueType.Float64), "max.f64" },
 
@@ -543,6 +594,7 @@ namespace ILGPU.Backends.PTX
                 { (BinaryArithmeticKind.Min, ArithmeticBasicValueType.UInt16), "min.u16" },
                 { (BinaryArithmeticKind.Min, ArithmeticBasicValueType.UInt32), "min.u32" },
                 { (BinaryArithmeticKind.Min, ArithmeticBasicValueType.UInt64), "min.u64" },
+                { (BinaryArithmeticKind.Min, ArithmeticBasicValueType.Float16), "min.f16" },
                 { (BinaryArithmeticKind.Min, ArithmeticBasicValueType.Float32), "min.f32" },
                 { (BinaryArithmeticKind.Min, ArithmeticBasicValueType.Float64), "min.f64" },
             };
@@ -552,14 +604,23 @@ namespace ILGPU.Backends.PTX
             {
                 // Basic arithmetic
                 
+                { (BinaryArithmeticKind.Add, ArithmeticBasicValueType.Float16), "add.ftz.f16" },
                 { (BinaryArithmeticKind.Add, ArithmeticBasicValueType.Float32), "add.ftz.f32" },
+
+                { (BinaryArithmeticKind.Sub, ArithmeticBasicValueType.Float16), "sub.ftz.f16" },
                 { (BinaryArithmeticKind.Sub, ArithmeticBasicValueType.Float32), "sub.ftz.f32" },
+
+                { (BinaryArithmeticKind.Mul, ArithmeticBasicValueType.Float16), "mul.ftz.f16" },
                 { (BinaryArithmeticKind.Mul, ArithmeticBasicValueType.Float32), "mul.ftz.f32" },
+
                 { (BinaryArithmeticKind.Div, ArithmeticBasicValueType.Float32), "div.approx.ftz.f32" },
 
                 // Functions
 
+                { (BinaryArithmeticKind.Max, ArithmeticBasicValueType.Float16), "max.ftz.f16" },
                 { (BinaryArithmeticKind.Max, ArithmeticBasicValueType.Float32), "max.ftz.f32" },
+
+                { (BinaryArithmeticKind.Min, ArithmeticBasicValueType.Float16), "min.ftz.f16" },
                 { (BinaryArithmeticKind.Min, ArithmeticBasicValueType.Float32), "min.ftz.f32" },
             };
 
@@ -576,6 +637,7 @@ namespace ILGPU.Backends.PTX
                 { (TernaryArithmeticKind.MultiplyAdd, ArithmeticBasicValueType.UInt32), "mad.lo.u32" },
                 { (TernaryArithmeticKind.MultiplyAdd, ArithmeticBasicValueType.UInt64), "mad.lo.u64" },
 
+                { (TernaryArithmeticKind.MultiplyAdd, ArithmeticBasicValueType.Float16), "fma.rn.f16" },
                 { (TernaryArithmeticKind.MultiplyAdd, ArithmeticBasicValueType.Float32), "fma.rn.f32" },
                 { (TernaryArithmeticKind.MultiplyAdd, ArithmeticBasicValueType.Float64), "fma.rn.f64" },
             };
@@ -613,6 +675,7 @@ namespace ILGPU.Backends.PTX
                 { (AtomicKind.Add, ArithmeticBasicValueType.Int64), "u64" },
                 { (AtomicKind.Add, ArithmeticBasicValueType.UInt32), "u32" },
                 { (AtomicKind.Add, ArithmeticBasicValueType.UInt64), "u64" },
+                { (AtomicKind.Add, ArithmeticBasicValueType.Float16), "f16" },
                 { (AtomicKind.Add, ArithmeticBasicValueType.Float32), "f32" },
                 { (AtomicKind.Add, ArithmeticBasicValueType.Float64), "f64" },
 

--- a/Src/ILGPU/Backends/PTX/PTXIntrinsics.Generated.tt
+++ b/Src/ILGPU/Backends/PTX/PTXIntrinsics.Generated.tt
@@ -15,6 +15,26 @@
 <#@ import namespace="System.Linq" #>
 <#@ import namespace="System.Text" #>
 <#@ import namespace="System.Collections.Generic" #>
+<#
+var fp16Ops = new (string, string, string, string)[]
+{
+    ("Unary", "Neg", "Neg", "SM_53"),
+    ("Unary", "Abs", "Abs", "SM_53"),
+    ("Unary", "IsInfF", "IsInfinity", null),
+    ("Unary", "IsNaNF", "IsNaN", null),
+    ("Unary", "Exp2F", "Exp2FP32", "SM_72"),
+    ("Unary", "TanhF", "TanhFP32", "SM_72"),
+
+    ("Binary", "Add", "AddFP32", "SM_53"),
+    ("Binary", "Sub", "SubFP32", "SM_53"),
+    ("Binary", "Mul", "MulFP32", "SM_53"),
+    ("Binary", "Div", "DivFP32", null),
+    ("Binary", "Min", "MinFP32", "SM_75"),
+    ("Binary", "Max", "MaxFP32", "SM_75"),
+
+    ("Ternary", "MultiplyAdd", "FmaFP32", "SM_53"),
+};
+#>
 using ILGPU.IR.Intrinsics;
 using ILGPU.IR.Values;
 using System.Runtime.CompilerServices;
@@ -113,6 +133,26 @@ namespace ILGPU.Backends.PTX
         }
 
 <# } #>
+
+        #endregion
+
+        #region FP16
+
+        /// <summary>
+        /// Registers all FP16 intrinsics with the given manager.
+        /// </summary>
+        /// <param name="manager">The target implementation manager.</param>
+        private static void RegisterFP16(IntrinsicImplementationManager manager)
+        {
+<# foreach (var (type, kind, name, sm) in fp16Ops) { #>
+            manager.Register<#= type #>Arithmetic(
+                <#= type #>ArithmeticKind.<#= kind #>,
+                BasicValueType.Float16,
+                CreateFP16Intrinsic(
+                    nameof(HalfExtensions.<#= name #>),
+                    <#= sm != null ? $"PTXArchitecture.{sm}" : "null" #>));
+<# } #>
+        }
 
         #endregion
     }

--- a/Src/ILGPU/Backends/PTX/PTXRegisterAllocator.cs
+++ b/Src/ILGPU/Backends/PTX/PTXRegisterAllocator.cs
@@ -99,7 +99,7 @@ namespace ILGPU.Backends.PTX
                 default, PTXRegisterKind.Predicate,
                 PTXRegisterKind.Int16, PTXRegisterKind.Int16,
                 PTXRegisterKind.Int32, PTXRegisterKind.Int64,
-                PTXRegisterKind.Float32, PTXRegisterKind.Float64);
+                PTXRegisterKind.Int16, PTXRegisterKind.Float32, PTXRegisterKind.Float64);
 
         /// <summary>
         /// Maps basic value types to their PTX-specific parameter-type counterparts.
@@ -109,7 +109,7 @@ namespace ILGPU.Backends.PTX
                 default, BasicValueType.Int32,
                 BasicValueType.Int8, BasicValueType.Int16,
                 BasicValueType.Int32, BasicValueType.Int64,
-                BasicValueType.Float32, BasicValueType.Float64);
+                BasicValueType.Int16, BasicValueType.Float32, BasicValueType.Float64);
 
         /// <summary>
         /// Declares all register kinds for which register declarations have to be

--- a/Src/ILGPU/BasicValueType.cs
+++ b/Src/ILGPU/BasicValueType.cs
@@ -47,6 +47,11 @@ namespace ILGPU
         Int64,
 
         /// <summary>
+        /// Represents a 16-bit float.
+        /// </summary>
+        Float16,
+
+        /// <summary>
         /// Represents a 32-bit float.
         /// </summary>
         Float32,
@@ -91,6 +96,11 @@ namespace ILGPU
         /// Represents a 64-bit integer.
         /// </summary>
         Int64,
+
+        /// <summary>
+        /// Represents a 16-bit float.
+        /// </summary>
+        Float16,
 
         /// <summary>
         /// Represents a 32-bit float.

--- a/Src/ILGPU/Frontend/Intrinsic/CompareIntrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/CompareIntrinsics.cs
@@ -1,0 +1,64 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                        Copyright (c) 2016-2020 Marcel Koester
+//                                    www.ilgpu.net
+//
+// File: CompareIntrinsics.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+
+using ILGPU.IR.Values;
+using System;
+
+namespace ILGPU.Frontend.Intrinsic
+{
+    /// <summary>
+    /// Marks compare intrinsics that are built in.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    sealed class CompareIntriniscAttribute : IntrinsicAttribute
+    {
+        public CompareIntriniscAttribute(CompareKind kind)
+            : this(kind, CompareFlags.None)
+        { }
+
+        public CompareIntriniscAttribute(CompareKind kind, CompareFlags flags)
+        {
+            IntrinsicKind = kind;
+            IntrinsicFlags = flags;
+        }
+
+        public override IntrinsicType Type => IntrinsicType.Compare;
+
+        /// <summary>
+        /// Returns the associated intrinsic kind.
+        /// </summary>
+        public CompareKind IntrinsicKind { get; }
+
+        /// <summary>
+        /// Returns the associated intrinsic flags.
+        /// </summary>
+        public CompareFlags IntrinsicFlags { get; }
+    }
+
+    partial class Intrinsics
+    {
+        /// <summary>
+        /// Handles compare operations.
+        /// </summary>
+        /// <param name="context">The current invocation context.</param>
+        /// <param name="attribute">The intrinsic attribute.</param>
+        /// <returns>The resulting value.</returns>
+        private static ValueReference HandleCompareOperation(
+            ref InvocationContext context,
+            CompareIntriniscAttribute attribute) =>
+            context.Builder.CreateCompare(
+                context.Location,
+                context[0],
+                context[1],
+                attribute.IntrinsicKind,
+                attribute.IntrinsicFlags);
+    }
+}

--- a/Src/ILGPU/Frontend/Intrinsic/ConvertIntrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/ConvertIntrinsics.cs
@@ -1,0 +1,62 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                        Copyright (c) 2016-2020 Marcel Koester
+//                                    www.ilgpu.net
+//
+// File: ConvertIntrinsics.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+
+using ILGPU.IR.Values;
+using ILGPU.Util;
+using System;
+
+namespace ILGPU.Frontend.Intrinsic
+{
+    /// <summary>
+    /// Marks compare intrinsics that are built in.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    sealed class ConvertIntriniscAttribute : IntrinsicAttribute
+    {
+        public ConvertIntriniscAttribute()
+            : this(ConvertFlags.None)
+        { }
+
+        public ConvertIntriniscAttribute(ConvertFlags flags)
+        {
+            IntrinsicFlags = flags;
+        }
+
+        public override IntrinsicType Type => IntrinsicType.Convert;
+
+        /// <summary>
+        /// Returns the associated intrinsic flags.
+        /// </summary>
+        public ConvertFlags IntrinsicFlags { get; }
+    }
+
+    partial class Intrinsics
+    {
+        /// <summary>
+        /// Handles convert operations.
+        /// </summary>
+        /// <param name="context">The current invocation context.</param>
+        /// <param name="attribute">The intrinsic attribute.</param>
+        /// <returns>The resulting value.</returns>
+        private static ValueReference HandleConvertOperation(
+            ref InvocationContext context,
+            ConvertIntriniscAttribute attribute)
+        {
+            var returnType = context.Method.GetReturnType();
+            var typeNode = context.Builder.CreateType(returnType);
+            return context.Builder.CreateConvert(
+                context.Location,
+                context[0],
+                typeNode,
+                attribute.IntrinsicFlags);
+        }
+    }
+}

--- a/Src/ILGPU/Frontend/Intrinsic/Intrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/Intrinsics.cs
@@ -28,6 +28,8 @@ namespace ILGPU.Frontend.Intrinsic
     {
         Accelerator,
         Atomic,
+        Compare,
+        Convert,
         Grid,
         Group,
         Interop,
@@ -92,6 +94,12 @@ namespace ILGPU.Frontend.Intrinsic
             (ref InvocationContext context, IntrinsicAttribute attribute) =>
                 HandleAtomicOperation(
                     ref context, attribute as AtomicIntrinsicAttribute),
+            (ref InvocationContext context, IntrinsicAttribute attribute) =>
+                HandleCompareOperation(
+                    ref context, attribute as CompareIntriniscAttribute),
+            (ref InvocationContext context, IntrinsicAttribute attribute) =>
+                HandleConvertOperation(
+                    ref context, attribute as ConvertIntriniscAttribute),
             (ref InvocationContext context, IntrinsicAttribute attribute) =>
                 HandleGridOperation(
                     ref context, attribute as GridIntrinsicAttribute),

--- a/Src/ILGPU/Frontend/Intrinsic/RemappedIntrinsics.Generated.tt
+++ b/Src/ILGPU/Frontend/Intrinsic/RemappedIntrinsics.Generated.tt
@@ -22,23 +22,23 @@ var unaryMathFunctions = new (string, TypeInformation, TypeInformation, string)[
         ("Abs",     null,          SignedIntTypes[1], "MathType"),
         ("Abs",     null,          SignedIntTypes[2], "MathType"),
         ("Abs",     null,          SignedIntTypes[3], "MathType"),
-        ("Abs",     FloatTypes[0], FloatTypes[0],     "MathType"),
-        ("Abs",     null,          FloatTypes[1],     "MathType"),
-        ("Sqrt",    FloatTypes[0], FloatTypes[1],     "CPUMathType"),
-        ("Sin",     FloatTypes[0], FloatTypes[1],     "CPUMathType"),
-        ("Sinh",    FloatTypes[0], FloatTypes[1],     "CPUMathType"),
-        ("Asin",    FloatTypes[0], FloatTypes[1],     "CPUMathType"),
-        ("Cos",     FloatTypes[0], FloatTypes[1],     "CPUMathType"),
-        ("Cosh",    FloatTypes[0], FloatTypes[1],     "CPUMathType"),
-        ("Acos",    FloatTypes[0], FloatTypes[1],     "CPUMathType"),
-        ("Tan",     FloatTypes[0], FloatTypes[1],     "CPUMathType"),
-        ("Tanh",    FloatTypes[0], FloatTypes[1],     "CPUMathType"),
-        ("Atan",    FloatTypes[0], FloatTypes[1],     "CPUMathType"),
-        ("Exp",     FloatTypes[0], FloatTypes[1],     "CPUMathType"),
-        ("Floor",   FloatTypes[0], FloatTypes[1],     "CPUMathType"),
-        ("Ceiling", FloatTypes[0], FloatTypes[1],     "CPUMathType"),
-        ("Log",     FloatTypes[0], FloatTypes[1],     "CPUMathType"),
-        ("Log10",   FloatTypes[0], FloatTypes[1],     "CPUMathType")
+        ("Abs",     FloatTypes[1], FloatTypes[1],     "MathType"),
+        ("Abs",     null,          FloatTypes[2],     "MathType"),
+        ("Sqrt",    FloatTypes[1], FloatTypes[2],     "CPUMathType"),
+        ("Sin",     FloatTypes[1], FloatTypes[2],     "CPUMathType"),
+        ("Sinh",    FloatTypes[1], FloatTypes[2],     "CPUMathType"),
+        ("Asin",    FloatTypes[1], FloatTypes[2],     "CPUMathType"),
+        ("Cos",     FloatTypes[1], FloatTypes[2],     "CPUMathType"),
+        ("Cosh",    FloatTypes[1], FloatTypes[2],     "CPUMathType"),
+        ("Acos",    FloatTypes[1], FloatTypes[2],     "CPUMathType"),
+        ("Tan",     FloatTypes[1], FloatTypes[2],     "CPUMathType"),
+        ("Tanh",    FloatTypes[1], FloatTypes[2],     "CPUMathType"),
+        ("Atan",    FloatTypes[1], FloatTypes[2],     "CPUMathType"),
+        ("Exp",     FloatTypes[1], FloatTypes[2],     "CPUMathType"),
+        ("Floor",   FloatTypes[1], FloatTypes[2],     "CPUMathType"),
+        ("Ceiling", FloatTypes[1], FloatTypes[2],     "CPUMathType"),
+        ("Log",     FloatTypes[1], FloatTypes[2],     "CPUMathType"),
+        ("Log10",   FloatTypes[1], FloatTypes[2],     "CPUMathType")
     };
 
 var binaryMathFunctions = new (string, TypeInformation, TypeInformation, string)[]
@@ -51,8 +51,8 @@ var binaryMathFunctions = new (string, TypeInformation, TypeInformation, string)
         ("Min",   null,          UnsignedIntTypes[1], "MathType"),
         ("Min",   null,          UnsignedIntTypes[2], "MathType"),
         ("Min",   null,          UnsignedIntTypes[3], "MathType"),
-        ("Min",   FloatTypes[0], FloatTypes[0],       "MathType"),
-        ("Min",   null,          FloatTypes[1],       "MathType"),
+        ("Min",   FloatTypes[1], FloatTypes[1],       "MathType"),
+        ("Min",   null,          FloatTypes[2],       "MathType"),
         ("Max",   null,          SignedIntTypes[0],   "MathType"),
         ("Max",   null,          SignedIntTypes[1],   "MathType"),
         ("Max",   null,          SignedIntTypes[2],   "MathType"),
@@ -61,11 +61,11 @@ var binaryMathFunctions = new (string, TypeInformation, TypeInformation, string)
         ("Max",   null,          UnsignedIntTypes[1], "MathType"),
         ("Max",   null,          UnsignedIntTypes[2], "MathType"),
         ("Max",   null,          UnsignedIntTypes[3], "MathType"),
-        ("Max",   FloatTypes[0], FloatTypes[0],       "MathType"),
-        ("Max",   null,          FloatTypes[1],       "MathType"),
-        ("Atan2", FloatTypes[0], FloatTypes[1],       "CPUMathType"),
-        ("Pow",   FloatTypes[0], FloatTypes[1],       "CPUMathType"),
-        ("Log",   FloatTypes[0], FloatTypes[1],       "CPUMathType")
+        ("Max",   FloatTypes[1], FloatTypes[1],       "MathType"),
+        ("Max",   null,          FloatTypes[2],       "MathType"),
+        ("Atan2", FloatTypes[1], FloatTypes[2],       "CPUMathType"),
+        ("Pow",   FloatTypes[1], FloatTypes[2],       "CPUMathType"),
+        ("Log",   FloatTypes[1], FloatTypes[2],       "CPUMathType")
     };
 #>
 using System;

--- a/Src/ILGPU/Half.cs
+++ b/Src/ILGPU/Half.cs
@@ -1,0 +1,436 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                        Copyright (c) 2016-2020 Marcel Koester
+//                                    www.ilgpu.net
+//
+// File: Half.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+
+using ILGPU.Frontend.Intrinsic;
+using ILGPU.IR.Values;
+using System;
+#if !DEBUG
+using System.Diagnostics;
+#endif
+using System.Runtime.CompilerServices;
+
+namespace ILGPU
+{
+    /// <summary>
+    /// A half precision floating point value with 16 bit precision.
+    /// </summary>
+    [Serializable]
+    public readonly partial struct Half : IEquatable<Half>, IComparable<Half>
+    {
+        #region Static
+
+        /// <summary>
+        /// Returns the absolute value of the given half value.
+        /// </summary>
+        /// <param name="half">The half value.</param>
+        /// <returns>The absolute value.</returns>
+        [MathIntrinsic(MathIntrinsicKind.Abs)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Half Abs(Half half) => HalfExtensions.Abs(half);
+
+        /// <summary>
+        /// Returns true if the given half value represents a NaN value.
+        /// </summary>
+        /// <param name="half">The half value.</param>
+        /// <returns>True, if the given half represents a NaN value.</returns>
+        [MathIntrinsic(MathIntrinsicKind.IsNaNF)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsNaN(Half half) => HalfExtensions.IsNaN(half);
+
+        /// <summary>
+        /// Returns true if the given half value represents 0.
+        /// </summary>
+        /// <param name="half">The half value.</param>
+        /// <returns>True, if the given half represents 0.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsZero(Half half) => HalfExtensions.IsZero(half);
+
+        /// <summary>
+        /// Returns true if the given half value represents +infinity.
+        /// </summary>
+        /// <param name="half">The half value.</param>
+        /// <returns>True, if the given half value represents +infinity.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsPositiveInfinity(Half half) =>
+            HalfExtensions.IsPositiveInfinity(half);
+
+        /// <summary>
+        /// Returns true if the given half value represents -infinity.
+        /// </summary>
+        /// <param name="half">The half value.</param>
+        /// <returns>True, if the given half value represents -infinity.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsNegativeInfinity(Half half) =>
+            HalfExtensions.IsNegativeInfinity(half);
+
+        /// <summary>
+        /// Returns true if the given half value represents infinity.
+        /// </summary>
+        /// <param name="half">The half value.</param>
+        /// <returns>True, if the given half value represents infinity.</returns>
+        [MathIntrinsic(MathIntrinsicKind.IsInfF)]
+        public static bool IsInfinity(Half half) => HalfExtensions.IsInfinity(half);
+
+        #endregion
+
+        #region Instance
+
+        /// <summary>
+        /// Constructs a new half value.
+        /// </summary>
+        /// <param name="rawValue">The underlying raw value.</param>
+        internal Half(ushort rawValue)
+        {
+            RawValue = rawValue;
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Represents the raw value.
+        /// </summary>
+#if !DEBUG
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+#endif
+        internal ushort RawValue { get; }
+
+        #endregion
+
+        #region IEquatable
+
+        /// <summary>
+        /// Returns true if the given half is equal to the current half.
+        /// </summary>
+        /// <param name="other">The other half.</param>
+        /// <returns>True, if the given half is equal to the current half.</returns>
+        public readonly bool Equals(Half other) => this == other;
+
+        #endregion
+
+        #region IComparable
+
+        /// <summary>
+        /// Compares this half value to the given half.
+        /// </summary>
+        /// <param name="other">The other half.</param>
+        /// <returns>The result of the half comparison.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public readonly int CompareTo(Half other) => ((float)this).CompareTo(other);
+
+        #endregion
+
+        #region Object
+
+        /// <summary>
+        /// Returns true if the given object is equal to the current half.
+        /// </summary>
+        /// <param name="obj">The other object.</param>
+        /// <returns>True, if the given object is equal to the current half.</returns>
+        public readonly override bool Equals(object obj) =>
+            obj is Half half && Equals(half);
+
+        /// <summary>
+        /// Returns the hash code of this half.
+        /// </summary>
+        /// <returns>The hash code of this half.</returns>
+        public readonly override int GetHashCode() => RawValue;
+
+        /// <summary>
+        /// Returns the string representation of this half.
+        /// </summary>
+        /// <returns>The string representation of this half.</returns>
+        public readonly override string ToString() => ((float)this).ToString();
+
+        #endregion
+
+        #region Operators
+
+        /// <summary>
+        /// Negates the given half value.
+        /// </summary>
+        /// <param name="halfValue">The half value to negate.</param>
+        /// <returns>The negated half value.</returns>
+        [MathIntrinsic(MathIntrinsicKind.Neg)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Half operator -(Half halfValue) => HalfExtensions.Neg(halfValue);
+
+        /// <summary>
+        /// Adds two half values.
+        /// </summary>
+        /// <param name="first">The first half.</param>
+        /// <param name="second">The second half.</param>
+        /// <returns>The resulting half value.</returns>
+        [MathIntrinsic(MathIntrinsicKind.Add)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Half operator +(Half first, Half second) =>
+            HalfExtensions.AddFP32(first, second);
+
+        /// <summary>
+        /// Subtracts two half values.
+        /// </summary>
+        /// <param name="first">The first half.</param>
+        /// <param name="second">The second half.</param>
+        /// <returns>The resulting half value.</returns>
+        [MathIntrinsic(MathIntrinsicKind.Sub)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Half operator -(Half first, Half second) =>
+            HalfExtensions.SubFP32(first, second);
+
+        /// <summary>
+        /// Multiplies two half values.
+        /// </summary>
+        /// <param name="first">The first half.</param>
+        /// <param name="second">The second half.</param>
+        /// <returns>The resulting half value.</returns>
+        [MathIntrinsic(MathIntrinsicKind.Mul)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Half operator *(Half first, Half second) =>
+            HalfExtensions.MulFP32(first, second);
+
+        /// <summary>
+        /// Divides two half values.
+        /// </summary>
+        /// <param name="first">The first half.</param>
+        /// <param name="second">The second half.</param>
+        /// <returns>The resulting half value.</returns>
+        [MathIntrinsic(MathIntrinsicKind.Div)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Half operator /(Half first, Half second) =>
+            HalfExtensions.DivFP32(first, second);
+
+        /// <summary>
+        /// Returns true if the first and second half represent the same value.
+        /// </summary>
+        /// <param name="first">The first value.</param>
+        /// <param name="second">The second value.</param>
+        /// <returns>True, if the first and second half are the same.</returns>
+        [CompareIntrinisc(CompareKind.Equal)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool operator ==(Half first, Half second) =>
+            (float)first == second;
+
+        /// <summary>
+        /// Returns true if the first and second half represent not the same value.
+        /// </summary>
+        /// <param name="first">The first value.</param>
+        /// <param name="second">The second value.</param>
+        /// <returns>True, if the first and second half are not the same.</returns>
+        [CompareIntrinisc(CompareKind.NotEqual, CompareFlags.UnsignedOrUnordered)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool operator !=(Half first, Half second) =>
+            (float)first != second;
+
+        /// <summary>
+        /// Returns true if the first half is smaller than the second half.
+        /// </summary>
+        /// <param name="first">The first half.</param>
+        /// <param name="second">The second half.</param>
+        /// <returns>True, if the first half is smaller than the second half.</returns>
+        [CompareIntrinisc(CompareKind.LessThan)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool operator <(Half first, Half second) =>
+            (float)first < second;
+
+        /// <summary>
+        /// Returns true if the first half is smaller than or equal to the half index.
+        /// </summary>
+        /// <param name="first">The first half.</param>
+        /// <param name="second">The second half.</param>
+        /// <returns>
+        /// True, if the first half is smaller than or equal to the second half.
+        /// </returns>
+        [CompareIntrinisc(CompareKind.LessEqual)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool operator <=(Half first, Half second) =>
+            (float)first <= second;
+
+        /// <summary>
+        /// Returns true if the first half is greater than the second half.
+        /// </summary>
+        /// <param name="first">The first half.</param>
+        /// <param name="second">The second half.</param>
+        /// <returns>True, if the first half is greater than the second half.</returns>
+        [CompareIntrinisc(CompareKind.GreaterThan)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool operator >(Half first, Half second) =>
+            (float)first > second;
+
+        /// <summary>
+        /// Returns true if the first half is greater than or equal to the second half.
+        /// </summary>
+        /// <param name="first">The first index.</param>
+        /// <param name="second">The second index.</param>
+        /// <returns>
+        /// True, if the first index is greater than or equal to the second index.
+        /// </returns>
+        [CompareIntrinisc(CompareKind.GreaterEqual)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool operator >=(Half first, Half second) =>
+            (float)first >= second;
+
+        /// <summary>
+        /// Implicitly converts a half to an float.
+        /// </summary>
+        /// <param name="halfValue">The half to convert.</param>
+        [ConvertIntrinisc]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static implicit operator float(Half halfValue) =>
+            HalfExtensions.ConvertHalfToFloat(halfValue);
+
+        /// <summary>
+        /// Implicitly converts a half to an double.
+        /// </summary>
+        /// <param name="halfValue">The half to convert.</param>
+        [ConvertIntrinisc]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static implicit operator double(Half halfValue) =>
+            (float)halfValue;
+
+        /// <summary>
+        /// Explicitly converts a float to a half.
+        /// </summary>
+        /// <param name="floatValue">The float to convert.</param>
+        [ConvertIntrinisc]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Half(float floatValue) =>
+            HalfExtensions.ConvertFloatToHalf(floatValue);
+
+        /// <summary>
+        /// Explicitly converts a double to a half.
+        /// </summary>
+        /// <param name="doubleValue">The double to convert.</param>
+        [ConvertIntrinisc]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Half(double doubleValue) =>
+            (Half)(float)doubleValue;
+
+        #endregion
+    }
+
+    internal static partial class HalfExtensions
+    {
+        /// <summary>
+        /// Negates the given half value.
+        /// </summary>
+        /// <param name="halfValue">The half value to negate.</param>
+        /// <returns>The negated half value.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Half Neg(Half halfValue) =>
+            new Half((ushort)(halfValue.RawValue ^ SignBitMask));
+
+        /// <summary>
+        /// Returns the absolute value of the given half value.
+        /// </summary>
+        /// <param name="half">The half value.</param>
+        /// <returns>The absolute value.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Half Abs(Half half) =>
+            new Half((ushort)(half.RawValue & ExponentMantissaMask));
+
+        /// <summary>
+        /// Returns true if the given half value represents a NaN value.
+        /// </summary>
+        /// <param name="half">The half value.</param>
+        /// <returns>True, if the given half represents a NaN value.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsNaN(Half half) =>
+            (half.RawValue & ExponentMantissaMask) > ExponentMask;
+
+        /// <summary>
+        /// Returns true if the given half value represents 0.
+        /// </summary>
+        /// <param name="half">The half value.</param>
+        /// <returns>True, if the given half represents 0.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsZero(Half half) =>
+-            (half.RawValue & ExponentMantissaMask) == 0;
+
+        /// <summary>
+        /// Returns true if the given half value represents +infinity.
+        /// </summary>
+        /// <param name="half">The half value.</param>
+        /// <returns>True, if the given half value represents +infinity.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsPositiveInfinity(Half half) =>
+            half == Half.PositiveInfinity;
+
+        /// <summary>
+        /// Returns true if the given half value represents -infinity.
+        /// </summary>
+        /// <param name="half">The half value.</param>
+        /// <returns>True, if the given half value represents -infinity.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsNegativeInfinity(Half half) =>
+            half == Half.NegativeInfinity;
+
+        /// <summary>
+        /// Returns true if the given half value represents infinity.
+        /// </summary>
+        /// <param name="half">The half value.</param>
+        /// <returns>True, if the given half value represents infinity.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsInfinity(Half half) =>
+            (half.RawValue & ExponentMantissaMask) == ExponentMask;
+
+        /// <summary>
+        /// Implements a FP16 addition using FP32.
+        /// </summary>
+        /// <param name="first">The first half.</param>
+        /// <param name="second">The second half.</param>
+        /// <returns>The resulting half value.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Half AddFP32(Half first, Half second) =>
+            (Half)((float)first + second);
+
+        /// <summary>
+        /// Implements a FP16 subtraction using FP32.
+        /// </summary>
+        /// <param name="first">The first half.</param>
+        /// <param name="second">The second half.</param>
+        /// <returns>The resulting half value.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Half SubFP32(Half first, Half second) =>
+            (Half)((float)first - second);
+
+        /// <summary>
+        /// Implements a FP16 multiplication using FP32.
+        /// </summary>
+        /// <param name="first">The first half.</param>
+        /// <param name="second">The second half.</param>
+        /// <returns>The resulting half value.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Half MulFP32(Half first, Half second) =>
+            (Half)((float)first * second);
+
+        /// <summary>
+        /// Implements a FP16 division using FP32.
+        /// </summary>
+        /// <param name="first">The first half.</param>
+        /// <param name="second">The second half.</param>
+        /// <returns>The resulting half value.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Half DivFP32(Half first, Half second) =>
+            (Half)((float)first / second);
+
+        /// <summary>
+        /// Implements a FP16 division using FP32.
+        /// </summary>
+        /// <param name="first">The first half.</param>
+        /// <param name="second">The second half.</param>
+        /// <param name="third">The third half.</param>
+        /// <returns>The resulting half value.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Half FmaFP32(Half first, Half second, Half third) =>
+            (Half)((float)first * second + third);
+    }
+}

--- a/Src/ILGPU/HalfConversion.tt
+++ b/Src/ILGPU/HalfConversion.tt
@@ -1,0 +1,431 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                        Copyright (c) 2016-2020 Marcel Koester
+//                                    www.ilgpu.net
+//
+// File: HalfConversion.tt/HalfConversion.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+
+<#@ template debug="false" hostspecific="true" language="C#" #>
+<#@ include file="Static/TypeInformation.ttinclude" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ output extension=".cs" #>
+<#
+string rootPath = Host.ResolvePath("Static");
+var unaryOps = GetUnaryMathOps(rootPath).
+    Where(t => t.HasFloats && t.HasImplementation &&
+        !FP16ImplementationMethods.Any(t2 => t2.Item1 == t.MethodName));
+var binaryOps = GetBinaryMathOps(rootPath).
+    Where(t => t.HasFloats && t.HasImplementation);
+#>
+using ILGPU.Frontend.Intrinsic;
+using ILGPU.IR.Values;
+using System;
+using System.Runtime.CompilerServices;
+
+// disable: max_line_length
+
+//
+// Based on an adapted version of the half-to-float and float-to-half conversion
+// algorithm from the paper: Fast Half Float Conversions, by Jeroen van der Zijp
+//
+
+namespace ILGPU
+{
+    partial struct Half
+    {
+        #region Constants
+
+        /// <summary>
+        /// Represents the smallest positive <see cref="Half"/> value that is greater
+        /// than zero.
+        /// </summary>
+        public static readonly Half Epsilon = new Half(<#= Assemble(false, 0, 1) #>);
+
+        /// <summary>
+        /// Represents the largest possible <see cref="Half"/> value.
+        /// </summary>
+        public static readonly Half MaxValue = new Half(
+            <#= Assemble(false, RawExponentMask << 1, MantissaMask) #>);
+
+        /// <summary>
+        /// Represents the smallest possible <see cref="Half"/> value.
+        /// </summary>
+        public static readonly Half MinValue = new Half(
+            <#= Assemble(true, RawExponentMask << 1, MantissaMask) #>);
+
+        /// <summary>
+        /// Represents not a number (NaN).
+        /// </summary>
+        public static readonly Half NaN = new Half(<#= Assemble(true, -1, 1) #>);
+
+        /// <summary>
+        /// Represents positive infinity.
+        /// </summary>
+        public static readonly Half PositiveInfinity = new Half(
+            <#= Assemble(false, -1, 0) #>);
+
+        /// <summary>
+        /// Represents negative infinity.
+        /// </summary>
+        public static readonly Half NegativeInfinity = new Half(
+            <#= Assemble(true, -1, 0) #>);
+
+        /// <summary>
+        /// Represents a positive zero <see cref="Half"/> value.
+        /// </summary>
+        public static readonly Half Zero = new Half(<#= Assemble(false, 0, 0) #>);
+
+        /// <summary>
+        /// Represents a positive zero <see cref="Half"/> value.
+        /// </summary>
+        public static readonly Half One = new Half(<#= Assemble(false, 0, 1) #>);
+
+        #endregion
+
+        #region Operators
+
+<# foreach (var type in IntTypes) { #>
+<#      bool clsCompliant = type.IsUnsignedInt || type == IntTypes[0]; #>
+        /// <summary>
+        /// Implicitly converts a half to type <#= type.Name #>.
+        /// </summary>
+        /// <param name="halfValue">The half to convert.</param>
+<#      if (clsCompliant) { #>
+        [CLSCompliant(false)]
+<#      } #>
+<#      if (type.IsUnsignedInt) { #>
+        [ConvertIntrinisc(ConvertFlags.TargetUnsigned)]
+<#      } else { #>
+        [ConvertIntrinisc]
+<#      } #>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator <#= type.Type #>(Half halfValue) =>
+            (<#= type.Type #>)(float)halfValue;
+
+        /// <summary>
+        /// Explicitly converts an instance of type <#= type.Name #> to a half.
+        /// </summary>
+        /// <param name="<#= type.Type #>Value">The value to convert.</param>
+<#      if (clsCompliant) { #>
+        [CLSCompliant(false)]
+<#      } #>
+<#      if (type.IsUnsignedInt) { #>
+        [ConvertIntrinisc(ConvertFlags.SourceUnsigned)]
+<#      } else { #>
+        [ConvertIntrinisc]
+<#      } #>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Half(<#= type.Type #> <#= type.Type #>Value) =>
+            (Half)(float)<#= type.Type #>Value;
+
+<# } #>
+        #endregion
+    }
+
+    partial class HalfExtensions
+    {
+        #region Constants
+
+        /// <summary>
+        /// The bit mask of the sign bit.
+        /// </summary>
+        private const ushort SignBitMask = <#= $"0x{SignBitMask:X}" #>;
+
+        /// <summary>
+        /// The bit mask of the exponent.
+        /// </summary>
+        private const ushort ExponentMask = <#= $"0x{ExponentMask:X}" #>;
+
+        /// <summary>
+        /// The bit mask of the mantissa.
+        /// </summary>
+        private const ushort MantissaMask = <#= $"0x{MantissaMask:X}" #>;
+
+        /// <summary>
+        /// The bit mask of the exponent and the mantissa.
+        /// </summary>
+        private const ushort ExponentMantissaMask = <#= $"0x{ExponentMantissaMask:X}" #>;
+
+        /// <summary>
+        /// The underlying offset table for van der Zijp's algorithm.
+        /// </summary>
+        private static readonly ushort[] OffsetTable =
+        {
+            0,
+            <#= string.Join(", ", Enumerable.Repeat(1024, 31)) #>,
+            0,
+            <#= string.Join(", ", Enumerable.Repeat(1024, 31)) #>,
+        };
+
+        /// <summary>
+        /// The underlying mantissa table for van der Zijp's algorithm.
+        /// </summary>
+        private static readonly uint[] MantissaTable =
+        {
+            0,
+            <#= CreateLowerMantissaTable() #>,
+            <#= CreateUpperMantissaTable() #>
+        };
+
+        /// <summary>
+        /// The underlying exponent table for van der Zijp's algorithm.
+        /// </summary>
+        private static readonly uint[] ExponentTable =
+        {
+            0,
+            <#= CreateLowerExponentTable() #>,
+            0x47800000,
+            <#= $"0x{FloatSignBitMask:X}" #>,
+            <#= CreateUpperExponentTable() #>,
+            0xC7800000
+        };
+
+        /// <summary>
+        /// The underlying base table for van der Zijp's algorithm.
+        /// </summary>
+        private static readonly ushort[] BaseTable =
+        {
+            <#= CreateBaseTable() #>
+        };
+
+        /// <summary>
+        /// The underlying shift table for van der Zijp's algorithm.
+        /// </summary>
+        private static readonly byte[] ShiftTable =
+        {
+            <#= CreateShiftTable() #>
+        };
+
+        #endregion
+
+        #region Static
+
+        /// <summary>
+        /// Converts a half value to a float value by using van der Zijp's algorithm.
+        /// </summary>
+        /// <param name="halfValue">The value to convert.</param>
+        /// <returns>The converted float value.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float ConvertHalfToFloat(Half halfValue)
+        {
+            ushort rawValue = halfValue.RawValue;
+
+            int baseOffset = OffsetTable[rawValue >> <#= MantissaBits #>];
+            int mantissaOffset = rawValue & MantissaMask;
+            uint mantissa = MantissaTable[baseOffset + mantissaOffset];
+            uint exponentBase = ExponentTable[rawValue >> <#= MantissaBits #>];
+
+            return Interop.IntAsFloat(mantissa + exponentBase);
+        }
+
+        /// <summary>
+        /// Converts a float value to a half value by using van der Zijp's algorithm.
+        /// </summary>
+        /// <param name="floatValue">The value to convert.</param>
+        /// <returns>The converted half value.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Half ConvertFloatToHalf(float floatValue)
+        {
+            uint rawValue = Interop.FloatAsInt(floatValue);
+            uint rawUpperValue = rawValue >> <#= FloatMantissaBits #>;
+
+            uint baseEntry = BaseTable[rawUpperValue];
+            int shiftAmount = ShiftTable[rawUpperValue];
+            uint mantissaOffset = rawValue & <#= $"0x{FloatMantissaMask:X}" #>;
+
+            uint result = baseEntry + (mantissaOffset >> shiftAmount);
+            return new Half((ushort)result);
+        }
+
+        #endregion
+
+        #region FP32 Implementation Methods
+
+<# foreach (var op in unaryOps) { #>
+        /// <summary>
+        /// <#= op.Summary #>
+        /// </summary>
+        /// <param name="value">The value.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Half <#= op.MethodName #>FP32(Half value) =>
+            (Half)IntrinsicMath.CPUOnly.<#= op.MethodName #>((float)value);
+
+<# } #>
+
+<# foreach (var op in binaryOps) { #>
+        /// <summary>
+        /// <#= op.Summary #>
+        /// </summary>
+        /// <param name="left">The left value.</param>
+        /// <param name="right">The right value.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Half <#= op.MethodName #>FP32(Half left, Half right) =>
+            (Half)IntrinsicMath.CPUOnly.<#= op.MethodName #>((float)left, (float)right);
+
+<# } #>
+
+        #endregion
+    }
+}
+
+<#+
+
+// Float constants
+
+private const int FloatMantissaBits = 23;
+private const uint FloatMantissaBody = 1U << FloatMantissaBits;
+private const uint FloatMantissaMask = 0x7fffff;
+private const int FloatExponentBias = 127;
+private const int FloatSignBitLocation = 31;
+private const uint FloatSignBitMask = 1U << FloatSignBitLocation;
+
+// Lookup generation based on von der Zijp's algorithm
+
+private static uint ConvertFloatMantissa(uint mantissa)
+{
+    uint exponent = 0;
+    mantissa <<= HalfToFloatZeroBits;
+
+    while ((mantissa & FloatMantissaBody) == 0)
+    {
+        exponent -= FloatMantissaBody;
+        mantissa <<= 1;
+    }
+
+    mantissa &= ~FloatMantissaBody;
+    exponent += HalfToFloatExponentAdjustment;
+    return exponent | mantissa;
+}
+
+private static string CreateLowerMantissaTable() =>
+    string.Join(
+        ", ",
+        Enumerable.Range(1, 1023).Select(t =>
+            $"0x{ConvertFloatMantissa((uint)t):X}"));
+
+private static string CreateUpperMantissaTable() =>
+    string.Join(
+        ", ",
+        Enumerable.Range(1, 1024).Select(t =>
+        {
+            uint shift = (uint)(t - 1) << HalfToFloatZeroBits;
+            return $"0x{(FloatToHalfExponentAdjustment + shift):X}";
+        }));
+
+private static string CreateLowerExponentTable() =>
+    string.Join(
+        ", ",
+        Enumerable.Range(1, 30).Select(t => $"0x{(t << FloatMantissaBits):X}"));
+
+private static string CreateUpperExponentTable() =>
+    string.Join(
+        ", ",
+        Enumerable.Range(1, 30).Select(t =>
+            FloatSignBitMask + (t << FloatMantissaBits)));
+
+// Adapted version of the original algorithm that used nested ifs
+static string CreateBaseTable()
+{
+    var baseTable = new int[512];
+
+    for (int i = 0; i < 103; ++i)
+    {
+        baseTable[i | 0x000] = 0x0000;
+        baseTable[i | 0x100] = 0x8000;
+    }
+
+    for (int i = 103, shift = 10; i < 113; ++i, --shift)
+    {
+        int eValue = 0x0400 >> shift;
+        baseTable[i | 0x000] = eValue;
+        baseTable[i | 0x100] = eValue | 0x8000;
+    }
+
+    for (int i = 113, baseValue = 1; i < 143; ++i, ++baseValue)
+    {
+        int eValue = baseValue << 10;
+        baseTable[i | 0x000] = eValue;
+        baseTable[i | 0x100] = eValue | 0x8000;
+    }
+
+    for (int i = 143; i < 255; ++i)
+    {
+        baseTable[i | 0x000] = 0x7C00;
+        baseTable[i | 0x100] = 0xFC00;
+    }
+
+    baseTable[255 | 0x000] = 0x7C00;
+    baseTable[255 | 0x100] = 0xFC00;
+
+    return string.Join(", ", baseTable.Select(t => $"0x{t:X}"));
+}
+
+// Adapted version of the original algorithm that used nested ifs
+static string CreateShiftTable()
+{
+    var shiftTable = new byte[512];
+
+    for (int i = 0; i < 103; ++i)
+    {
+        shiftTable[i | 0x000] = 24;
+        shiftTable[i | 0x100] = 24;
+    }
+
+    for (int i = 103, eValue = 23; i < 113; ++i, --eValue)
+    {
+        shiftTable[i | 0x000] = (byte)eValue;
+        shiftTable[i | 0x100] = (byte)eValue;
+    }
+
+    for (int i = 113, baseValue = 1; i < 143; ++i, ++baseValue)
+    {
+        shiftTable[i | 0x000] = 13;
+        shiftTable[i | 0x100] = 13;
+    }
+
+    for (int i = 143; i < 255; ++i)
+    {
+        shiftTable[i | 0x000] = 24;
+        shiftTable[i | 0x100] = 24;
+    }
+
+    shiftTable[255 | 0x000] = 13;
+    shiftTable[255 | 0x100] = 13;
+
+    return string.Join(", ", shiftTable.Select(t => $"0x{t:X}"));
+}
+
+// Custom ILGPU Half extensions
+
+private const int ExponentBits = 5;
+private const int MantissaBits = 10;
+private const int SignBitLocation = 15;
+
+private const int HalfToFloatZeroBits = 13;
+private const uint FloatToHalfExponentAdjustment =
+    FloatExponentBias - SignBitLocation << FloatMantissaBits;
+private const int HalfToFloatExponentAdjustment =
+    FloatExponentBias - SignBitLocation + 1 << FloatMantissaBits;
+
+private const ushort SignBitMask = 1 << SignBitLocation;
+private const ushort RawExponentMask = 0x1f;
+private const ushort ExponentMask = RawExponentMask << MantissaBits;
+private const ushort MantissaMask = 0x3ff;
+private const ushort ExponentMantissaMask = ExponentMask | MantissaMask;
+
+private static string Assemble(bool signBit, int exponent, int mantissa)
+{
+    int assembled =
+        Convert.ToInt32(signBit) << (ExponentBits + MantissaBits) |
+        (exponent & 0x1f) << MantissaBits |
+        (mantissa & MantissaMask);
+    return $"0x{assembled:X}";
+}
+#>

--- a/Src/ILGPU/ILGPU.csproj
+++ b/Src/ILGPU/ILGPU.csproj
@@ -72,6 +72,11 @@
           <AutoGen>True</AutoGen>
           <DependentUpon>IntrinsicMath.CPUOnly.tt</DependentUpon>
         </None>
+        <None Include="HalfConversion.cs">
+          <DesignTime>True</DesignTime>
+          <AutoGen>True</AutoGen>
+          <DependentUpon>HalfConversion.tt</DependentUpon>
+        </None>
         <None Include="IR\Intrinsics\IntrinsicMatchers.cs">
           <DesignTime>True</DesignTime>
           <AutoGen>True</AutoGen>
@@ -150,6 +155,11 @@
           <AutoGen>True</AutoGen>
           <DependentUpon>IntrinsicMath.CPUOnly.tt</DependentUpon>
         </Compile>
+        <Compile Update="HalfConversion.cs">
+          <DesignTime>True</DesignTime>
+          <AutoGen>True</AutoGen>
+          <DependentUpon>HalfConversion.tt</DependentUpon>
+        </Compile>
         <Compile Update="IR\Intrinsics\IntrinsicMatchers.cs">
           <DesignTime>True</DesignTime>
           <AutoGen>True</AutoGen>
@@ -226,6 +236,10 @@
         <None Update="IntrinsicMath.CPUOnly.tt">
           <Generator>TextTemplatingFileGenerator</Generator>
           <LastGenOutput>IntrinsicMath.CPUOnly.cs</LastGenOutput>
+        </None>
+        <None Update="HalfConversion.tt">
+          <Generator>TextTemplatingFileGenerator</Generator>
+          <LastGenOutput>HalfConversion.cs</LastGenOutput>
         </None>
         <None Update="IR\Construction\CompareOperations.tt">
             <Generator>TextTemplatingFileGenerator</Generator>

--- a/Src/ILGPU/IR/Construction/ArithmeticOperations.tt
+++ b/Src/ILGPU/IR/Construction/ArithmeticOperations.tt
@@ -59,6 +59,10 @@ namespace ILGPU.IR.Construction
             switch (value.BasicValueType)
             {
 <#          if (op.HasFloats) { #>
+                case BasicValueType.Float16:
+                    return CreatePrimitiveValue(
+                        location,
+                        <#= op.GetOpOrCall(false, "value.Float16Value") #>);
                 case BasicValueType.Float32:
                     return CreatePrimitiveValue(
                         location,
@@ -135,6 +139,10 @@ namespace ILGPU.IR.Construction
             switch (left.BasicValueType)
             {
 <#          if (op.HasFloats) { #>
+                case BasicValueType.Float16:
+                    return CreatePrimitiveValue(
+                        location,
+                        <#= op.GetOpOrCall(false, "left.Float16Value", "right.Float16Value") #>);
                 case BasicValueType.Float32:
                     return CreatePrimitiveValue(
                         location,

--- a/Src/ILGPU/IR/Construction/Cast.cs
+++ b/Src/ILGPU/IR/Construction/Cast.cs
@@ -103,6 +103,9 @@ namespace ILGPU.IR.Construction
             {
                 return primitiveType.BasicValueType switch
                 {
+                    BasicValueType.Float16 => CreatePrimitiveValue(
+                        location,
+                        Interop.FloatAsInt(primitive.Float16Value)),
                     BasicValueType.Float32 => CreatePrimitiveValue(
                         location,
                         Interop.FloatAsInt(primitive.Float32Value)),
@@ -117,6 +120,7 @@ namespace ILGPU.IR.Construction
 
             var basicValueType = primitiveType.BasicValueType switch
             {
+                BasicValueType.Float16 => BasicValueType.Int16,
                 BasicValueType.Float32 => BasicValueType.Int32,
                 BasicValueType.Float64 => BasicValueType.Int64,
                 _ => throw location.GetNotSupportedException(
@@ -145,6 +149,9 @@ namespace ILGPU.IR.Construction
             {
                 return primitiveType.BasicValueType switch
                 {
+                    BasicValueType.Int16 => CreatePrimitiveValue(
+                        location,
+                        Interop.IntAsFloat(primitive.UInt16Value)),
                     BasicValueType.Int32 => CreatePrimitiveValue(
                         location,
                         Interop.IntAsFloat(primitive.UInt32Value)),
@@ -159,6 +166,7 @@ namespace ILGPU.IR.Construction
 
             var basicValueType = primitiveType.BasicValueType switch
             {
+                BasicValueType.Int16 => BasicValueType.Float16,
                 BasicValueType.Int32 => BasicValueType.Float32,
                 BasicValueType.Int64 => BasicValueType.Float64,
                 _ => throw location.GetNotSupportedException(

--- a/Src/ILGPU/IR/Construction/CompareOperations.tt
+++ b/Src/ILGPU/IR/Construction/CompareOperations.tt
@@ -69,6 +69,8 @@ namespace ILGPU.IR.Construction
             var isUnsigned = (flags & CompareFlags.UnsignedOrUnordered) == CompareFlags.UnsignedOrUnordered;
             switch (left.BasicValueType)
             {
+                case BasicValueType.Float16:
+                    return CreatePrimitiveValue(location, <#= operation.Prefix #>left.Float16Value<#= operation.Operation #>right.Float16Value<#= operation.Suffix #>);
                 case BasicValueType.Float32:
                     return CreatePrimitiveValue(location, <#= operation.Prefix #>left.Float32Value<#= operation.Operation #>right.Float32Value<#= operation.Suffix #>);
                 case BasicValueType.Float64:

--- a/Src/ILGPU/IR/Construction/Convert.cs
+++ b/Src/ILGPU/IR/Construction/Convert.cs
@@ -133,9 +133,12 @@ namespace ILGPU.IR.Construction
                     case BasicValueType.Int1:
                         return targetBasicValueType switch
                         {
+                            BasicValueType.Float16 => CreatePrimitiveValue(
+                                location,
+                                value.Int1Value ? Half.One : Half.Zero),
                             BasicValueType.Float32 => CreatePrimitiveValue(
                                 location,
-                               Convert.ToSingle(value.Int1Value)),
+                                Convert.ToSingle(value.Int1Value)),
                             BasicValueType.Float64 => CreatePrimitiveValue(
                                 location,
                                 Convert.ToDouble(value.Int1Value)),
@@ -150,6 +153,14 @@ namespace ILGPU.IR.Construction
                     case BasicValueType.Int64:
                         switch (targetBasicValueType)
                         {
+                            case BasicValueType.Float16:
+                                return isSourceUnsigned
+                                    ? CreatePrimitiveValue(
+                                        location,
+                                        (Half)value.UInt64Value)
+                                    : (ValueReference)CreatePrimitiveValue(
+                                        location,
+                                        (Half)value.Int64Value);
                             case BasicValueType.Float32:
                                 return isSourceUnsigned
                                     ? CreatePrimitiveValue(
@@ -193,6 +204,40 @@ namespace ILGPU.IR.Construction
                                     targetBasicValueType,
                                     value.RawValue);
                         }
+                    case BasicValueType.Float16:
+                        switch (targetBasicValueType)
+                        {
+                            case BasicValueType.Int1:
+                                return CreatePrimitiveValue(
+                                    location,
+                                    targetBasicValueType,
+                                    Half.IsZero(value.Float16Value) ? 0 : 1);
+                            case BasicValueType.Int8:
+                            case BasicValueType.Int16:
+                            case BasicValueType.Int32:
+                            case BasicValueType.Int64:
+                                return isTargetUnsigned
+                                    ? CreatePrimitiveValue(
+                                        location,
+                                        targetBasicValueType,
+                                        (long)(ulong)value.Float16Value)
+                                    : (ValueReference)CreatePrimitiveValue(
+                                        location,
+                                        targetBasicValueType,
+                                        (long)value.Float16Value);
+                            case BasicValueType.Float32:
+                                return CreatePrimitiveValue(
+                                    location,
+                                    (float)value.Float16Value);
+                            case BasicValueType.Float64:
+                                return CreatePrimitiveValue(
+                                    location,
+                                    (double)value.Float16Value);
+                        }
+                        throw location.GetNotSupportedException(
+                            ErrorMessages.NotSupportedConversion,
+                            value.BasicValueType,
+                            targetBasicValueType);
                     case BasicValueType.Float32:
                         switch (targetBasicValueType)
                         {
@@ -214,6 +259,10 @@ namespace ILGPU.IR.Construction
                                         location,
                                         targetBasicValueType,
                                         (long)value.Float32Value);
+                            case BasicValueType.Float16:
+                                return CreatePrimitiveValue(
+                                    location,
+                                    (Half)value.Float32Value);
                             case BasicValueType.Float64:
                                 return CreatePrimitiveValue(
                                     location,
@@ -240,6 +289,10 @@ namespace ILGPU.IR.Construction
                                         location,
                                         targetBasicValueType,
                                         (long)value.Float64Value);
+                            case BasicValueType.Float16:
+                                return CreatePrimitiveValue(
+                                    location,
+                                    (Half)value.Float64Value);
                             case BasicValueType.Float32:
                                 return CreatePrimitiveValue(
                                     location,

--- a/Src/ILGPU/IR/Construction/Structures.cs
+++ b/Src/ILGPU/IR/Construction/Structures.cs
@@ -12,6 +12,7 @@
 using ILGPU.IR.Types;
 using ILGPU.IR.Values;
 using ILGPU.Resources;
+using ILGPU.Util;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using ValueList = ILGPU.Util.InlineList<ILGPU.IR.Values.ValueReference>;
@@ -34,7 +35,7 @@ namespace ILGPU.IR.Construction
                 throw location.GetArgumentNullException(nameof(instance));
 
             var managedType = instance.GetType();
-            if (managedType.IsPrimitive)
+            if (managedType.IsILGPUPrimitiveType())
                 return CreatePrimitiveValue(location, instance);
             if (managedType.IsEnum)
                 return CreateEnumValue(location, instance);

--- a/Src/ILGPU/IR/Types/IRTypeContext.cs
+++ b/Src/ILGPU/IR/Types/IRTypeContext.cs
@@ -38,6 +38,7 @@ namespace ILGPU.IR.Types
                 BasicValueType.Int16,
                 BasicValueType.Int32,
                 BasicValueType.Int64,
+                BasicValueType.Float16,
                 BasicValueType.Float32,
                 BasicValueType.Float64);
 

--- a/Src/ILGPU/IR/Types/PrimitiveTypes.cs
+++ b/Src/ILGPU/IR/Types/PrimitiveTypes.cs
@@ -33,6 +33,7 @@ namespace ILGPU.IR.Types
                 2,
                 4,
                 8,
+                2,
                 4,
                 8);
 

--- a/Src/ILGPU/IR/Values/Cast.cs
+++ b/Src/ILGPU/IR/Values/Cast.cs
@@ -424,9 +424,11 @@ namespace ILGPU.IR.Values
         {
             var basicValueType = source.Type.BasicValueType;
             initializer.Assert(
+                basicValueType == BasicValueType.Float16 ||
                 basicValueType == BasicValueType.Float32 ||
                 basicValueType == BasicValueType.Float64);
             initializer.Assert(
+                targetType.BasicValueType == BasicValueType.Int16 ||
                 targetType.BasicValueType == BasicValueType.Int32 ||
                 targetType.BasicValueType == BasicValueType.Int64);
         }
@@ -488,9 +490,11 @@ namespace ILGPU.IR.Values
         {
             var basicValueType = source.Type.BasicValueType;
             initializer.Assert(
+                basicValueType == BasicValueType.Int16 ||
                 basicValueType == BasicValueType.Int32 ||
                 basicValueType == BasicValueType.Int64);
             initializer.Assert(
+                targetType.BasicValueType == BasicValueType.Float16 ||
                 targetType.BasicValueType == BasicValueType.Float32 ||
                 targetType.BasicValueType == BasicValueType.Float64);
         }

--- a/Src/ILGPU/IR/Values/Constants.cs
+++ b/Src/ILGPU/IR/Values/Constants.cs
@@ -187,6 +187,11 @@ namespace ILGPU.IR.Values
         public ulong UInt64Value => (ulong)Int64Value;
 
         /// <summary>
+        /// Returns the value as f16.
+        /// </summary>
+        public Half Float16Value => Unsafe.As<long, Half>(ref rawValue);
+
+        /// <summary>
         /// Returns the value as f32.
         /// </summary>
         public float Float32Value => Unsafe.As<long, float>(ref rawValue);
@@ -251,6 +256,7 @@ namespace ILGPU.IR.Values
                 BasicValueType.Int16 => Int16Value.ToString(),
                 BasicValueType.Int32 => Int32Value.ToString(),
                 BasicValueType.Int64 => Int64Value.ToString(),
+                BasicValueType.Float16 => Float16Value.ToString(),
                 BasicValueType.Float32 => Float32Value.ToString(),
                 BasicValueType.Float64 => Float64Value.ToString(),
                 _ => $"Raw({rawValue})",

--- a/Src/ILGPU/Interop.cs
+++ b/Src/ILGPU/Interop.cs
@@ -143,6 +143,17 @@ namespace ILGPU
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [InteropIntrinsic(InteropIntrinsicKind.FloatAsInt)]
+        public static ushort FloatAsInt(Half value) =>
+            value.RawValue;
+
+        /// <summary>
+        /// Casts the given float to an int via a reinterpret cast.
+        /// </summary>
+        /// <param name="value">The value to cast.</param>
+        /// <returns>The int value.</returns>
+        [CLSCompliant(false)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [InteropIntrinsic(InteropIntrinsicKind.FloatAsInt)]
         public static uint FloatAsInt(float value) =>
             Unsafe.As<float, uint>(ref value);
 
@@ -156,6 +167,17 @@ namespace ILGPU
         [InteropIntrinsic(InteropIntrinsicKind.FloatAsInt)]
         public static ulong FloatAsInt(double value) =>
             Unsafe.As<double, ulong>(ref value);
+
+        /// <summary>
+        /// Casts the given int to a float via a reinterpret cast.
+        /// </summary>
+        /// <param name="value">The value to cast.</param>
+        /// <returns>The float value.</returns>
+        [CLSCompliant(false)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [InteropIntrinsic(InteropIntrinsicKind.IntAsFloat)]
+        public static Half IntAsFloat(ushort value) =>
+            new Half(value);
 
         /// <summary>
         /// Casts the given int to a float via a reinterpret cast.

--- a/Src/ILGPU/IntrinsicMath.CPUOnly.tt
+++ b/Src/ILGPU/IntrinsicMath.CPUOnly.tt
@@ -110,6 +110,31 @@ namespace ILGPU
 #endif
 
             #endregion
+
+            #region Half Precision
+
+<# foreach (var op in unaryOps) { #>
+            /// <summary>
+            /// <#= op.Summary #>
+            /// </summary>
+            /// <param name="value">The value.</param>
+            [MathIntrinsic(MathIntrinsicKind.<#= op.Name #>)]
+            public static <#= op.IsPredicate ? "bool" : "Half" #> <#= op.MethodName #>(Half value) =>
+                <#= op.IsPredicate ? string.Empty : "(Half)" #><#= op.MethodName #>((float)value);
+
+<# } #>
+<# foreach (var op in binaryOps) { #>
+            /// <summary>
+            /// <#= op.Summary #>
+            /// </summary>
+            /// <param name="left">The left operand.</param>
+            /// <param name="right">The right operand.</param>
+            [MathIntrinsic(MathIntrinsicKind.<#= op.Name #>)]
+            public static Half <#= op.MethodName #>(Half left, Half right) =>
+                HalfExtensions.<#= op.MethodName #>FP32(left, right);
+
+<# } #>
+            #endregion
         }
     }
 }

--- a/Src/ILGPU/IntrinsicMath.cs
+++ b/Src/ILGPU/IntrinsicMath.cs
@@ -49,6 +49,15 @@ namespace ILGPU
         /// </summary>
         /// <param name="value">The value.</param>
         /// <returns>|value|.</returns>
+        [MathIntrinsic(MathIntrinsicKind.Abs)]
+        public static Half Abs(Half value) =>
+            Half.Abs(value);
+
+        /// <summary>
+        /// Computes |value|.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>|value|.</returns>
         [CLSCompliant(false)]
         public static sbyte Abs(sbyte value) =>
             (sbyte)Abs((int)value);

--- a/Src/ILGPU/Runtime/SpecializationCache.cs
+++ b/Src/ILGPU/Runtime/SpecializationCache.cs
@@ -156,10 +156,9 @@ namespace ILGPU.Runtime
                         // Resolve the managed argument -> note that this object cannot
                         // be null
                         var managedArgument = args.GetSpecializedArg(specialParamIdx);
-                        var irValue = blockBuilder.CreateValue(
+                        var irValue = blockBuilder.CreateObjectValue(
                             location,
-                            managedArgument,
-                            managedArgument.GetType());
+                            managedArgument);
 
                         callBuilder.Add(irValue);
                         ++specialParamIdx;

--- a/Src/ILGPU/Static/TypeInformation.ttinclude
+++ b/Src/ILGPU/Static/TypeInformation.ttinclude
@@ -87,6 +87,7 @@ public static readonly TypeInformation[] DefaultIntTypes =
 
 public static readonly TypeInformation[] FloatTypes =
     {
+        new TypeInformation("Half", "Half", TypeInformationKind.Float, "(Half)", "f"),
         new TypeInformation("Float", "float", TypeInformationKind.Float, null, "f"),
         new TypeInformation("Double", "double", TypeInformationKind.Float),
     };
@@ -96,38 +97,19 @@ public static readonly TypeInformation[] NumericTypes =
 
 // Atomic information
 
-public class AtomicTypeInformation : TypeInformation
-{
-    public AtomicTypeInformation(
-        string name,
-        string type,
-        TypeInformationKind kind)
-        : base(name, type, kind)
-    { }
-}
+public static readonly TypeInformation[] AtomicSignedIntTypes =
+    SignedIntTypes.Skip(2).ToArray();
 
-public static readonly AtomicTypeInformation[] AtomicSignedIntTypes =
-    {
-        new AtomicTypeInformation("Int32", "int", TypeInformationKind.SignedInt),
-        new AtomicTypeInformation("Int64", "long", TypeInformationKind.SignedInt),
-    };
+public static readonly TypeInformation[] AtomicUnsignedIntTypes =
+    UnsignedIntTypes.Skip(2).ToArray();
 
-public static readonly AtomicTypeInformation[] AtomicUnsignedIntTypes =
-    {
-        new AtomicTypeInformation("UInt32", "uint", TypeInformationKind.UnsignedInt),
-        new AtomicTypeInformation("UInt64", "ulong", TypeInformationKind.UnsignedInt),
-    };
-
-public static readonly AtomicTypeInformation[] AtomicIntTypes =
+public static readonly TypeInformation[] AtomicIntTypes =
     AtomicSignedIntTypes.Concat(AtomicUnsignedIntTypes).ToArray();
 
-public static readonly AtomicTypeInformation[] AtomicFloatTypes =
-    {
-        new AtomicTypeInformation("Float", "float", TypeInformationKind.Float),
-        new AtomicTypeInformation("Double", "double", TypeInformationKind.Float),
-    };
+public static readonly TypeInformation[] AtomicFloatTypes =
+    FloatTypes.Skip(1).ToArray();
 
-public static readonly AtomicTypeInformation[] AtomicNumericTypes =
+public static readonly TypeInformation[] AtomicNumericTypes =
     AtomicIntTypes.Concat(AtomicFloatTypes).ToArray();
 
 // Math operations

--- a/Src/ILGPU/Util/TypeExtensions.cs
+++ b/Src/ILGPU/Util/TypeExtensions.cs
@@ -174,6 +174,16 @@ namespace ILGPU.Util
         }
 
         /// <summary>
+        /// Returns true if the given type is an ILGPU intrinsic primitive type.
+        /// </summary>
+        /// <param name="type">The source type.</param>
+        /// <returns>
+        /// True, if the given type is an ILGPU intrinsic primitive type.
+        /// </returns>
+        public static bool IsILGPUPrimitiveType(this Type type) =>
+            type.GetBasicValueType() != BasicValueType.None;
+
+        /// <summary>
         /// Resolves the managed type for the given basic-value type.
         /// </summary>
         /// <param name="type">The source type.</param>
@@ -186,6 +196,7 @@ namespace ILGPU.Util
                 BasicValueType.Int16 => typeof(short),
                 BasicValueType.Int32 => typeof(int),
                 BasicValueType.Int64 => typeof(long),
+                BasicValueType.Float16 => typeof(Half),
                 BasicValueType.Float32 => typeof(float),
                 BasicValueType.Float64 => typeof(double),
                 _ => null,
@@ -219,7 +230,9 @@ namespace ILGPU.Util
                 case TypeCode.Double:
                     return BasicValueType.Float64;
                 default:
-                    return BasicValueType.None;
+                    return type == typeof(Half)
+                        ? BasicValueType.Float16
+                        : BasicValueType.None;
             }
         }
 
@@ -243,7 +256,9 @@ namespace ILGPU.Util
                 TypeCode.UInt64 => ArithmeticBasicValueType.UInt64,
                 TypeCode.Single => ArithmeticBasicValueType.Float32,
                 TypeCode.Double => ArithmeticBasicValueType.Float64,
-                _ => ArithmeticBasicValueType.None,
+                _ => type == typeof(Half)
+                    ? ArithmeticBasicValueType.Float16
+                    : ArithmeticBasicValueType.None
             };
 
         /// <summary>
@@ -270,6 +285,8 @@ namespace ILGPU.Util
                 case ArithmeticBasicValueType.Int64:
                 case ArithmeticBasicValueType.UInt64:
                     return BasicValueType.Int64;
+                case ArithmeticBasicValueType.Float16:
+                    return BasicValueType.Float16;
                 case ArithmeticBasicValueType.Float32:
                     return BasicValueType.Float32;
                 case ArithmeticBasicValueType.Float64:
@@ -305,6 +322,7 @@ namespace ILGPU.Util
                 BasicValueType.Int64 => isUnsigned
                     ? ArithmeticBasicValueType.UInt64
                     : ArithmeticBasicValueType.Int64,
+                BasicValueType.Float16 => ArithmeticBasicValueType.Float16,
                 BasicValueType.Float32 => ArithmeticBasicValueType.Float32,
                 BasicValueType.Float64 => ArithmeticBasicValueType.Float64,
                 _ => ArithmeticBasicValueType.None,
@@ -355,6 +373,7 @@ namespace ILGPU.Util
         {
             switch (value)
             {
+                case BasicValueType.Float16:
                 case BasicValueType.Float32:
                 case BasicValueType.Float64:
                     return true;
@@ -374,6 +393,7 @@ namespace ILGPU.Util
         {
             switch (value)
             {
+                case ArithmeticBasicValueType.Float16:
                 case ArithmeticBasicValueType.Float32:
                 case ArithmeticBasicValueType.Float64:
                     return true;


### PR DESCRIPTION
This PR provides support for Half-precision (Float16/FP16) values and operations. It includes a new intrinsic type `ILGPU.Half`, which represents a 16bit floating-point number on all devices. It is designed to be `IEEE` compliant to allow a seamless integration with other 3rd-part fp16 data sources. All backends and code-generation pipelines have been adapted to emit the required FP16 instructions.

Note that FP16 support requires the presence of specific GPU hardware functions. In the case of Nvidia GPUs, these operations can be simulated in software on devices with computing capability `<= SM5.3`.

Note that this PR depends on #179.