### PR TITLE
Fixed incorrect field access on structures with multiple fixed buffers.

### DIFF
--- a/Src/ILGPU.Tests/FixedBuffers.tt
+++ b/Src/ILGPU.Tests/FixedBuffers.tt
@@ -3,6 +3,7 @@
 <#@ assembly name="System.Core" #>
 <#@ import namespace="System.IO" #>
 <#@ output extension=".cs" #>
+using ILGPU.Runtime;
 using System;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -57,6 +58,63 @@ namespace ILGPU.Tests
             Equals(fixedStruct);
     }
 
+    public unsafe struct MultiFixedBufferStruct<#= type.Name #> :
+        IXunitSerializable,
+        IEquatable<MultiFixedBufferStruct<#= type.Name #>>
+    {
+        public fixed <#= type.Type #> A[FixedBuffers.Length];
+        public fixed <#= type.Type #> B[FixedBuffers.Length];
+        public fixed <#= type.Type #> C[FixedBuffers.Length];
+
+        public MultiFixedBufferStruct<#= type.Name #>(<#= type.Type #> data)
+        {
+            for (int i = 0; i < FixedBuffers.Length; ++i)
+            {
+                A[i] = data++;
+                B[i] = data++;
+                C[i] = data++;
+            }
+        }
+
+        public void Deserialize(IXunitSerializationInfo info)
+        {
+            for (int i = 0; i < FixedBuffers.Length; ++i)
+            {
+                A[i] = info.GetValue<<#= type.Type #>>(nameof(A) + i);
+                B[i] = info.GetValue<<#= type.Type #>>(nameof(B) + i);
+                C[i] = info.GetValue<<#= type.Type #>>(nameof(C) + i);
+            }
+        }
+
+        public void Serialize(IXunitSerializationInfo info)
+        {
+            for (int i = 0; i < FixedBuffers.Length; ++i)
+            {
+                info.AddValue(nameof(A) + i, A[i]);
+                info.AddValue(nameof(B) + i, B[i]);
+                info.AddValue(nameof(C) + i, C[i]);
+            }
+        }
+
+        public bool Equals(MultiFixedBufferStruct<#= type.Name #> buffer)
+        {
+            for (int i = 0; i < FixedBuffers.Length; ++i)
+            {
+                if (A[i] != buffer.A[i])
+                    return false;
+                if (B[i] != buffer.B[i])
+                    return false;
+                if (C[i] != buffer.C[i])
+                    return false;
+            }
+            return true;
+        }
+
+        public override bool Equals(object obj) =>
+            obj is MultiFixedBufferStruct<#= type.Name #> fixedStruct &&
+            Equals(fixedStruct);
+    }
+
 <# } #>
 
     public unsafe abstract class FixedBuffers : TestBase
@@ -106,6 +164,81 @@ namespace ILGPU.Tests
                 Length).ToArray();
             Verify(buffer1, expected1);
             Verify(buffer2, expected2);
+        }
+
+        internal static void GetMultiFixedBuffer<#= type.Name #>Kernel(
+            Index1 index,
+            ArrayView<<#= type.Type #>> data,
+            ArrayView<<#= type.Type #>> data2,
+            ArrayView<<#= type.Type #>> data3,
+            MultiFixedBufferStruct<#= type.Name #> value,
+            <#= type.Type #> scalarValue)
+        {
+            data[index] = value.A[index];
+            data2[index] = value.B[index];
+            data3[index] = value.C[index];
+        }
+
+        [Fact]
+        [KernelMethod(nameof(GetMultiFixedBuffer<#= type.Name #>Kernel))]
+        public void GetMultiFixedBuffer<#= type.Name #>()
+        {
+            using var buffer1 = Accelerator.Allocate<<#= type.Type #>>(Length);
+            using var buffer2 = Accelerator.Allocate<<#= type.Type #>>(Length);
+            using var buffer3 = Accelerator.Allocate<<#= type.Type #>>(Length);
+
+            <#= type.Type #> scalarValue = 2;
+            var fixedBufferData = new MultiFixedBufferStruct<#= type.Name #>(scalarValue);
+            Execute(
+                Length,
+                buffer1.View,
+                buffer2.View,
+                buffer3.View,
+                fixedBufferData,
+                scalarValue);
+
+            var expected1 = new <#= type.Type #>[] { 2, 5, 8, 11, 14, 17, 20, 23, 26 };
+            var expected2 = new <#= type.Type #>[] { 3, 6, 9, 12, 15, 18, 21, 24, 27 };
+            var expected3 = new <#= type.Type #>[] { 4, 7, 10, 13, 16, 19, 22, 25, 28 };
+            Verify(buffer1, expected1);
+            Verify(buffer2, expected2);
+            Verify(buffer3, expected3);
+        }
+
+        internal static void SetMultiFixedBuffer<#= type.Name #>Kernel(
+            Index1 index,
+            ArrayView<<#= type.Type #>> data,
+            ArrayView<<#= type.Type #>> data2,
+            ArrayView<<#= type.Type #>> data3,
+            ArrayView<MultiFixedBufferStruct<#= type.Name #>> values)
+        {
+            values[0].A[index] = data[index];
+            values[0].B[index] = data2[index];
+            values[0].C[index] = data3[index];
+        }
+
+        [Fact]
+        [KernelMethod(nameof(SetMultiFixedBuffer<#= type.Name #>Kernel))]
+        public void SetMultiFixedBuffer<#= type.Name #>()
+        {
+            var expected1 = new <#= type.Type #>[] { 2, 5, 8, 11, 14, 17, 20, 23, 26 };
+            var expected2 = new <#= type.Type #>[] { 3, 6, 9, 12, 15, 18, 21, 24, 27 };
+            var expected3 = new <#= type.Type #>[] { 4, 7, 10, 13, 16, 19, 22, 25, 28 };
+            using var buffer1 = Accelerator.Allocate(expected1);
+            using var buffer2 = Accelerator.Allocate(expected2);
+            using var buffer3 = Accelerator.Allocate(expected3);
+            using var fixedBuffers =
+                Accelerator.Allocate<MultiFixedBufferStruct<#= type.Name #>>(1);
+
+            Execute(Length, buffer1.View, buffer2.View, buffer3.View, fixedBuffers.View);
+                
+            <#= type.Type #> scalarValue = 2;
+            var expected =
+                new[]
+                {
+                    new MultiFixedBufferStruct<#= type.Name #>(scalarValue)
+                };
+            Verify(fixedBuffers, expected);
         }
 <# } #>
     }

--- a/Src/ILGPU/Backends/OpenCL/CLTypeGenerator.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLTypeGenerator.cs
@@ -263,6 +263,10 @@ namespace ILGPU.Backends.OpenCL
 
                 clName = CLInstructions.StructTypePrefix + " " + GetTypeName(typeNode);
             }
+            else if (typeNode is PaddingType paddingType)
+            {
+                clName = GetOrCreateType(paddingType.PrimitiveType);
+            }
             else
             {
                 // Must be a not supported view type

--- a/Src/ILGPU/Backends/RegisterAllocator.cs
+++ b/Src/ILGPU/Backends/RegisterAllocator.cs
@@ -396,6 +396,10 @@ namespace ILGPU.Backends
                 case PointerType _:
                 case StringType _:
                     return AllocateType(Backend.PointerType);
+                case PaddingType paddingType:
+                    var paddingRegisterKind =
+                        ResolveRegisterDescription(paddingType.PrimitiveType);
+                    return AllocateRegister(paddingRegisterKind);
                 default:
                     throw new NotSupportedException();
             }

--- a/Src/ILGPU/Backends/VariableAllocator.cs
+++ b/Src/ILGPU/Backends/VariableAllocator.cs
@@ -264,6 +264,8 @@ namespace ILGPU.Backends
                     primitiveType.BasicValueType),
                 PointerType pointerType => AllocatePointerType(pointerType),
                 ObjectType objectType => new ObjectVariable(idCounter++, objectType),
+                PaddingType paddingType => AllocateType(
+                    paddingType.PrimitiveType.BasicValueType),
                 _ => throw new NotSupportedException(),
             };
 

--- a/Src/ILGPU/Frontend/CodeGenerator/Fields.cs
+++ b/Src/ILGPU/Frontend/CodeGenerator/Fields.cs
@@ -10,6 +10,7 @@
 // ---------------------------------------------------------------------------------------
 
 using ILGPU.IR;
+using ILGPU.IR.Types;
 using ILGPU.IR.Values;
 using ILGPU.Util;
 using System.Reflection;
@@ -77,6 +78,13 @@ namespace ILGPU.Frontend
             var typeInfo = Context.TypeContext.GetTypeInfo(field.FieldType);
             var parentInfo = Context.TypeContext.GetTypeInfo(parentType);
             int absoluteIndex = parentInfo.GetAbsoluteIndex(field);
+
+            if (targetPointerType.ElementType.IsStructureType)
+            {
+                var structureType =
+                    targetPointerType.ElementType.As<StructureType>(Location);
+                absoluteIndex = structureType.RemapFieldIndex(absoluteIndex);
+            }
 
             var fieldAddress = Builder.CreateLoadFieldAddress(
                 Location,

--- a/Src/ILGPU/IR/Types/IRTypeContext.cs
+++ b/Src/ILGPU/IR/Types/IRTypeContext.cs
@@ -103,6 +103,8 @@ namespace ILGPU.IR.Types
                         (int)BasicValueType.Float32];
             }
 
+            PaddingType = new PaddingType(this, GetPrimitiveType(BasicValueType.Int8));
+
             PopulateTypeMapping();
         }
 
@@ -138,7 +140,7 @@ namespace ILGPU.IR.Types
         /// <summary>
         /// Returns a custom padding type that is used to pad structure values.
         /// </summary>
-        public TypeNode PaddingType => GetPrimitiveType(BasicValueType.Int8);
+        public TypeNode PaddingType { get; }
 
         #endregion
 

--- a/Src/ILGPU/IR/Types/PaddingType.cs
+++ b/Src/ILGPU/IR/Types/PaddingType.cs
@@ -1,0 +1,79 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                        Copyright (c) 2016-2020 Marcel Koester
+//                                    www.ilgpu.net
+//
+// File: PaddingType.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+
+using ILGPU.Util;
+using System;
+
+namespace ILGPU.IR.Types
+{
+    /// <summary>
+    /// Represents a padding type.
+    /// </summary>
+    public sealed class PaddingType : TypeNode
+    {
+        #region Instance
+
+        /// <summary>
+        /// Constructs a new padding type.
+        /// </summary>
+        /// <param name="typeContext">The parent type context.</param>
+        /// <param name="primitiveType">The primitive type to use for padding.</param>
+        internal PaddingType(IRTypeContext typeContext, PrimitiveType primitiveType)
+            : base(typeContext)
+        {
+            PrimitiveType = primitiveType;
+            Size = PrimitiveType.Size;
+            Alignment = PrimitiveType.Alignment;
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Returns the associated basic value type.
+        /// </summary>
+        public new BasicValueType BasicValueType => PrimitiveType.BasicValueType;
+
+        /// <summary>
+        /// Returns the associated basic value type.
+        /// </summary>
+        public PrimitiveType PrimitiveType { get; }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Returns the corresponding managed basic value type.
+        /// </summary>
+        protected override Type GetManagedType() => BasicValueType.GetManagedType();
+
+        #endregion
+
+        #region Object
+
+        /// <summary cref="Node.ToPrefixString"/>
+        protected override string ToPrefixString() =>
+            BasicValueType.ToString();
+
+        /// <summary cref="TypeNode.GetHashCode"/>
+        public override int GetHashCode() =>
+            base.GetHashCode() ^ 0x2AB11613 ^ (int)BasicValueType;
+
+        /// <summary cref="TypeNode.Equals(object)"/>
+        public override bool Equals(object obj) =>
+            obj is PaddingType paddingType &&
+            paddingType.BasicValueType == BasicValueType;
+
+        #endregion
+    }
+}

--- a/Src/ILGPU/IR/Types/TypeNode.cs
+++ b/Src/ILGPU/IR/Types/TypeNode.cs
@@ -182,6 +182,11 @@ namespace ILGPU.IR.Types
         public bool IsArrayType => this is ArrayType;
 
         /// <summary>
+        /// Returns true if the current type is a <see cref="PaddingType"/>.
+        /// </summary>
+        public bool IsPaddingType => this is PaddingType;
+
+        /// <summary>
         /// Returns true if this type is a root object type.
         /// </summary>
         public bool IsRootType =>


### PR DESCRIPTION
Fixes https://github.com/m4rs-mt/ILGPU/issues/256.

When a structure contains a fixed buffer, ILGPU will add padding bytes to correctly align the data structure. However, when there are multiple fields in the structure (such as another fixed buffer),  these padding fields alter the field index of the MSIL code.

This PR introduces a new node type (`PaddingType`) to identify which fields of a structure are for padding. A new type was used because it was not always possible to pass information about which fields were padding e.g. when merging structures.