### PR TITLE
Improved PTX block scheduling

### DIFF
--- a/Src/ILGPU/Backends/PTX/Analyses/DefaultPTXBlockSchedule.cs
+++ b/Src/ILGPU/Backends/PTX/Analyses/DefaultPTXBlockSchedule.cs
@@ -1,0 +1,67 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                        Copyright (c) 2016-2020 Marcel Koester
+//                                    www.ilgpu.net
+//
+// File: DefaultPTXBlockSchedule.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+
+using ILGPU.IR;
+using ILGPU.IR.Analyses.ControlFlowDirection;
+using ILGPU.IR.Analyses.TraversalOrders;
+
+namespace ILGPU.Backends.PTX.Analyses
+{
+    /// <summary>
+    /// Represents a default PTX-specific block schedule.
+    /// </summary>
+    public sealed class DefaultPTXBlockSchedule :
+        PTXBlockSchedule<ReversePostOrder, Forwards>
+    {
+        #region Instance
+
+        /// <summary>
+        /// Constructs a new PTX block schedule.
+        /// </summary>
+        /// <param name="blocks">The underlying block collection.</param>
+        internal DefaultPTXBlockSchedule(
+            in BasicBlockCollection<ReversePostOrder, Forwards> blocks)
+            : base(blocks)
+        { }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Returns false to ensure that all branches will be generated.
+        /// </summary>
+        /// <returns>False.</returns>
+        public override bool IsImplicitSuccessor(
+            BasicBlock source,
+            BasicBlock successor) => false;
+
+        /// <summary>
+        /// Returns true to ensure that all blocks will receive a branch target.
+        /// </summary>
+        /// <returns>True.</returns>
+        public override bool NeedBranchTarget(BasicBlock block) => true;
+
+        #endregion
+    }
+
+    public partial class PTXBlockScheduleExtensions
+    {
+        /// <summary>
+        /// Creates a new default block schedule using the given blocks.
+        /// </summary>
+        /// <param name="blocks">The input blocks.</param>
+        /// <returns>The created block schedule.</returns>
+        public static PTXBlockSchedule CreateDefaultPTXSchedule(
+            this BasicBlockCollection<ReversePostOrder, Forwards> blocks) =>
+            new DefaultPTXBlockSchedule(blocks);
+    }
+}

--- a/Src/ILGPU/Backends/PTX/Analyses/OptimizedPTXBlockSchedule.cs
+++ b/Src/ILGPU/Backends/PTX/Analyses/OptimizedPTXBlockSchedule.cs
@@ -1,0 +1,214 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                        Copyright (c) 2016-2020 Marcel Koester
+//                                    www.ilgpu.net
+//
+// File: OptimizedPTXBlockSchedule.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+
+using ILGPU.IR;
+using ILGPU.IR.Analyses.ControlFlowDirection;
+using ILGPU.IR.Analyses.TraversalOrders;
+using ILGPU.IR.Values;
+using ILGPU.Util;
+using System;
+using System.Runtime.CompilerServices;
+
+namespace ILGPU.Backends.PTX.Analyses
+{
+    /// <summary>
+    /// Represents a optimized PTX-specific block schedule to place blocks.
+    /// </summary>
+    /// <typeparam name="TOrder">The current order.</typeparam>
+    /// <typeparam name="TDirection">The control-flow direction.</typeparam>
+    public sealed class OptimizedPTXBlockSchedule<TOrder, TDirection> :
+        PTXBlockSchedule<TOrder, TDirection>
+        where TOrder : struct, ITraversalOrder
+        where TDirection : struct, IControlFlowDirection
+    {
+        #region Nested Types
+
+        /// <summary>
+        /// A specific successor provider that inverts the successors of all
+        /// <see cref="IfBranch"/> terminators.
+        /// </summary>
+        private readonly struct SuccessorProvider :
+            ITraversalSuccessorsProvider<Forwards>
+        {
+            /// <summary>
+            /// Returns all successors in the default order except for
+            /// <see cref="IfBranch"/> terminators. The successors of these terminators
+            /// will be reversed to invert all if branch targets.
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public readonly ReadOnlySpan<BasicBlock> GetSuccessors(BasicBlock basicBlock)
+            {
+                var successors = basicBlock.Successors;
+                if (basicBlock.Terminator is IfBranch ifBranch && ifBranch.IsInverted)
+                {
+                    var tempList = successors.ToInlineList();
+                    tempList.Reverse();
+                    successors = tempList;
+                }
+                return successors;
+            }
+        }
+
+        #endregion
+
+        #region Instance
+
+        /// <summary>
+        /// Constructs a new PTX block schedule.
+        /// </summary>
+        /// <param name="blocks">The underlying block collection.</param>
+        internal OptimizedPTXBlockSchedule(
+            in BasicBlockCollection<TOrder, TDirection> blocks)
+            : base(blocks)
+        {
+            BlockIndices = blocks.CreateMap(new BasicBlockMapTraversalIndexProvider());
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Returns the block-traversal indices.
+        /// </summary>
+        public BasicBlockMap<int> BlockIndices { get; }
+
+        /// <summary>
+        /// Maps the given block to its traversal index.
+        /// </summary>
+        /// <param name="block">The block to map to its traversal index.</param>
+        /// <returns>The associated traversal index.</returns>
+        public int this[BasicBlock block] => BlockIndices[block];
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Returns true if the given <paramref name="successor"/> is an implicit
+        /// successor of the <paramref name="source"/> block.
+        /// </summary>
+        /// <param name="source">The source block.</param>
+        /// <param name="successor">The target successor to jump to.</param>
+        /// <returns>True, if the given successor in an implicit branch target.</returns>
+        public override bool IsImplicitSuccessor(
+            BasicBlock source,
+            BasicBlock successor) =>
+            this[source] + 1 == this[successor];
+
+        /// <summary>
+        /// Returns true if the given block needs an explicit branch target.
+        /// </summary>
+        /// <param name="block">The block to test.</param>
+        /// <returns>True, if the given block needs an explicit branch target.</returns>
+        public override bool NeedBranchTarget(BasicBlock block)
+        {
+            // If there is more than one predecessor
+            if (block.Predecessors.Length > 1)
+                return true;
+
+            // If there is less than one predecessor
+            if (block.Predecessors.Length < 1)
+                return false;
+
+            // If there is exactly one predecessor, we have to check whether this block
+            // can be reached via an implicit successor branch
+            var pred = block.Predecessors[0];
+            if (pred.Terminator is IfBranch ifBranch)
+            {
+                var (trueTarget, _) = ifBranch.GetNotInvertedBranchTargets();
+                return block != trueTarget || !IsImplicitSuccessor(pred, block);
+            }
+
+            // Ensure that we are not removing labels from switch-based branch targets
+            return !(pred.Terminator is UnconditionalBranch);
+        }
+
+        #endregion
+    }
+
+    public partial class PTXBlockScheduleExtensions
+    {
+        #region Nested Types
+
+        /// <summary>
+        /// A specific successor provider that inverts the successors of all
+        /// <see cref="IfBranch"/> terminators.
+        /// </summary>
+        private readonly struct SuccessorProvider :
+            ITraversalSuccessorsProvider<Forwards>
+        {
+            /// <summary>
+            /// Returns all successors in the default order except for
+            /// <see cref="IfBranch"/> terminators. The successors of these terminators
+            /// will be reversed to invert all if branch targets.
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public readonly ReadOnlySpan<BasicBlock> GetSuccessors(BasicBlock basicBlock)
+            {
+                var successors = basicBlock.Successors;
+                if (basicBlock.Terminator is IfBranch ifBranch && ifBranch.IsInverted)
+                {
+                    var tempList = successors.ToInlineList();
+                    tempList.Reverse();
+                    successors = tempList;
+                }
+                return successors;
+            }
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Creates a new optimized block schedule using the given blocks.
+        /// </summary>
+        /// <typeparam name="TOrder">The current order.</typeparam>
+        /// <typeparam name="TDirection">The control-flow direction.</typeparam>
+        /// <param name="blocks">The input blocks.</param>
+        /// <returns>The created block schedule.</returns>
+        public static PTXBlockSchedule CreatePTXScheduleToOptimize<TOrder, TDirection>(
+            this BasicBlockCollection<TOrder, TDirection> blocks)
+            where TOrder : struct, ITraversalOrder
+            where TDirection : struct, IControlFlowDirection =>
+            CreateSchedule(blocks.ChangeOrder<PreOrder, Forwards>());
+
+        /// <summary>
+        /// Creates a schedule from an already existing schedule.
+        /// </summary>
+        /// <typeparam name="TOrder">The current order.</typeparam>
+        /// <typeparam name="TDirection">The control-flow direction.</typeparam>
+        /// <param name="blocks">The input blocks.</param>
+        /// <returns>The created block schedule.</returns>
+        public static PTXBlockSchedule CreateOptimizedPTXSchedule<TOrder, TDirection>(
+            this BasicBlockCollection<TOrder, TDirection> blocks)
+            where TOrder : struct, ITraversalOrder
+            where TDirection : struct, IControlFlowDirection =>
+            CreateSchedule(
+                blocks.Traverse<PreOrder, Forwards, SuccessorProvider>(default));
+
+        /// <summary>
+        /// Creates an optimized PTX block schedule.
+        /// </summary>
+        /// <typeparam name="TOrder">The current order.</typeparam>
+        /// <typeparam name="TDirection">The control-flow direction.</typeparam>
+        /// <param name="blocks">The input blocks.</param>
+        /// <returns>The created block schedule.</returns>
+        private static PTXBlockSchedule CreateSchedule<TOrder, TDirection>(
+            in BasicBlockCollection<TOrder, TDirection> blocks)
+            where TOrder : struct, ITraversalOrder
+            where TDirection : struct, IControlFlowDirection =>
+            new OptimizedPTXBlockSchedule<TOrder, TDirection>(blocks);
+
+        #endregion
+    }
+}

--- a/Src/ILGPU/Backends/PTX/Analyses/PTXBlockSchedule.cs
+++ b/Src/ILGPU/Backends/PTX/Analyses/PTXBlockSchedule.cs
@@ -1,0 +1,144 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                        Copyright (c) 2016-2020 Marcel Koester
+//                                    www.ilgpu.net
+//
+// File: PTXBlockSchedule.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+
+using ILGPU.IR;
+using ILGPU.IR.Analyses.ControlFlowDirection;
+using ILGPU.IR.Analyses.TraversalOrders;
+using System.Collections.Immutable;
+
+namespace ILGPU.Backends.PTX.Analyses
+{
+    /// <summary>
+    /// Represents a PTX-specific block schedule.
+    /// </summary>
+    public abstract class PTXBlockSchedule
+    {
+        #region Instance
+
+        /// <summary>
+        /// Constructs a new PTX block schedule.
+        /// </summary>
+        /// <param name="entryBlock">The entry block.</param>
+        /// <param name="blocks">The underlying block collection.</param>
+        protected PTXBlockSchedule(
+            BasicBlock entryBlock,
+            ImmutableArray<BasicBlock> blocks)
+        {
+            EntryBlock = entryBlock;
+            Blocks = blocks;
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Returns the entry block.
+        /// </summary>
+        public BasicBlock EntryBlock { get; }
+
+        /// <summary>
+        /// Returns all blocks.
+        /// </summary>
+        public ImmutableArray<BasicBlock> Blocks { get; }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Creates a new phi bindings mapping.
+        /// </summary>
+        /// <typeparam name="TAllocator">The custom allocator type.</typeparam>
+        /// <param name="allocator">The allocator to use.</param>
+        /// <returns>The created phi bindings.</returns>
+        public abstract PhiBindings ComputePhiBindings<TAllocator>(TAllocator allocator)
+            where TAllocator : IPhiBindingAllocator;
+
+        /// <summary>
+        /// Returns true if the given <paramref name="successor"/> is an implicit
+        /// successor of the <paramref name="source"/> block.
+        /// </summary>
+        /// <param name="source">The source block.</param>
+        /// <param name="successor">The target successor to jump to.</param>
+        /// <returns>True, if the given successor in an implicit branch target.</returns>
+        public abstract bool IsImplicitSuccessor(
+            BasicBlock source,
+            BasicBlock successor);
+
+        /// <summary>
+        /// Returns true if the given block needs an explicit branch target.
+        /// </summary>
+        /// <param name="block">The block to test.</param>
+        /// <returns>True, if the given block needs an explicit branch target.</returns>
+        public abstract bool NeedBranchTarget(BasicBlock block);
+
+        /// <summary>
+        /// Returns an enumerator to iterate over all blocks in the underlying
+        /// collection.
+        /// </summary>
+        public ImmutableArray<BasicBlock>.Enumerator GetEnumerator() =>
+            Blocks.GetEnumerator();
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Represents a PTX-specific block schedule.
+    /// </summary>
+    /// <typeparam name="TOrder">The current order.</typeparam>
+    /// <typeparam name="TDirection">The control-flow direction.</typeparam>
+    public abstract class PTXBlockSchedule<TOrder, TDirection> : PTXBlockSchedule
+        where TOrder : struct, ITraversalOrder
+        where TDirection : struct, IControlFlowDirection
+    {
+        #region Instance
+
+        /// <summary>
+        /// Constructs a new PTX block schedule.
+        /// </summary>
+        /// <param name="blocks">The underlying block collection.</param>
+        protected PTXBlockSchedule(in BasicBlockCollection<TOrder, TDirection> blocks)
+            : base(blocks.EntryBlock, blocks.ToImmutableArray())
+        { }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Returns the entry block.
+        /// </summary>
+        public BasicBlockCollection<TOrder, TDirection> BasicBlockCollection =>
+            new BasicBlockCollection<TOrder, TDirection>(EntryBlock, Blocks);
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Creates a new phi bindings mapping.
+        /// </summary>
+        /// <typeparam name="TAllocator">The custom allocator type.</typeparam>
+        /// <param name="allocator">The allocator to use.</param>
+        /// <returns>The created phi bindings.</returns>
+        public override PhiBindings ComputePhiBindings<TAllocator>(
+            TAllocator allocator) =>
+            PhiBindings.Create(BasicBlockCollection, allocator);
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Extensions methods for the <see cref="PTXBlockSchedule"/> class.
+    /// </summary>
+    public static partial class PTXBlockScheduleExtensions { }
+}

--- a/Src/ILGPU/Backends/PTX/PTXBackend.cs
+++ b/Src/ILGPU/Backends/PTX/PTXBackend.cs
@@ -10,6 +10,7 @@
 // ---------------------------------------------------------------------------------------
 
 using ILGPU.Backends.EntryPoints;
+using ILGPU.Backends.PTX.Transformations;
 using ILGPU.IR;
 using ILGPU.IR.Analyses;
 using ILGPU.IR.Transformations;
@@ -100,6 +101,14 @@ namespace ILGPU.Backends.PTX
                 transformerBuilder.AddBackendOptimizations(
                     new PTXAcceleratorSpecializer(PointerType),
                     context.OptimizationLevel);
+
+                if (Context.HasFlags(ContextFlags.EnhancedPTXBackendFeatures))
+                {
+                    // Create an optimized PTX assembler block schedule
+                    transformerBuilder.Add(new PTXBlockScheduling());
+                    transformerBuilder.Add(new DeadCodeElimination());
+                }
+
                 builder.Add(transformerBuilder.ToTransformer());
             });
         }

--- a/Src/ILGPU/Backends/PTX/Transformations/PTXBlockScheduling.cs
+++ b/Src/ILGPU/Backends/PTX/Transformations/PTXBlockScheduling.cs
@@ -1,0 +1,65 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                        Copyright (c) 2016-2020 Marcel Koester
+//                                    www.ilgpu.net
+//
+// File: PTXBlockScheduling.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+
+using ILGPU.Backends.PTX.Analyses;
+using ILGPU.IR;
+using ILGPU.IR.Transformations;
+using ILGPU.IR.Values;
+
+namespace ILGPU.Backends.PTX.Transformations
+{
+    /// <summary>
+    /// Adapts the actual block branch order in a way to avoid negated predicated
+    /// branches and which maximizes the number of implicit block branches.
+    /// </summary>
+    public sealed class PTXBlockScheduling : UnorderedTransformation
+    {
+        /// <summary>
+        /// Applies the PTX-specific block schedule to the given builder.
+        /// </summary>
+        protected override bool PerformTransformation(Method.Builder builder)
+        {
+            // We change the control-flow structure during the transformation but
+            // need to get information about previous predecessors and successors
+            builder.AcceptControlFlowUpdates(accept: true);
+
+            // Compute the intended block scheduling order and assign all blocks to their
+            // traversal index
+            var schedule = builder.SourceBlocks.CreatePTXScheduleToOptimize();
+
+            // Ensure that all conditional if branches (which can fall through in the
+            // true case) will be inverted to have "optimistic" branch checks in the
+            // false case. This circumvents several limitations in the current PTX
+            // assembler implementation.
+            foreach (var block in schedule)
+            {
+                if (!(block.Terminator is IfBranch ifBranch))
+                    continue;
+
+                // Ensure that all branches are not inverted at this point
+                block.Assert(!ifBranch.IsInverted);
+
+                // Ignore if branches that can jump to arbitrary locations and branches
+                // that are already in the desired state (with respect to the other false
+                // branch target).
+                if (!schedule.IsImplicitSuccessor(block, ifBranch.TrueTarget))
+                    continue;
+
+                // Invert the current if such that the false target becomes the true
+                // branch target and the condition is properly inverted to avoid the
+                // generation of negated predicate checks
+                ifBranch.Invert(builder[block]);
+            }
+
+            return true;
+        }
+    }
+}

--- a/Src/ILGPU/Context.cs
+++ b/Src/ILGPU/Context.cs
@@ -92,7 +92,6 @@ namespace ILGPU
 
         #endregion
 
-
         #region Events
 
         /// <summary>
@@ -149,6 +148,13 @@ namespace ILGPU
             OptimizationLevel = optimizationLevel;
             Flags = flags.Prepare();
             TargetPlatform = Backend.RuntimePlatform;
+
+            // Initialize enhanced PTX backend feature flags
+            if (optimizationLevel > OptimizationLevel.O1 &&
+                !Flags.HasFlags(ContextFlags.DefaultPTXBackendFeatures))
+            {
+                Flags |= ContextFlags.EnhancedPTXBackendFeatures;
+            }
 
             // Initialize verifier
             Verifier = flags.HasFlags(ContextFlags.EnableVerifier)

--- a/Src/ILGPU/ContextFlags.cs
+++ b/Src/ILGPU/ContextFlags.cs
@@ -197,7 +197,18 @@ namespace ILGPU
         DisableAcceleratorGC =
             DisableKernelCaching |
             DisableAutomaticBufferDisposal |
-            DisableAutomaticKernelDisposal
+            DisableAutomaticKernelDisposal,
+
+        /// <summary>
+        /// Enforces the use of the default PTX backend features.
+        /// </summary>
+        DefaultPTXBackendFeatures = 1 << 27,
+
+        /// <summary>
+        /// Enables the use of enhanced PTX backend features to improve performance of
+        /// the kernel programs being generated.
+        /// </summary>
+        EnhancedPTXBackendFeatures = 1 << 28,
     }
 
     /// <summary>

--- a/Src/ILGPU/IR/BasicBlockMapping.cs
+++ b/Src/ILGPU/IR/BasicBlockMapping.cs
@@ -379,6 +379,19 @@ namespace ILGPU.IR
     }
 
     /// <summary>
+    /// A map provider that returns the traversal index of each block.
+    /// </summary>
+    public readonly struct BasicBlockMapTraversalIndexProvider :
+        IBasicBlockMapValueProvider<int>
+    {
+        /// <summary>
+        /// Returns the value of <paramref name="traversalIndex"/>.
+        /// </summary>
+        public readonly int GetValue(BasicBlock block, int traversalIndex) =>
+            traversalIndex;
+    }
+
+    /// <summary>
     /// A mapping of basic block to values.
     /// </summary>
     /// <typeparam name="T">The value type.</typeparam>

--- a/Src/ILGPU/IR/Construction/Terminators.cs
+++ b/Src/ILGPU/IR/Construction/Terminators.cs
@@ -54,7 +54,7 @@ namespace ILGPU.IR.Construction
                 target));
 
         /// <summary>
-        /// Creates a new conditional branch.
+        /// Creates a new conditional branch using no specific flags.
         /// </summary>
         /// <param name="location">The current location.</param>
         /// <param name="condition">The branch condition.</param>
@@ -66,11 +66,34 @@ namespace ILGPU.IR.Construction
             Value condition,
             BasicBlock trueTarget,
             BasicBlock falseTarget) =>
+            CreateIfBranch(
+                location,
+                condition,
+                trueTarget,
+                falseTarget,
+                IfBranchFlags.None);
+
+        /// <summary>
+        /// Creates a new conditional branch using the given flags.
+        /// </summary>
+        /// <param name="location">The current location.</param>
+        /// <param name="condition">The branch condition.</param>
+        /// <param name="trueTarget">The true target block.</param>
+        /// <param name="falseTarget">The false target block.</param>
+        /// <param name="flags">The branch flags.</param>
+        /// <returns>The created terminator.</returns>
+        public Branch CreateIfBranch(
+            Location location,
+            Value condition,
+            BasicBlock trueTarget,
+            BasicBlock falseTarget,
+            IfBranchFlags flags) =>
             CreateTerminator(new IfBranch(
                 GetInitializer(location),
                 condition,
                 trueTarget,
-                falseTarget));
+                falseTarget,
+                flags));
 
         /// <summary>
         /// Creates a switch terminator builder.


### PR DESCRIPTION
The PTX assembler (which is also integrated into the driver) expects certain control flow patterns to appear in the generated code. Following these patterns can significantly improve runtime performance with respect to the SASS code being generated. It turns out that negated predicates can cause the PTX assembler to output non-optimal vectorized instruction blocks. In addition, jumping to blocks that can be reached implicitly via "fall-through branches" (no explicit branch instructions are required when two blocks are placed one after the other in the emitted assembler code) seems to help the PTX assembler considerably.

This PR adds experimental support for generating optimized block sequences using a newly introduced `PTXBlockSchedule` class. It depends on #269 and should be used in combination with #251, #268, #270, #271 and #272.