### PR TITLE
Fixes for MemoryBuffer range checks and 32-bit offsets

### DIFF
--- a/Src/ILGPU.Tests/MemoryBufferOperations.tt
+++ b/Src/ILGPU.Tests/MemoryBufferOperations.tt
@@ -128,6 +128,8 @@ namespace ILGPU.Tests
                 dst.<#= copyOperation #>(src, Index1.Zero, Index1.Zero, new Index1(-1)));
             Assert.Throws<ArgumentOutOfRangeException>("extent", () =>
                 dst.<#= copyOperation #>(src, Index1.Zero, Index1.Zero, new Index1(x + 1)));
+            Assert.Throws<ArgumentOutOfRangeException>("extent", () =>
+                dst.<#= copyOperation #>(src, Index1.Zero, new Index1(x - 1), new Index1(2)));
 
             // Partial copy
             var half = new Index1(x / 2);

--- a/Src/ILGPU/Runtime/MemoryBuffer.cs
+++ b/Src/ILGPU/Runtime/MemoryBuffer.cs
@@ -219,7 +219,7 @@ namespace ILGPU.Runtime
             CopyToView(
                 stream,
                 target.AsLinearView(),
-                sourceOffset.ComputeLinearIndex(Extent));
+                sourceOffset.ComputeLongLinearIndex(Extent));
         }
 
         /// <summary>
@@ -257,7 +257,7 @@ namespace ILGPU.Runtime
             CopyFromView(
                 stream,
                 source.AsLinearView(),
-                targetOffset.ComputeLinearIndex(Extent));
+                targetOffset.ComputeLongLinearIndex(Extent));
         }
 
         #endregion
@@ -384,9 +384,10 @@ namespace ILGPU.Runtime
                 throw new ArgumentOutOfRangeException(nameof(sourceOffset));
             if (!targetOffset.InBounds(target.Extent))
                 throw new ArgumentOutOfRangeException(nameof(targetOffset));
-            var linearSourceIndex = sourceOffset.ComputeLinearIndex(Extent);
+            var linearSourceIndex = sourceOffset.ComputeLongLinearIndex(Extent);
+            var linearTargetIndex = targetOffset.ComputeLongLinearIndex(target.Extent);
             if (linearSourceIndex + extent > Length ||
-                targetOffset.ComputeLinearIndex(target.Extent) + extent > target.Length)
+                linearTargetIndex + extent > target.Length)
             {
                 throw new ArgumentOutOfRangeException(nameof(extent));
             }
@@ -428,7 +429,7 @@ namespace ILGPU.Runtime
                 CopyToView(
                     stream,
                     new ArrayView<T>(wrapper, 0, 1),
-                    targetIndex.ComputeLinearIndex(Extent));
+                    targetIndex.ComputeLongLinearIndex(Extent));
             }
             stream.Synchronize();
         }
@@ -495,7 +496,7 @@ namespace ILGPU.Runtime
                         stream,
                         new ArrayView<T>(wrapper, 0, length).GetSubView(
                             targetOffset, extent.Size),
-                        sourceOffset.ComputeLinearIndex(Extent));
+                        sourceOffset.ComputeLongLinearIndex(Extent));
                 }
                 stream.Synchronize();
             }
@@ -647,7 +648,7 @@ namespace ILGPU.Runtime
             CopyFromView(
                 stream,
                 new ArrayView<T>(wrapper, 0, 1),
-                sourceIndex.ComputeLinearIndex(Extent));
+                sourceIndex.ComputeLongLinearIndex(Extent));
             stream.Synchronize();
         }
 

--- a/Src/ILGPU/Runtime/MemoryBuffer.cs
+++ b/Src/ILGPU/Runtime/MemoryBuffer.cs
@@ -386,7 +386,7 @@ namespace ILGPU.Runtime
                 throw new ArgumentOutOfRangeException(nameof(targetOffset));
             var linearSourceIndex = sourceOffset.ComputeLinearIndex(Extent);
             if (linearSourceIndex + extent > Length ||
-                targetOffset.ComputeLinearIndex(target.Extent) + extent > Length)
+                targetOffset.ComputeLinearIndex(target.Extent) + extent > target.Length)
             {
                 throw new ArgumentOutOfRangeException(nameof(extent));
             }
@@ -478,8 +478,12 @@ namespace ILGPU.Runtime
             var length = target.LongLength;
             if (targetOffset < 0 || targetOffset >= length)
                 throw new ArgumentOutOfRangeException(nameof(targetOffset));
-            if (extent.Size < 1 || !sourceOffset.Add(extent).InBoundsInclusive(Extent))
+            if (extent.Size < 1 ||
+                targetOffset + extent.Size > length ||
+                !sourceOffset.Add(extent).InBoundsInclusive(Extent))
+            {
                 throw new ArgumentOutOfRangeException(nameof(extent));
+            }
 
             Debug.Assert(target.Rank == 1);
 
@@ -688,12 +692,15 @@ namespace ILGPU.Runtime
             var length = source.LongLength;
             if (sourceOffset < 0 || sourceOffset >= length)
                 throw new ArgumentOutOfRangeException(nameof(sourceOffset));
-            if (!targetOffset.InBounds(Extent))
+            var linearIndex = targetOffset.ComputeLongLinearIndex(Extent);
+            if (!targetOffset.InBounds(Extent) || linearIndex >= Length)
                 throw new ArgumentOutOfRangeException(nameof(targetOffset));
-            if (extent < 1 || extent > source.LongLength)
+            if (extent < 1 || extent > source.LongLength ||
+                extent + sourceOffset > source.LongLength ||
+                linearIndex + extent > Length)
+            {
                 throw new ArgumentOutOfRangeException(nameof(extent));
-            if (sourceOffset + extent < 1 || extent + sourceOffset > source.LongLength)
-                throw new ArgumentOutOfRangeException(nameof(sourceOffset));
+            }
 
             fixed (T* ptr = &source[0])
             {
@@ -703,7 +710,7 @@ namespace ILGPU.Runtime
                     new ArrayView<T>(wrapper, 0, source.Length).GetSubView(
                         sourceOffset,
                         extent),
-                    targetOffset.ComputeLongLinearIndex(Extent));
+                    linearIndex);
                 stream.Synchronize();
             }
         }

--- a/Src/ILGPU/Runtime/MemoryBuffers.tt
+++ b/Src/ILGPU/Runtime/MemoryBuffers.tt
@@ -450,7 +450,7 @@ namespace ILGPU.Runtime
         public void CopyTo(
             T[] target,
             <#= indexType #> sourceOffset,
-            int targetOffset,
+            long targetOffset,
             <#= indexType #> extent) =>
             buffer.CopyTo(
                 target,
@@ -471,7 +471,7 @@ namespace ILGPU.Runtime
             AcceleratorStream stream,
             T[] target,
             <#= indexType #> sourceOffset,
-            int targetOffset,
+            long targetOffset,
             <#= indexType #> extent) =>
             buffer.CopyTo(
                 stream,


### PR DESCRIPTION
This PR updates obsolete 32-bit offsets and invalid range checks in current `MemoryBuffer` implementations.

Test cases are missing from the current PR and will be added in future commits.