### PR TITLE
Highlight unit test failures.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Release Build
         run: dotnet build --configuration=Release -p:TreatWarningsAsErrors=true Src
       - name: CPU Tests
-        run: dotnet test --configuration=Release ./Src/ILGPU.Tests.CPU
+        run: dotnet test --logger GitHubActions --configuration=Release ./Src/ILGPU.Tests.CPU
       - name: Set up NuGet
         if: runner.os == 'Windows'
         uses: nuget/setup-nuget@v1

--- a/Src/ILGPU.Tests.CPU/ILGPU.Tests.CPU.csproj
+++ b/Src/ILGPU.Tests.CPU/ILGPU.Tests.CPU.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="GitHubActionsTestLogger" Version="1.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Src/ILGPU.Tests.Cuda/ILGPU.Tests.Cuda.csproj
+++ b/Src/ILGPU.Tests.Cuda/ILGPU.Tests.Cuda.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="GitHubActionsTestLogger" Version="1.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Src/ILGPU.Tests.OpenCL/ILGPU.Tests.OpenCL.csproj
+++ b/Src/ILGPU.Tests.OpenCL/ILGPU.Tests.OpenCL.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="GitHubActionsTestLogger" Version="1.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Src/ILGPU.Tests/ILGPU.Tests.csproj
+++ b/Src/ILGPU.Tests/ILGPU.Tests.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="GitHubActionsTestLogger" Version="1.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
This PR adds a nuget package to the test projects that injects a custom logger that emits the correct messages for Github.

https://github.com/Tyrrrz/GitHubActionsTestLogger

See https://github.com/MoFtZ/ILGPU/runs/998231316?check_suite_focus=true for an example.