### PR TITLE
Check mismatch between version number and tag during CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,18 @@ jobs:
           nuget-version: '5.x'
       - name: Create NuGet package
         if: runner.os == 'Windows'
-        run: dotnet pack --configuration=Release Src
+        run: |
+          if ("${{ github.ref }}" -like "refs/tags/v*") {
+            $tag = "${{ github.ref }}".SubString(11)
+            $version = (Select-Xml -path Src/ILGPU/ILGPU.csproj -XPath "/Project/PropertyGroup/VersionPrefix/text()").node.Value
+            if (-not ($tag -eq $version)) {
+              echo "There is a mismatch between the project version ($version) and the tag ($tag)"
+              exit 1
+            }
+          } else {
+            $params = "--version-suffix", $(git rev-parse --short HEAD)
+          }
+          dotnet pack --configuration=Release @params Src
       - name: Fix NuGet Symbols Package
         if: runner.os == 'Windows'
         run: |

--- a/Src/ILGPU/ILGPU.csproj
+++ b/Src/ILGPU/ILGPU.csproj
@@ -9,7 +9,7 @@
 
     <PropertyGroup>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <Version>0.8.1.1</Version>
+        <VersionPrefix>0.8.1.1</VersionPrefix>
         <NeutralLanguage>en-US</NeutralLanguage>
         <!-- CAUTION: ILGPU supports a limited subset only - due to the .Net 4.7 backwards compatibility -->
         <LangVersion>8.0</LangVersion>


### PR DESCRIPTION
Also add a version suffix to CI build artifacts when building for a branch or a PR.