### PR TITLE
Fixed missing type updates of affected address-space dependent values in InferAddressSpaces.

### DIFF
--- a/Src/ILGPU/IR/Transformations/InferAddressSpaces.cs
+++ b/Src/ILGPU/IR/Transformations/InferAddressSpaces.cs
@@ -84,6 +84,15 @@ namespace ILGPU.IR.Transformations
             return true;
         }
 
+        /// <summary>
+        /// Invalidates the type of an affected value.
+        /// </summary>
+        private static void InvalidateType<TValue>(
+            RewriterContext context,
+            TValue value)
+            where TValue : Value =>
+            value.InvalidateType();
+
         #endregion
 
         #region Rewriter
@@ -102,6 +111,11 @@ namespace ILGPU.IR.Transformations
             Rewriter.Add<AddressSpaceCast>(
                 IsRedundant,
                 (context, cast) => context.ReplaceAndRemove(cast, cast.Value));
+
+            // Invalidate types of affected values
+            Rewriter.Add<PointerCast>(InvalidateType);
+            Rewriter.Add<LoadFieldAddress>(InvalidateType);
+            Rewriter.Add<LoadElementAddress>(InvalidateType);
         }
 
         #endregion

--- a/Src/ILGPU/IR/Values/Value.cs
+++ b/Src/ILGPU/IR/Values/Value.cs
@@ -524,7 +524,7 @@ namespace ILGPU.IR
         /// type.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected void InvalidateType()
+        public void InvalidateType()
         {
             if (!HasStaticType)
                 type = null;


### PR DESCRIPTION
The current `InferAddressSpaces` transformation removes unnecessary `AddressSpaceCast` operations. However, it does not invalidate the types of possibly affected address-space dependent pointer operations. This can cause significant slowdowns of the finally emitted code. This PR fixes this issue by invaliding the types of potentially affected operations.