### PR TITLE
Fixed invalid block enumeration for pre-order traversals.

### DIFF
--- a/Src/ILGPU/IR/Analyses/TraversalOrder.cs
+++ b/Src/ILGPU/IR/Analyses/TraversalOrder.cs
@@ -165,7 +165,11 @@ namespace ILGPU.IR.Analyses.TraversalOrders
         /// Initializes a forwards enumeration state.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static TraversalEnumerationState ForwardsInit() => default;
+        public static TraversalEnumerationState ForwardsInit() =>
+            new TraversalEnumerationState()
+            {
+                Index = -1,
+            };
 
         /// <summary>
         /// Tries to move a forwards state to the next block.


### PR DESCRIPTION
The current pre-order traversal enumerator skips the first block in all cases. This PR fixes this off-by-one issue.