### PR TITLE
Fixed implementation of Rem intrinsic

### DIFF
--- a/Src/ILGPU/Backends/OpenCL/CLInstructions.Data.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLInstructions.Data.cs
@@ -348,7 +348,7 @@ namespace ILGPU.Backends.OpenCL
                 { (BinaryArithmeticKind.Div, true), ("/", false) },
 
                 { (BinaryArithmeticKind.Rem, false), ("%", false) },
-                { (BinaryArithmeticKind.Rem, true), ("remainder", true) },
+                { (BinaryArithmeticKind.Rem, true), ("fmod", true) },
 
                 { (BinaryArithmeticKind.And, false), ("&", false) },
                 { (BinaryArithmeticKind.Or, false), ("|", false) },

--- a/Src/ILGPU/Static/BinaryMathOperations.xml
+++ b/Src/ILGPU/Static/BinaryMathOperations.xml
@@ -25,7 +25,7 @@
         <Flags>IntsAndFloats</Flags>
         <Op>{Value0} % {Value1}</Op>
         <Call>IntrinsicMath.CPUOnly.Rem</Call>
-        <Implementation>{MathType}.IEEERemainder({Value0}, {Value1})</Implementation>
+        <Implementation>{Value0} % {Value1}</Implementation>
     </Operation>
 
     <Operation Name="And">


### PR DESCRIPTION
[OpCodes.Rem](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.rem) is defined as [floating point remainder operator](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/arithmetic-operators#remainder-operator-) rather than [IEEERemainder](https://docs.microsoft.com/en-us/dotnet/api/system.math.ieeeremainder).

This fixes the ILGPU-side of https://github.com/m4rs-mt/ILGPU.Algorithms/issues/43.