### PR TITLE
Highlight line length errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
                 Foreach ($line in Get-Content $file)
                 {
                   If ($line.Length -gt 90) {
-                    Write-Host "${file}:${index}: line too long ($($line.Length) > 90 characters)"
+                    Write-Host "##[error]${file}:${index}: line too long ($($line.Length) > 90 characters)"
                     $found = $true
                   }
                   $index++


### PR DESCRIPTION
When a file has lines that are too long, the check-style CI job will fail.
This PR also writes the `##[error]` prefix, which Github recognises, and wil provide additional UI rather than reading the raw logs.

See https://github.com/MoFtZ/ILGPU/actions/runs/213521018 for an example.