### PR TITLE
Updated PTX intrinsics

### DIFF
--- a/Src/ILGPU/Backends/PTX/PTXInstructions.Data.cs
+++ b/Src/ILGPU/Backends/PTX/PTXInstructions.Data.cs
@@ -449,6 +449,7 @@ namespace ILGPU.Backends.PTX
 
                 { (UnaryArithmeticKind.SinF, ArithmeticBasicValueType.Float32), "sin.approx.ftz.f32" },
                 { (UnaryArithmeticKind.CosF, ArithmeticBasicValueType.Float32), "cos.approx.ftz.f32" },
+                { (UnaryArithmeticKind.TanhF, ArithmeticBasicValueType.Float32), "tanh.approx.ftz.f32" },
 
                 { (UnaryArithmeticKind.Log2F, ArithmeticBasicValueType.Float32), "lg2.approx.ftz.f32" },
                 { (UnaryArithmeticKind.Exp2F, ArithmeticBasicValueType.Float32), "ex2.approx.ftz.f32" },

--- a/Src/ILGPU/Backends/PTX/PTXIntrinsic.cs
+++ b/Src/ILGPU/Backends/PTX/PTXIntrinsic.cs
@@ -65,18 +65,19 @@ namespace ILGPU.Backends.PTX
         { }
 
         /// <summary>
-        /// Constructs a new PTX intrinsic that can handle all architectures.
+        /// Constructs a new PTX intrinsic that can handle all architectures
+        /// newer or equal to <paramref name="minArchitecture"/>.
         /// </summary>
         /// <param name="handlerType">The associated target handler type.</param>
         /// <param name="mode">The code-generation mode.</param>
-        /// <param name="architecture">The target architecture (if any).</param>
+        /// <param name="minArchitecture">The target/minimum architecture.</param>
         public PTXIntrinsic(
             Type handlerType,
             IntrinsicImplementationMode mode,
-            PTXArchitecture architecture)
+            PTXArchitecture minArchitecture)
             : this(handlerType, mode)
         {
-            MinArchitecture = architecture;
+            MinArchitecture = minArchitecture;
         }
 
         /// <summary>
@@ -102,19 +103,19 @@ namespace ILGPU.Backends.PTX
         /// <param name="handlerType">The associated target handler type.</param>
         /// <param name="methodName">The target method name (or null).</param>
         /// <param name="mode">The code-generator mode.</param>
-        /// <param name="architecture">The target architecture (if any).</param>
+        /// <param name="minArchitecture">The target/minimum architecture.</param>
         public PTXIntrinsic(
             Type handlerType,
             string methodName,
             IntrinsicImplementationMode mode,
-            PTXArchitecture architecture)
+            PTXArchitecture minArchitecture)
             : base(
                   BackendType.PTX,
                   handlerType,
                   methodName,
                   mode)
         {
-            MinArchitecture = architecture;
+            MinArchitecture = minArchitecture;
         }
 
         /// <summary>
@@ -124,7 +125,7 @@ namespace ILGPU.Backends.PTX
         /// <param name="methodName">The target method name (or null).</param>
         /// <param name="mode">The code-generator mode.</param>
         /// <param name="minArchitecture">The min architecture (if any).</param>
-        /// <param name="maxArchitecture">The max architecture.</param>
+        /// <param name="maxArchitecture">The max architecture (exclusive).</param>
         public PTXIntrinsic(
             Type handlerType,
             string methodName,
@@ -148,11 +149,18 @@ namespace ILGPU.Backends.PTX
         /// <summary>
         /// Returns the associated architecture (if any).
         /// </summary>
+        /// <remarks>
+        /// This intrinsic will be used for any architecture greater than or equal this
+        /// value.
+        /// </remarks>
         public PTXArchitecture? MinArchitecture { get; }
 
         /// <summary>
         /// Returns the associated architecture (if any).
         /// </summary>
+        /// <remarks>
+        /// This intrinsic will be used for any architecture less than this value.
+        /// </remarks>
         public PTXArchitecture? MaxArchitecture { get; }
 
         #endregion
@@ -162,12 +170,10 @@ namespace ILGPU.Backends.PTX
         /// <summary cref="IntrinsicImplementation.CanHandleBackend(Backend)"/>
         protected internal override bool CanHandleBackend(Backend backend) =>
             backend is PTXBackend ptxBackend
-            ? MinArchitecture.HasValue &&
-                ptxBackend.Architecture < MinArchitecture.Value
-                ? false
-                : !MaxArchitecture.HasValue ||
-                    ptxBackend.Architecture <= MaxArchitecture.Value
-            : false;
+            && (!MinArchitecture.HasValue ||
+                ptxBackend.Architecture >= MinArchitecture.Value)
+            && (!MaxArchitecture.HasValue ||
+                    ptxBackend.Architecture < MaxArchitecture.Value);
 
         #endregion
     }

--- a/Src/ILGPU/Backends/PTX/PTXIntrinsics.Generated.tt
+++ b/Src/ILGPU/Backends/PTX/PTXIntrinsics.Generated.tt
@@ -22,15 +22,15 @@ var fp16Ops = new (string, string, string, string)[]
     ("Unary", "Abs", "Abs", "SM_53"),
     ("Unary", "IsInfF", "IsInfinity", null),
     ("Unary", "IsNaNF", "IsNaN", null),
-    ("Unary", "Exp2F", "Exp2FP32", "SM_72"),
-    ("Unary", "TanhF", "TanhFP32", "SM_72"),
+    ("Unary", "Exp2F", "Exp2FP32", "SM_75"),
+    ("Unary", "TanhF", "TanhFP32", "SM_75"),
 
     ("Binary", "Add", "AddFP32", "SM_53"),
     ("Binary", "Sub", "SubFP32", "SM_53"),
     ("Binary", "Mul", "MulFP32", "SM_53"),
     ("Binary", "Div", "DivFP32", null),
-    ("Binary", "Min", "MinFP32", "SM_75"),
-    ("Binary", "Max", "MaxFP32", "SM_75"),
+    ("Binary", "Min", "MinFP32", "SM_80"),
+    ("Binary", "Max", "MaxFP32", "SM_80"),
 
     ("Ternary", "MultiplyAdd", "FmaFP32", "SM_53"),
 };

--- a/Src/ILGPU/Backends/PTX/PTXIntrinsics.cs
+++ b/Src/ILGPU/Backends/PTX/PTXIntrinsics.cs
@@ -11,6 +11,7 @@
 
 using ILGPU.AtomicOperations;
 using ILGPU.Frontend;
+using ILGPU.IR;
 using ILGPU.IR.Intrinsics;
 using ILGPU.IR.Values;
 using System;
@@ -112,6 +113,16 @@ namespace ILGPU.Backends.PTX
                 CreateIntrinsic(
                     nameof(AssertFailed),
                     IntrinsicImplementationMode.Redirect));
+
+            // Register math
+            manager.RegisterUnaryArithmetic(
+                UnaryArithmeticKind.TanhF,
+                BasicValueType.Float32,
+                CreateIntrinsic(
+                    nameof(Tanh),
+                    IntrinsicImplementationMode.GenerateCode,
+                    null,
+                    PTXArchitecture.SM_80));
         }
 
         #endregion
@@ -198,6 +209,20 @@ namespace ILGPU.Backends.PTX
         private static T WarpBroadcast<T>(T value, int laneIndex)
             where T : unmanaged =>
             Warp.Shuffle(value, laneIndex);
+
+        #endregion
+
+        #region Math
+
+        /// <summary>
+        /// Computes tanh(x).
+        /// </summary>
+        public static void Tanh(
+            PTXBackend backend,
+            PTXCodeGenerator codeGenerator,
+            Value value) =>
+            throw new NotSupportedIntrinsicException(
+                UnaryArithmeticKind.TanhF.ToString());
 
         #endregion
     }

--- a/Src/ILGPU/Backends/PTX/PTXIntrinsics.cs
+++ b/Src/ILGPU/Backends/PTX/PTXIntrinsics.cs
@@ -130,7 +130,7 @@ namespace ILGPU.Backends.PTX
                     nameof(AtomicAddF64),
                     IntrinsicImplementationMode.Redirect,
                     null,
-                    PTXArchitecture.SM_53));
+                    PTXArchitecture.SM_60));
 
         /// <summary>
         /// Represents an atomic compare-exchange operation of type double.


### PR DESCRIPTION
Changed the `MaxArchitecture` of `PTXIntrinsic` to be an exclusive range.

Added missing `Tanh` intrinsic for FastMath.

For architectures that do not support the new `Tanh` intrinsic, added a code generator to mimic the original behaviour by throwing `NonSupportedIntrinsicException`.