### PR TITLE
Fixed invalid sign extension of UInt8 and UInt16 values in calls.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -272,6 +272,7 @@ Src/ILGPU/Util/PrimitiveDataBlocks.cs
 Src/ILGPU.Tests/Generic/ConfigurationBase.cs
 Src/ILGPU.Tests/AtomicCASOperations.cs
 Src/ILGPU.Tests/AtomicOperations.cs
+Src/ILGPU.Tests/BasicCalls.Generated.cs
 Src/ILGPU.Tests/BinaryIntOperations.cs
 Src/ILGPU.Tests/CompareFloatOperations.cs
 Src/ILGPU.Tests/CompareIntOperations.cs

--- a/Src/ILGPU.Tests/BasicCalls.Generated.tt
+++ b/Src/ILGPU.Tests/BasicCalls.Generated.tt
@@ -1,0 +1,71 @@
+﻿<#@ template debug="false" hostspecific="true" language="C#" #>
+<#@ include file="Generic/ConfigurationBase.tt" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.IO" #>
+<#@ output extension=".cs" #>
+<# var smallIntTypes =
+    // sbyte and short
+    SignedIntTypes.Take(2).Concat(
+    // byte and ushort
+    UnsignedIntTypes.Take(2)).ToArray(); #>
+using ILGPU.Runtime;
+using System.Linq;
+using Xunit;
+
+namespace ILGPU.Tests
+{
+    partial class BasicCalls
+    {
+        private static T GetCallValue<T, TStructure>(TStructure value)
+            where T : struct
+            where TStructure : struct, IValueStructure<T> =>
+            value.NestedValue;
+
+<# foreach (var type in smallIntTypes) { #>
+<#      var structName = $"TestStruct<{type.Type}>"; #>
+        internal static void CallReturn<#= type.Name #>Kernel(
+            Index1 index,
+            ArrayView<<#= structName #>> source,
+            ArrayView<<#= type.Type #>> target1,
+            ArrayView<<#= type.Type #>> target2)
+        {
+            float val1 = source[index].Val1;
+            target1[index] = (<#= type.Type #>)val1;
+
+            float val2 = GetCallValue<
+                <#= type.Type #>,
+                TestStruct<<#= type.Type #>>>(source[index]);
+            target2[index] = (<#= type.Type #>)val2;
+        }
+
+        [Theory]
+<#      if (type.Kind == TypeInformationKind.SignedInt) { #>
+        [InlineData(0)]
+<#      } #>
+        [InlineData(<#= type.Type #>.MinValue)]
+        [InlineData(<#= type.Type #>.MaxValue)]
+        [KernelMethod(nameof(CallReturn<#= type.Name #>Kernel))]
+        public void CallReturn<#= type.Name #>(<#= type.Type #> value)
+        {
+            var dataStruct = new <#= structName #>()
+            {
+                Val0 = byte.MaxValue,
+                Val1 = value,
+                Val2 = short.MaxValue,
+            };
+
+            using var source = Accelerator.Allocate<<#= structName #>>(
+                Enumerable.Repeat(dataStruct, Length).ToArray());
+            using var target1 = Accelerator.Allocate<<#= type.Type #>>(Length);
+            using var target2 = Accelerator.Allocate<<#= type.Type #>>(Length);
+
+            Execute(source.Length, source.View, target1.View, target2.View);
+
+            var expected = Enumerable.Repeat(dataStruct.Val1, Length).ToArray();
+            Verify(target1, expected);
+            Verify(target2, expected);
+        }
+
+<# } #>
+    }
+}

--- a/Src/ILGPU.Tests/BasicCalls.cs
+++ b/Src/ILGPU.Tests/BasicCalls.cs
@@ -5,7 +5,7 @@ using Xunit.Abstractions;
 
 namespace ILGPU.Tests
 {
-    public abstract class BasicCalls : TestBase
+    public abstract partial class BasicCalls : TestBase
     {
         private const int Length = 32;
 

--- a/Src/ILGPU.Tests/ILGPU.Tests.csproj
+++ b/Src/ILGPU.Tests/ILGPU.Tests.csproj
@@ -109,6 +109,11 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>AtomicOperations.tt</DependentUpon>
     </Compile>
+    <Compile Update="BasicCalls.Generated.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>BasicCalls.Generated.tt</DependentUpon>
+    </Compile>
     <Compile Update="BinaryIntOperations.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
@@ -205,6 +210,10 @@
     <None Update="ReinterpretCasts.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>ReinterpretCasts.cs</LastGenOutput>
+    </None>
+    <None Update="BasicCalls.Generated.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>BasicCalls.Generated.cs</LastGenOutput>
     </None>
     <None Update="UnaryIntOperations.tt">
       <Generator>TextTemplatingFileGenerator</Generator>

--- a/Src/ILGPU/Frontend/CodeGenerator/Calls.cs
+++ b/Src/ILGPU/Frontend/CodeGenerator/Calls.cs
@@ -11,7 +11,9 @@
 
 using ILGPU.Frontend.Intrinsic;
 using ILGPU.IR;
+using ILGPU.IR.Values;
 using ILGPU.Resources;
+using ILGPU.Util;
 using System;
 using System.Reflection;
 using ValueList = ILGPU.Util.InlineList<ILGPU.IR.Values.ValueReference>;
@@ -56,7 +58,12 @@ namespace ILGPU.Frontend
 
             // Setup result
             if (result.IsValid && !result.Type.IsVoidType)
-                Block.Push(result);
+            {
+                var flags = method.GetReturnType().IsUnsignedInt()
+                    ? ConvertFlags.SourceUnsigned
+                    : ConvertFlags.None;
+                Block.Push(LoadOntoEvaluationStack(result, flags));
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This PR resolves the issues of value rounding described in #221. The problem is related to an invalid sign extension of `byte` and `ushort` values returned by functions.