### PR TITLE
Added basic support for FP16x2 types.

### DIFF
--- a/Src/ILGPU/Util/PrimitiveDataBlocks.tt
+++ b/Src/ILGPU/Util/PrimitiveDataBlocks.tt
@@ -21,6 +21,7 @@
         new { TypeName = "Short", Info = SignedIntTypes[1] },
         new { TypeName = "Int", Info = SignedIntTypes[2] },
         new { TypeName = "Long", Info = SignedIntTypes[3] },
+        new { TypeName = "Half", Info = FloatTypes[0] },
         new { TypeName = "Float", Info = FloatTypes[1] },
         new { TypeName = "Double", Info = FloatTypes[2] },
     };


### PR DESCRIPTION
This PR adds basic support for `Half2` (FP16x2) types (closes #250). Although this PR seems to be a bit limited on first sight, it turns out that the latest NVIDIA GPU drivers (at least the ones shipped with Ampere support) seem to automatically fuse certain FP16 operation sequences automatically. Since ILGPU always tries to keep similar operations next to each other, the driver can automatically fuse FP16 sequences into FP16x2 operation chains. However, we might want to extend this functionality in the future to enforce the generation of specialized FP16x2 operations in ILGPU.