### PR TITLE
Fixed CL grid dimensions returning wrong values

### DIFF
--- a/Src/ILGPU.Tests/GridOperations.cs
+++ b/Src/ILGPU.Tests/GridOperations.cs
@@ -1,6 +1,4 @@
-﻿using ILGPU.IR.Values;
-using ILGPU.Runtime;
-using ILGPU.Runtime.OpenCL;
+﻿using ILGPU.Runtime;
 using System;
 using System.Diagnostics;
 using Xunit;

--- a/Src/ILGPU.Tests/GridOperations.cs
+++ b/Src/ILGPU.Tests/GridOperations.cs
@@ -58,27 +58,25 @@ namespace ILGPU.Tests
         internal static void GridLaunchDimensionKernel(ArrayView<int> data)
         {
             data[0] = Grid.DimX;
-            data[1] = Grid.DimY;
-            data[2] = Grid.DimZ;
         }
 
+        // This test is one-dimensional and uses small sizes for the sake of passing
+        // tests on the CI machine, but on a machine with more threads it works
+        // for higher dimensions and higher sizes.
         [Fact]
         public void GridLaunchDimension()
         {
-            using var buffer = Accelerator.Allocate<int>(3);
+            using var buffer = Accelerator.Allocate<int>(1);
             var kernel = Accelerator.LoadStreamKernel<ArrayView<int>>
                 (GridLaunchDimensionKernel);
 
-            kernel((new Index3(1, 2, 3), new Index3(4, 5, 6)), buffer.View);
+            kernel((1, 2), buffer.View); 
             Accelerator.Synchronize();
 
             var data = buffer.GetAsArray();
-            int[] expected = { 1, 2, 3 };
+            int expected = 1;
 
-            for(int i = 0; i < expected.Length; i++)
-            {
-                Assert.Equal(expected[i], data[i]);
-            }
+            Assert.Equal(expected, data[0]);
         }
     }
 }

--- a/Src/ILGPU.Tests/GridOperations.cs
+++ b/Src/ILGPU.Tests/GridOperations.cs
@@ -1,4 +1,5 @@
-﻿using ILGPU.Runtime;
+﻿using ILGPU.IR.Values;
+using ILGPU.Runtime;
 using ILGPU.Runtime.OpenCL;
 using System;
 using System.Diagnostics;
@@ -51,6 +52,32 @@ namespace ILGPU.Tests
                     extent.GridDim.Z,
                 };
                 Verify(buffer, expected);
+            }
+        }
+
+        internal static void GridLaunchDimensionKernel(ArrayView<int> data)
+        {
+            data[0] = Grid.DimX;
+            data[1] = Grid.DimY;
+            data[2] = Grid.DimZ;
+        }
+
+        [Fact]
+        public void GridLaunchDimension()
+        {
+            using var buffer = Accelerator.Allocate<int>(3);
+            var kernel = Accelerator.LoadStreamKernel<ArrayView<int>>
+                (GridLaunchDimensionKernel);
+
+            kernel((new Index3(1, 2, 3), new Index3(4, 5, 6)), buffer.View);
+            Accelerator.Synchronize();
+
+            var data = buffer.GetAsArray();
+            int[] expected = { 1, 2, 3 };
+
+            for(int i = 0; i < expected.Length; i++)
+            {
+                Assert.Equal(expected[i], data[i]);
             }
         }
     }

--- a/Src/ILGPU.Tests/GridOperations.cs
+++ b/Src/ILGPU.Tests/GridOperations.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using ILGPU.Runtime;
+using ILGPU.Runtime.OpenCL;
+using System;
 using System.Diagnostics;
 using Xunit;
 using Xunit.Abstractions;

--- a/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Values.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Values.cs
@@ -509,11 +509,22 @@ namespace ILGPU.Backends.OpenCL
                 value.Dimension);
 
         /// <summary cref="IBackendCodeGenerator.GenerateCode(GridDimensionValue)"/>
-        public void GenerateCode(GridDimensionValue value) =>
-            MakeIntrinsicValue(
-                value,
-                CLInstructions.GetGridSize,
-                value.Dimension);
+        public void GenerateCode(GridDimensionValue value)
+        {
+            var target = Allocate(value);
+            using var statement = BeginStatement(target);
+            statement.AppendCommand(CLInstructions.GetGridSize);
+            statement.BeginArguments();
+            statement.AppendCommand(((int)value.Dimension).ToString());
+            statement.EndArguments();
+
+            statement.AppendCommand("/");
+
+            statement.AppendCommand(CLInstructions.GetGroupSize);
+            statement.BeginArguments();
+            statement.AppendCommand(((int)value.Dimension).ToString());
+            statement.EndArguments();
+        }
 
         /// <summary cref="IBackendCodeGenerator.GenerateCode(GroupDimensionValue)"/>
         public void GenerateCode(GroupDimensionValue value) =>

--- a/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Values.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Values.cs
@@ -509,22 +509,8 @@ namespace ILGPU.Backends.OpenCL
                 value.Dimension);
 
         /// <summary cref="IBackendCodeGenerator.GenerateCode(GridDimensionValue)"/>
-        public void GenerateCode(GridDimensionValue value)
-        {
-            var target = Allocate(value);
-            using var statement = BeginStatement(target);
-            statement.AppendCommand(CLInstructions.GetGridSize);
-            statement.BeginArguments();
-            statement.AppendCommand(((int)value.Dimension).ToString());
-            statement.EndArguments();
-
-            statement.AppendCommand("/");
-
-            statement.AppendCommand(CLInstructions.GetGroupSize);
-            statement.BeginArguments();
-            statement.AppendCommand(((int)value.Dimension).ToString());
-            statement.EndArguments();
-        }
+        public void GenerateCode(GridDimensionValue value) =>
+            MakeIntrinsicValue(value, CLInstructions.GetGridSize, value.Dimension);
 
         /// <summary cref="IBackendCodeGenerator.GenerateCode(GroupDimensionValue)"/>
         public void GenerateCode(GroupDimensionValue value) =>

--- a/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Values.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Values.cs
@@ -510,7 +510,10 @@ namespace ILGPU.Backends.OpenCL
 
         /// <summary cref="IBackendCodeGenerator.GenerateCode(GridDimensionValue)"/>
         public void GenerateCode(GridDimensionValue value) =>
-            MakeIntrinsicValue(value, CLInstructions.GetGridSize, value.Dimension);
+            MakeIntrinsicValue(
+                value,
+                CLInstructions.GetGridSize,
+                value.Dimension);
 
         /// <summary cref="IBackendCodeGenerator.GenerateCode(GroupDimensionValue)"/>
         public void GenerateCode(GroupDimensionValue value) =>

--- a/Src/ILGPU/Backends/OpenCL/CLInstructions.Data.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLInstructions.Data.cs
@@ -125,7 +125,7 @@ namespace ILGPU.Backends.OpenCL
         /// <summary>
         /// Resolves the current grid size.
         /// </summary>
-        public const string GetGridSize = "get_global_size";
+        public const string GetGridSize = "get_num_groups";
 
         /// <summary>
         /// Resolves the current grid index.


### PR DESCRIPTION
This closes #223 . At the moment, it's sort of janky and I would like everyone's advice on how this can be better accomplished. Essentially, the issue was that OpenCL's `get_global_size` returns the number of total threads launched across all blocks, not the number of blocks. In order to fix this, I just divided by the number of threads per block. Because of this, the method that generates `Grid` now looks kind of messy, as I couldn't find any existing functionality to do what is necessary. I'm not sure exactly how to refactor this so it's cleaner, so your input would be appreciated. I have tested it and it does work for single- and multi-dimensional data. I also want to thank @MoFtZ for helping me tremendously with understanding the backend and helping solve this issue.