### PR TITLE
Remove debug build step from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,6 @@ jobs:
       - name: Build templates
         # TargetFramework specified so this only runs once rather than per framework
         run: dotnet msbuild -t:TextTemplateTransform -p:TargetFramework=NA Src
-      - name: Debug Build
-        run: dotnet build --configuration=Debug -p:TreatWarningsAsErrors=true Src
       - name: Release Build
         run: dotnet build --configuration=Release -p:TreatWarningsAsErrors=true Src
       - name: CPU Tests


### PR DESCRIPTION
Now that release builds have been enabled (#156), this step has become obsolete.