### PR TITLE
Fixed invalid offset computation of IL instructions.

### DIFF
--- a/Src/ILGPU/Frontend/ILInstruction.cs
+++ b/Src/ILGPU/Frontend/ILInstruction.cs
@@ -786,7 +786,7 @@ namespace ILGPU.Frontend
 
             // Compute detailed offset information for all flags
             for (
-                int i = (int)ILInstructionFlags.Unsigned;
+                int i = (int)ILInstructionFlags.Unchecked;
                 i < (int)ILInstructionFlags.Constrained;
                 i <<= 1)
             {


### PR DESCRIPTION
The patch #204 introduced a critical issue that is related to unsigned comparison-based branches. Due to the fact that different compilers sometimes emit unsigned branch statements in release builds, it is not possible to provide a deterministically executable test.