### PR TITLE
Fixed ability to override registration of Tanh PTX intrinsic

### DIFF
--- a/Src/ILGPU/IR/Intrinsics/IntrinsicImplementationManager.cs
+++ b/Src/ILGPU/IR/Intrinsics/IntrinsicImplementationManager.cs
@@ -56,13 +56,13 @@ namespace ILGPU.IR.Intrinsics
             /// </summary>
             public struct Enumerator : IEnumerator<IntrinsicImplementation>
             {
-                private HashSet<IntrinsicImplementation>.Enumerator enumerator;
+                private List<IntrinsicImplementation>.Enumerator enumerator;
 
                 /// <summary>
                 /// Constructs a new implementation enumerator.
                 /// </summary>
                 /// <param name="implementationSet">The implementations.</param>
-                internal Enumerator(HashSet<IntrinsicImplementation> implementationSet)
+                internal Enumerator(List<IntrinsicImplementation> implementationSet)
                 {
                     enumerator = implementationSet.GetEnumerator();
                 }
@@ -89,8 +89,8 @@ namespace ILGPU.IR.Intrinsics
 
             #region Instance
 
-            private readonly HashSet<IntrinsicImplementation> implementations =
-                new HashSet<IntrinsicImplementation>();
+            private readonly List<IntrinsicImplementation> implementations =
+                new List<IntrinsicImplementation>();
 
             #endregion
 
@@ -101,7 +101,10 @@ namespace ILGPU.IR.Intrinsics
             /// </summary>
             /// <param name="implementation">The implementation to register.</param>
             public void Register(IntrinsicImplementation implementation) =>
-                implementations.Add(
+                // NB: Prepend to the list so that we preference the last registered
+                // implementations.
+                implementations.Insert(
+                    0,
                     implementation
                     ?? throw new ArgumentNullException(nameof(implementation)));
 


### PR DESCRIPTION
In https://github.com/m4rs-mt/ILGPU/pull/187, we implemented support for the new Tanh PTX intrinsic. To prevent older Cuda architectures from incorrectly using this intrinsic, we also registered a custom intrinsic which throws `NotSupportedException`.

When we integrate with ILGPU.Algorithms, calling `EnableAlgorithms` will also register a custom intrinsic for Tanh. However, there is no specific rule for choosing which intrinsic to use.

This PR defines that the last registered intrinsic implementation is the preferred implementation.

A PR will also need to be raised in ILGPU.Algorithms to avoid registering the Tanh intrinsic if not required.