### PR TITLE
Ensure compiler exceptions are annotated with location information.

### DIFF
--- a/Src/ILGPU.Tests/KernelEntryPoints.cs
+++ b/Src/ILGPU.Tests/KernelEntryPoints.cs
@@ -491,8 +491,9 @@ namespace ILGPU.Tests
                 };
 
             using var buffer = Accelerator.Allocate<int>(length);
-            Assert.Throws<NotSupportedException>(() =>
+            var e = Assert.Throws<InternalCompilerException>(() =>
                 Execute(kernel.Method, new Index1((int)buffer.Length), buffer.View));
+            Assert.IsType<NotSupportedException>(e.InnerException);
         }
 
         [Theory]
@@ -510,8 +511,9 @@ namespace ILGPU.Tests
 
             var extent = new Index2(length, length);
             using var buffer = Accelerator.Allocate<int>(extent.Size);
-            Assert.Throws<NotSupportedException>(() =>
+            var e = Assert.Throws<InternalCompilerException>(() =>
                 Execute(kernel.Method, extent, buffer.View, extent));
+            Assert.IsType<NotSupportedException>(e.InnerException);
         }
 
         [Theory]
@@ -529,8 +531,9 @@ namespace ILGPU.Tests
 
             var extent = new Index3(length, length, length);
             using var buffer = Accelerator.Allocate<int>(extent.Size);
-            Assert.Throws<NotSupportedException>(() =>
+            var e = Assert.Throws<InternalCompilerException>(() =>
                 Execute(kernel.Method, extent, buffer.View, extent));
+            Assert.IsType<NotSupportedException>(e.InnerException);
         }
     }
 }

--- a/Src/ILGPU/Frontend/CodeGenerator/CodeGenerator.cs
+++ b/Src/ILGPU/Frontend/CodeGenerator/CodeGenerator.cs
@@ -303,7 +303,22 @@ namespace ILGPU.Frontend
                 Location = instruction.Location;
 
                 // Try to generate code for this instruction
-                if (!TryGenerateCode(instruction))
+                bool generated;
+                try
+                {
+                    generated = TryGenerateCode(instruction);
+                }
+                catch (InternalCompilerException)
+                {
+                    // If we already have an internal compiler exception, re-throw it.
+                    throw;
+                }
+                catch (Exception e)
+                {
+                    // Wrap generic exceptions with location information.
+                    throw Location.GetException(e);
+                }
+                if (!generated)
                 {
                     throw Location.GetNotSupportedException(
                         ErrorMessages.NotSupportedInstruction,

--- a/Src/ILGPU/IR/ILocation.cs
+++ b/Src/ILGPU/IR/ILocation.cs
@@ -40,21 +40,20 @@ namespace ILGPU.IR
         /// information.
         /// </summary>
         /// <param name="location">The current location.</param>
-        /// <param name="message">The error message.</param>
+        /// <param name="exception">The inner exception.</param>
         /// <returns>
-        /// A new exception of type <typeparamref name="TException"/> with detailed
-        /// origin information about the current source location at which this exception
-        /// has been created.
+        /// A new <see cref="InternalCompilerException"/> with an inner exception of
+        /// <paramref name="exception"/>. Includes detailed origin information about
+        /// the current source location at which this exception has been created.
         /// </returns>
-        public static TException GetException<TException>(
+        public static InternalCompilerException GetException(
             this ILocation location,
-            string message)
-            where TException : Exception
+            Exception exception)
         {
-            message = (location?.FormatErrorMessage(
-                message ?? ErrorMessages.InternalCompilerError))
+            var message = (location?.FormatErrorMessage(
+                ErrorMessages.InternalCompilerError))
                 ?? ErrorMessages.InternalCompilerError;
-            return Activator.CreateInstance(typeof(TException), message) as TException;
+            return new InternalCompilerException(message, exception);
         }
 
         /// <summary>
@@ -63,11 +62,14 @@ namespace ILGPU.IR
         /// </summary>
         /// <param name="location">The current location.</param>
         /// <param name="paramName">The parameter name.</param>
-        /// <returns>A new <see cref="ArgumentOutOfRangeException"/>.</returns>
-        public static ArgumentOutOfRangeException GetArgumentException(
+        /// <returns>
+        /// A new <see cref="InternalCompilerException"/> with an inner exception of
+        /// <see cref="ArgumentOutOfRangeException"/>.
+        /// </returns>
+        public static InternalCompilerException GetArgumentException(
             this ILocation location,
             string paramName) =>
-            location.GetException<ArgumentOutOfRangeException>(paramName);
+            location.GetException(new ArgumentOutOfRangeException(paramName));
 
         /// <summary>
         /// Constructs a new <see cref="ArgumentException"/> based on the given
@@ -75,11 +77,14 @@ namespace ILGPU.IR
         /// </summary>
         /// <param name="location">The current location.</param>
         /// <param name="paramName">The parameter name.</param>
-        /// <returns>A new <see cref="ArgumentException"/>.</returns>
-        public static ArgumentNullException GetArgumentNullException(
+        /// <returns>
+        /// A new <see cref="InternalCompilerException"/> with an inner exception of
+        /// <see cref="ArgumentNullException"/>.
+        /// </returns>
+        public static InternalCompilerException GetArgumentNullException(
             this ILocation location,
             string paramName) =>
-            location.GetException<ArgumentNullException>(paramName);
+            location.GetException(new ArgumentNullException(paramName));
 
         /// <summary>
         /// Constructs a new <see cref="NotSupportedException"/> based on the given
@@ -88,24 +93,30 @@ namespace ILGPU.IR
         /// <param name="location">The current location.</param>
         /// <param name="message">The main contents of the error message.</param>
         /// <param name="args">The formatting arguments.</param>
-        /// <returns>A new <see cref="NotSupportedException"/>.</returns>
-        public static NotSupportedException GetNotSupportedException(
+        /// <returns>
+        /// A new <see cref="InternalCompilerException"/> with an inner exception of
+        /// <see cref="NotSupportedException"/>.
+        /// </returns>
+        public static InternalCompilerException GetNotSupportedException(
             this ILocation location,
             string message,
             params object[] args) =>
-            location.GetException<NotSupportedException>(
-                string.Format(message, args));
+            location.GetException(new NotSupportedException(
+                string.Format(message, args)));
 
         /// <summary>
         /// Constructs a new <see cref="InvalidOperationException"/> that refers to an
         /// invalid compiler state.
         /// </summary>
         /// <param name="location">The current location.</param>
-        /// <returns>A new <see cref="InvalidOperationException"/>.</returns>
-        public static InvalidOperationException GetInvalidOperationException(
+        /// <returns>
+        /// A new <see cref="InternalCompilerException"/> with an inner exception of
+        /// <see cref="InvalidOperationException"/>.
+        /// </returns>
+        public static InternalCompilerException GetInvalidOperationException(
             this ILocation location) =>
-            location.GetException<InvalidOperationException>(
-                ErrorMessages.InternalCompilerError);
+            location.GetException(new InvalidOperationException(
+                ErrorMessages.InternalCompilerError));
 
         /// <summary>
         /// Constructs a new <see cref="InvalidOperationException"/> that refers to an
@@ -113,11 +124,14 @@ namespace ILGPU.IR
         /// </summary>
         /// <param name="location">The current location.</param>
         /// <param name="message">The main content of the error message.</param>
-        /// <returns>A new <see cref="InvalidOperationException"/>.</returns>
-        public static InvalidOperationException GetInvalidOperationException(
+        /// <returns>
+        /// A new <see cref="InternalCompilerException"/> with an inner exception of
+        /// <see cref="InvalidOperationException"/>.
+        /// </returns>
+        public static InternalCompilerException GetInvalidOperationException(
             this ILocation location,
             string message) =>
-            location.GetException<InvalidOperationException>(message);
+            location.GetException(new InvalidOperationException(message));
 
         /// <summary>
         /// Ensures that a certain reference value is not null.
@@ -134,8 +148,8 @@ namespace ILGPU.IR
         {
             if (value == null)
             {
-                throw location.GetException<InvalidOperationException>(
-                    ErrorMessages.InternalCompilerErrorNull);
+                throw location.GetException(new InvalidOperationException(
+                    ErrorMessages.InternalCompilerErrorNull));
             }
         }
 
@@ -155,8 +169,8 @@ namespace ILGPU.IR
         {
             if (!condition)
             {
-                throw location.GetException<InvalidOperationException>(
-                    ErrorMessages.InternalCompilerError);
+                throw location.GetException(new InvalidOperationException(
+                    ErrorMessages.InternalCompilerError));
             }
         }
     }

--- a/Src/ILGPU/InternalCompilerException.cs
+++ b/Src/ILGPU/InternalCompilerException.cs
@@ -1,0 +1,72 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                        Copyright (c) 2016-2020 Marcel Koester
+//                                    www.ilgpu.net
+//
+// File: InternalCompilerException.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+
+using System;
+using System.Runtime.Serialization;
+
+namespace ILGPU
+{
+    /// <summary>
+    /// The exception that is thrown when an internal compiler error has been detected.
+    /// </summary>
+    [Serializable]
+    public sealed class InternalCompilerException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the InternalCompilerException class.
+        /// </summary>
+        public InternalCompilerException()
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the InternalCompilerException class
+        /// with a specified error message.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public InternalCompilerException(string message)
+            : base(message)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the InternalCompilerException class
+        /// with a specified error message and a reference to the inner exception
+        /// that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">
+        /// The error message that explains the reason for the exception.
+        /// </param>
+        /// <param name="innerException">
+        /// The exception that is the cause of the current exception, or a null reference
+        /// if no inner exception is specified.
+        /// </param>
+        public InternalCompilerException(string message, Exception innerException)
+            : base(message, innerException)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the InternalCompilerException class with
+        /// serialized data.
+        /// </summary>
+        /// <param name="serializationInfo">
+        /// The System.Runtime.Serialization.SerializationInfo that holds the serialized
+        /// object data about the exception being thrown.
+        /// </param>
+        /// <param name="streamingContext">
+        /// The System.Runtime.Serialization.StreamingContext that contains contextual
+        /// information about the source or destination.
+        /// </param>
+        private InternalCompilerException(
+            SerializationInfo serializationInfo,
+            StreamingContext streamingContext)
+            : base(serializationInfo, streamingContext)
+        { }
+    }
+}


### PR DESCRIPTION
Attempts to trap all compiler exceptions, particularly those without location information, and generates a new `InternalCompilerException` with location information.

REQUEST FOR COMMENT: Naming of `ILGPU.InternalCompilerException`.