### PR TITLE
Fixed and used UtilityIntrinsic implementation.

### DIFF
--- a/Src/ILGPU/Frontend/Intrinsic/UtilityIntrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/UtilityIntrinsics.cs
@@ -30,7 +30,7 @@ namespace ILGPU.Frontend.Intrinsic
             IntrinsicKind = kind;
         }
 
-        public override IntrinsicType Type => IntrinsicType.Atomic;
+        public override IntrinsicType Type => IntrinsicType.Utility;
 
         /// <summary>
         /// Returns the associated intrinsic kind.

--- a/Src/ILGPU/Util/Utilities.cs
+++ b/Src/ILGPU/Util/Utilities.cs
@@ -9,6 +9,7 @@
 // Source License. See LICENSE.txt for details
 // ---------------------------------------------------------------------------------------
 
+using ILGPU.Frontend.Intrinsic;
 using System;
 using System.Runtime.CompilerServices;
 
@@ -62,6 +63,7 @@ namespace ILGPU.Util
         /// <remarks>
         /// Note that this function will be mapped to the ILGPU IR.
         /// </remarks>
+        [UtilityIntrinsic(UtilityIntrinsicKind.Select)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static T Select<T>(bool takeFirst, T first, T second) =>
             takeFirst ? first : second;


### PR DESCRIPTION
The `UtilityIntrinsicAttribute` marks utility intrinsics and offers the opportunity to construct the built-in `Select` instruction. This PR fixes the `UtilityIntrinsicAttribute` and applies it to the `Utilities.Select` operation.