### PR TITLE
Fixed invalid alignment of local and shared-memory allocations in PTXBackend

### DIFF
--- a/Src/ILGPU/Backends/PTX/PTXCodeGenerator.cs
+++ b/Src/ILGPU/Backends/PTX/PTXCodeGenerator.cs
@@ -585,7 +585,8 @@ namespace ILGPU.Backends.PTX
                 Builder.Append(addressSpacePrefix);
 
                 Builder.Append(".align ");
-                Builder.Append(allocaInfo.ElementAlignment);
+                Builder.Append(
+                    PointerAlignments.GetInitialAlignment(allocaInfo.Alloca));
                 Builder.Append(" .b8 ");
 
                 var name = namePrefix + offset++;


### PR DESCRIPTION
We have updated the global alignment rules in #260. This PR fixes invalidly aligned local and shared-memory allocations that are not compatible with the updated alignment information.