### PR TITLE
Fixed loading unsafe structure from a static field.

### DIFF
--- a/Src/ILGPU.Tests/FixedBuffers.tt
+++ b/Src/ILGPU.Tests/FixedBuffers.tt
@@ -240,6 +240,42 @@ namespace ILGPU.Tests
                 };
             Verify(fixedBuffers, expected);
         }
+        
+        internal static readonly MultiFixedBufferStruct<#= type.Name #>
+            Local<#= type.Name #>Struct =
+            new MultiFixedBufferStruct<#= type.Name #>((<#= type.Type #>)2);
+
+        internal static void GetStaticMultiFixedBuffer<#= type.Name #>Kernel(
+            Index1 index,
+            ArrayView<<#= type.Type #>> data,
+            ArrayView<<#= type.Type #>> data2,
+            ArrayView<<#= type.Type #>> data3)
+         {
+            data[index] = Local<#= type.Name #>Struct.A[index];
+            data2[index] = Local<#= type.Name #>Struct.B[index];
+            data3[index] = Local<#= type.Name #>Struct.C[index];
+        }
+        
+        [Fact]
+        [KernelMethod(nameof(GetStaticMultiFixedBuffer<#= type.Name #>Kernel))]
+        public void GetStaticMultiFixedBuffer<#= type.Name #>()
+        {
+            using var buffer1 = Accelerator.Allocate<<#= type.Type #>>(Length);
+            using var buffer2 = Accelerator.Allocate<<#= type.Type #>>(Length);
+            using var buffer3 = Accelerator.Allocate<<#= type.Type #>>(Length);
+            Execute(
+                Length,
+                buffer1.View,
+                buffer2.View,
+                buffer3.View);
+
+            var expected1 = new <#= type.Type #>[] { 2, 5, 8, 11, 14, 17, 20, 23, 26 };
+            var expected2 = new <#= type.Type #>[] { 3, 6, 9, 12, 15, 18, 21, 24, 27 };
+            var expected3 = new <#= type.Type #>[] { 4, 7, 10, 13, 16, 19, 22, 25, 28 };
+            Verify(buffer1, expected1);
+            Verify(buffer2, expected2);
+            Verify(buffer3, expected3);
+        }
 <# } #>
     }
 }

--- a/Src/ILGPU/IR/Types/IRContext.Types.cs
+++ b/Src/ILGPU/IR/Types/IRContext.Types.cs
@@ -27,6 +27,11 @@ namespace ILGPU.IR
         public StringType StringType => TypeContext.StringType;
 
         /// <summary>
+        /// Returns the padding type.
+        /// </summary>
+        public PaddingType PaddingType => TypeContext.PaddingType;
+
+        /// <summary>
         /// Returns the runtime handle type.
         /// </summary>
         public HandleType HandleType => TypeContext.HandleType;

--- a/Src/ILGPU/IR/Types/IRTypeContext.cs
+++ b/Src/ILGPU/IR/Types/IRTypeContext.cs
@@ -140,7 +140,7 @@ namespace ILGPU.IR.Types
         /// <summary>
         /// Returns a custom padding type that is used to pad structure values.
         /// </summary>
-        public TypeNode PaddingType { get; }
+        public PaddingType PaddingType { get; }
 
         #endregion
 

--- a/Src/ILGPU/IR/Values/StructureValues.cs
+++ b/Src/ILGPU/IR/Values/StructureValues.cs
@@ -813,7 +813,9 @@ namespace ILGPU.IR.Values
                     Count + 1 <= Parent.NumFields);
                 Location.Assert(
                     value.Type == Parent[Count] ||
-                    value is UndefinedValue);
+                    value is UndefinedValue ||
+                    Parent[Count].IsPaddingType &&
+                    value.BasicValueType == IRBuilder.Context.PaddingType.BasicValueType);
 
                 builder.Add(value);
             }


### PR DESCRIPTION
Fixes https://github.com/m4rs-mt/ILGPU/issues/213.

When loading an unsafe structure from a static field, and the structure contains a fixed buffer, we need to load all the elements of the fixed buffer. This is accomplished by pinning the first element of the fixed buffer, then using unsafe code to copy the remaining elements one byte at a time.

Also had to alter equality comparison of `TypeNode` so that `PrimitiveType` and `PaddingType` are considered equal. Otherwise, the additional padding bytes would fail to consider a `PrimitiveValue` to be compatible with `PaddingType`.



