### PR TITLE
Added support for Span during MemoryBuffer copy operations.

### DIFF
--- a/Src/ILGPU/Runtime/MemoryBuffer.cs
+++ b/Src/ILGPU/Runtime/MemoryBuffer.cs
@@ -444,7 +444,7 @@ namespace ILGPU.Runtime
         /// <param name="extent">The extent (number of elements).</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void CopyTo(
-            T[] target,
+            Span<T> target,
             TIndex sourceOffset,
             long targetOffset,
             TIndex extent) =>
@@ -465,7 +465,7 @@ namespace ILGPU.Runtime
         /// <param name="extent">The extent (number of elements).</param>
         public unsafe void CopyTo(
             AcceleratorStream stream,
-            T[] target,
+            Span<T> target,
             TIndex sourceOffset,
             long targetOffset,
             TIndex extent)
@@ -476,7 +476,7 @@ namespace ILGPU.Runtime
                 throw new ArgumentNullException(nameof(stream));
             if (!sourceOffset.InBounds(Extent))
                 throw new ArgumentOutOfRangeException(nameof(sourceOffset));
-            var length = target.LongLength;
+            var length = target.Length;
             if (targetOffset < 0 || targetOffset >= length)
                 throw new ArgumentOutOfRangeException(nameof(targetOffset));
             if (extent.Size < 1 ||
@@ -485,8 +485,6 @@ namespace ILGPU.Runtime
             {
                 throw new ArgumentOutOfRangeException(nameof(extent));
             }
-
-            Debug.Assert(target.Rank == 1);
 
             fixed (T* ptr = &target[0])
             {
@@ -662,7 +660,7 @@ namespace ILGPU.Runtime
         /// <param name="extent">The extent (number of elements).</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void CopyFrom(
-            T[] source,
+            ReadOnlySpan<T> source,
             long sourceOffset,
             TIndex targetOffset,
             long extent) =>
@@ -683,21 +681,21 @@ namespace ILGPU.Runtime
         /// <param name="extent">The extent (number of elements).</param>
         public unsafe void CopyFrom(
             AcceleratorStream stream,
-            T[] source,
+            ReadOnlySpan<T> source,
             long sourceOffset,
             TIndex targetOffset,
             long extent)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
-            var length = source.LongLength;
+            var length = source.Length;
             if (sourceOffset < 0 || sourceOffset >= length)
                 throw new ArgumentOutOfRangeException(nameof(sourceOffset));
             var linearIndex = targetOffset.ComputeLongLinearIndex(Extent);
             if (!targetOffset.InBounds(Extent) || linearIndex >= Length)
                 throw new ArgumentOutOfRangeException(nameof(targetOffset));
-            if (extent < 1 || extent > source.LongLength ||
-                extent + sourceOffset > source.LongLength ||
+            if (extent < 1 || extent > source.Length ||
+                extent + sourceOffset > source.Length ||
                 linearIndex + extent > Length)
             {
                 throw new ArgumentOutOfRangeException(nameof(extent));

--- a/Src/ILGPU/Runtime/MemoryBuffers.tt
+++ b/Src/ILGPU/Runtime/MemoryBuffers.tt
@@ -481,6 +481,48 @@ namespace ILGPU.Runtime
                 extent);
 
         /// <summary>
+        /// Copies the contents of this buffer into the given array using
+        /// the default accelerator stream.
+        /// </summary>
+        /// <param name="target">The target array.</param>
+        /// <param name="sourceOffset">The source offset.</param>
+        /// <param name="targetOffset">The target offset.</param>
+        /// <param name="extent">The extent (number of elements).</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void CopyTo(
+            Span<T> target,
+            <#= indexType #> sourceOffset,
+            long targetOffset,
+            <#= indexType #> extent) =>
+            buffer.CopyTo(
+                target,
+                sourceOffset,
+                targetOffset,
+                extent);
+
+        /// <summary>
+        /// Copies the contents of this buffer into the given array.
+        /// </summary>
+        /// <param name="stream">The used accelerator stream.</param>
+        /// <param name="target">The target array.</param>
+        /// <param name="sourceOffset">The source offset.</param>
+        /// <param name="targetOffset">The target offset.</param>
+        /// <param name="extent">The extent (number of elements).</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void CopyTo(
+            AcceleratorStream stream,
+            Span<T> target,
+            <#= indexType #> sourceOffset,
+            long targetOffset,
+            <#= indexType #> extent) =>
+            buffer.CopyTo(
+                stream,
+                target,
+                sourceOffset,
+                targetOffset,
+                extent);
+
+        /// <summary>
         /// Copies elements to the current buffer from the source buffer using
         /// the default accelerator stream.
         /// </summary>
@@ -667,6 +709,48 @@ namespace ILGPU.Runtime
                 targetOffset,
                 extent);
 
+        /// <summary>
+        /// Copies the contents to this buffer from the given array using
+        /// the default accelerator stream.
+        /// </summary>
+        /// <param name="source">The source array.</param>
+        /// <param name="sourceOffset">The source offset.</param>
+        /// <param name="targetOffset">The target offset.</param>
+        /// <param name="extent">The extent (number of elements).</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void CopyFrom(
+            ReadOnlySpan<T> source,
+            long sourceOffset,
+            <#= indexType #> targetOffset,
+            long extent) =>
+            buffer.CopyFrom(
+                source,
+                sourceOffset,
+                targetOffset,
+                extent);
+
+        /// <summary>
+        /// Copies the contents to this buffer from the given array.
+        /// </summary>
+        /// <param name="stream">The used accelerator stream.</param>
+        /// <param name="source">The source array.</param>
+        /// <param name="sourceOffset">The source offset.</param>
+        /// <param name="targetOffset">The target offset.</param>
+        /// <param name="extent">The extent (number of elements).</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void CopyFrom(
+            AcceleratorStream stream,
+            ReadOnlySpan<T> source,
+            long sourceOffset,
+            <#= indexType #> targetOffset,
+            long extent) =>
+            buffer.CopyFrom(
+                stream,
+                source,
+                sourceOffset,
+                targetOffset,
+                extent);
+
         #endregion
 
         #region Operators
@@ -729,6 +813,26 @@ namespace ILGPU.Runtime
             buffer.CopyFrom(data, <#= indexType #>.Zero, <#= indexType #>.Zero, buffer.Extent);
             return buffer;
         }
+
+<#      if (dimension == 1) { #>
+        /// <summary>
+        /// Allocates a <#= dimension #>D memory buffer with the given content on the
+        /// associated accelerator.
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <param name="accelerator">The current accelerator.</param>
+        /// <param name="data">The initial data array.</param>
+        /// <returns>The allocated memory buffer.</returns>
+        public static <#= typeName #><T> Allocate<T>(
+            this Accelerator accelerator,
+            ReadOnlySpan<T> data)
+            where T : unmanaged
+        {
+            var buffer = accelerator.Allocate<T>(data.Length);
+            buffer.CopyFrom(data, <#= indexType #>.Zero, <#= indexType #>.Zero, buffer.Extent);
+            return buffer;
+        }
+<#      } #>
 
         /// <summary>
         /// Allocates a <#= dimension #>D memory buffer on the associated accelerator that


### PR DESCRIPTION
Fixed #122.

Added `Span/ReadOnlySpan` versions of the `CopyFrom` and `CopyTo`. I had considered removing the existing functions that accept `T[]`, but it seems that sometimes the implicit conversion from `T[]` to `ReadOnlySpan<T>` does not work. This could be related to C# extension methods, because it affected the `Allocate<T>(ReadOnlySpan<T>)` extension method.

Also changed the internal `MemoryBuffer` to use `Span/ReadOnlySpan`. This required a minor change from calling `Array.LongLength` to `Span.Length`. This should not be a big issue because .NET arrays are limited to `int.MaxValue` elements anyway.

Note that this also indirectly supports `Memory<T>`, which has a `Span` property.
