### PR TITLE
Added IsCLSCompliant property to type information

### DIFF
--- a/Src/ILGPU/AtomicFunctions.tt
+++ b/Src/ILGPU/AtomicFunctions.tt
@@ -36,7 +36,7 @@ namespace ILGPU
         /// <summary>
         /// Represents an atomic compare-exchange operation of type <#= type.Type #>.
         /// </summary>
-<#      if (type.IsUnsignedInt) { #>
+<#      if (!type.IsCLSCompliant) { #>
         [CLSCompliant(false)]
 <#      } #>
         public readonly struct CompareExchange<#= type.Name #> :
@@ -157,7 +157,7 @@ namespace ILGPU
         /// <param name="target">The target location.</param>
         /// <param name="value">The comparison value.</param>
         /// <returns>The old value that was stored at the target location.</returns>
-<#      if (type.IsUnsignedInt) { #>
+<#      if (!type.IsCLSCompliant) { #>
         [CLSCompliant(false)]
         [AtomicIntrinsic(AtomicIntrinsicKind.Max, AtomicFlags.Unsigned)]
 <#      } else if (type.IsInt) { #>
@@ -195,7 +195,7 @@ namespace ILGPU
         /// <param name="target">The target location.</param>
         /// <param name="value">The comparison value.</param>
         /// <returns>The old value that was stored at the target location.</returns>
-<#      if (type.IsUnsignedInt) { #>
+<#      if (!type.IsCLSCompliant) { #>
         [CLSCompliant(false)]
         [AtomicIntrinsic(AtomicIntrinsicKind.Min, AtomicFlags.Unsigned)]
 <#      } else if (type.IsInt) { #>
@@ -234,7 +234,7 @@ namespace ILGPU
         /// <param name="target">The target location.</param>
         /// <param name="value">The comparison value.</param>
         /// <returns>The old value that was stored at the target location.</returns>
-<#      if (type.IsUnsignedInt) { #>
+<#      if (!type.IsCLSCompliant) { #>
         [CLSCompliant(false)]
         [AtomicIntrinsic(AtomicIntrinsicKind.And, AtomicFlags.Unsigned)]
 <#      } else if (type.IsInt) { #>
@@ -273,7 +273,7 @@ namespace ILGPU
         /// <param name="target">The target location.</param>
         /// <param name="value">The comparison value.</param>
         /// <returns>The old value that was stored at the target location.</returns>
-<#      if (type.IsUnsignedInt) { #>
+<#      if (!type.IsCLSCompliant) { #>
         [CLSCompliant(false)]
         [AtomicIntrinsic(AtomicIntrinsicKind.Or, AtomicFlags.Unsigned)]
 <#      } else if (type.IsInt) { #>
@@ -312,7 +312,7 @@ namespace ILGPU
         /// <param name="target">The target location.</param>
         /// <param name="value">The comparison value.</param>
         /// <returns>The old value that was stored at the target location.</returns>
-<#      if (type.IsUnsignedInt) { #>
+<#      if (!type.IsCLSCompliant) { #>
         [CLSCompliant(false)]
         [AtomicIntrinsic(AtomicIntrinsicKind.Xor, AtomicFlags.Unsigned)]
 <#      } else if (type.IsInt) { #>
@@ -341,7 +341,7 @@ namespace ILGPU
         /// <param name="target">The target location.</param>
         /// <param name="value">The target value.</param>
         /// <returns>The old value.</returns>
-<#      if (type.IsUnsignedInt) { #>
+<#      if (!type.IsCLSCompliant) { #>
         [CLSCompliant(false)]
         [AtomicIntrinsic(AtomicIntrinsicKind.Exchange, AtomicFlags.Unsigned)]
 <#      } else if (type.IsInt) { #>

--- a/Src/ILGPU/HalfConversion.tt
+++ b/Src/ILGPU/HalfConversion.tt
@@ -92,12 +92,11 @@ namespace ILGPU
         #region Operators
 
 <# foreach (var type in IntTypes) { #>
-<#      bool clsCompliant = type.IsUnsignedInt || type == IntTypes[0]; #>
         /// <summary>
         /// Implicitly converts a half to type <#= type.Name #>.
         /// </summary>
         /// <param name="halfValue">The half to convert.</param>
-<#      if (clsCompliant) { #>
+<#      if (!type.IsCLSCompliant) { #>
         [CLSCompliant(false)]
 <#      } #>
 <#      if (type.IsUnsignedInt) { #>
@@ -113,7 +112,7 @@ namespace ILGPU
         /// Explicitly converts an instance of type <#= type.Name #> to a half.
         /// </summary>
         /// <param name="<#= type.Type #>Value">The value to convert.</param>
-<#      if (clsCompliant) { #>
+<#      if (!type.IsCLSCompliant) { #>
         [CLSCompliant(false)]
 <#      } #>
 <#      if (type.IsUnsignedInt) { #>

--- a/Src/ILGPU/Static/TypeInformation.ttinclude
+++ b/Src/ILGPU/Static/TypeInformation.ttinclude
@@ -59,6 +59,8 @@ public class TypeInformation
 
     public bool IsFloat => Kind == TypeInformationKind.Float;
 
+    public bool IsCLSCompliant => !(IsUnsignedInt || Name == "Int8");
+
     public string FormatNumber(string number) =>
         Prefix + "(" + number + Suffix + ")";
 };
@@ -81,9 +83,6 @@ public static readonly TypeInformation[] UnsignedIntTypes =
 
 public static readonly TypeInformation[] IntTypes =
     SignedIntTypes.Concat(UnsignedIntTypes).ToArray();
-
-public static readonly TypeInformation[] DefaultIntTypes =
-    SignedIntTypes.Skip(2).Concat(UnsignedIntTypes.Skip(2)).ToArray();
 
 public static readonly TypeInformation[] FloatTypes =
     {


### PR DESCRIPTION
Consolidates the logic of what is `CLSCompliant` to make maintenance easier.

Also removed `DefaultIntTypes` as it appears unused.