### PR TITLE
Fixed missing implicit casts on ExchangeBuffers.

### DIFF
--- a/Src/ILGPU/Runtime/ExchangeBuffer.cs
+++ b/Src/ILGPU/Runtime/ExchangeBuffer.cs
@@ -332,26 +332,6 @@ namespace ILGPU.Runtime
 
         #endregion
 
-        #region Operators
-
-        /// <summary>
-        /// Implicitly converts this buffer into a generic array view.
-        /// </summary>
-        /// <param name="buffer">The source buffer.</param>
-        public static implicit operator ArrayView<T, TIndex>(
-            ExchangeBufferBase<T, TIndex> buffer) =>
-            buffer.View;
-
-        /// <summary>
-        /// Implicitly converts this buffer into a memory buffer.
-        /// </summary>
-        /// <param name="buffer">The source buffer.</param>
-        public static implicit operator MemoryBuffer<T, TIndex>(
-            ExchangeBufferBase<T, TIndex> buffer) =>
-            buffer.Buffer;
-
-        #endregion
-
         #region IDisposable
 
         /// <summary cref="DisposeBase.Dispose(bool)"/>

--- a/Src/ILGPU/Runtime/ExchangeBufferExtensions.tt
+++ b/Src/ILGPU/Runtime/ExchangeBufferExtensions.tt
@@ -177,6 +177,26 @@ namespace ILGPU.Runtime
         }
 
 <#}#>        #endregion
+
+        #region Operators
+
+        /// <summary>
+        /// Implicitly converts this buffer into a generic array view.
+        /// </summary>
+        /// <param name="buffer">The source buffer.</param>
+        public static implicit operator ArrayView<T, <#= indexName #>>(
+            <#= typeName #><T> buffer) =>
+            buffer.View;
+
+        /// <summary>
+        /// Implicitly converts this buffer into a memory buffer.
+        /// </summary>
+        /// <param name="buffer">The source buffer.</param>
+        public static implicit operator MemoryBuffer<T, <#= indexName #>>(
+            <#= typeName #><T> buffer) =>
+            buffer.Buffer;
+
+        #endregion
     }
 <#}
 #>}


### PR DESCRIPTION
In ILGPU v0.8.x, the `ExchangeBuffer` class provided an implicit cast to 'ArrayView' and 'MemoryBuffer'. Since upgrading to ILGPU v0.9.0, I'm getting compiler issues because the implicit cast no longer exists.

Moved the implicit cast from the base class to the derived classes.