### PR TITLE
Added support for System.ValueTuple.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -255,6 +255,7 @@ Src/ILGPU/HalfConversion.cs
 Src/ILGPU/IR/Construction/ArithmeticOperations.cs
 Src/ILGPU/IR/Construction/CompareOperations.cs
 Src/ILGPU/IR/Intrinsics/IntrinsicMatchers.cs
+Src/ILGPU/IR/Types/ValueTuples.cs
 Src/ILGPU/IndexTypes.cs
 Src/ILGPU/IntrinsicMath.CPUOnly.cs
 Src/ILGPU/ReductionOperations.cs
@@ -283,6 +284,7 @@ Src/ILGPU.Tests/FixedBuffers.cs
 Src/ILGPU.Tests/MemoryBufferOperations.cs
 Src/ILGPU.Tests/ReinterpretCasts.cs
 Src/ILGPU.Tests/UnaryIntOperations.cs
+Src/ILGPU.Tests/ValueTuples.cs
 
 Src/ILGPU.Tests.CPU/Configurations.cs
 Src/ILGPU.Tests.CPU/TestContexts.cs

--- a/Src/ILGPU.Tests/Configurations.txt
+++ b/Src/ILGPU.Tests/Configurations.txt
@@ -12,6 +12,7 @@ SharedMemory: Debug, Release, O2
 SizeOfValues: Debug, Release, O2
 SpecializedKernels: Debug, Release, O2
 StructureValues: Debug, Release, O2
+ValueTuples: Debug, Release, O2
 
 BinaryIntOperations: Debug, Release, O2
 UnaryIntOperations: Debug, Release, O2

--- a/Src/ILGPU.Tests/ILGPU.Tests.csproj
+++ b/Src/ILGPU.Tests/ILGPU.Tests.csproj
@@ -165,6 +165,11 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>UnaryIntOperations.tt</DependentUpon>
     </Compile>
+    <Compile Update="ValueTuples.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ValueTuples.tt</DependentUpon>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>
@@ -219,6 +224,10 @@
     <None Update="UnaryIntOperations.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>UnaryIntOperations.cs</LastGenOutput>
+    </None>
+    <None Update="ValueTuples.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>ValueTuples.cs</LastGenOutput>
     </None>
   </ItemGroup>
 

--- a/Src/ILGPU.Tests/ValueTuples.tt
+++ b/Src/ILGPU.Tests/ValueTuples.tt
@@ -1,0 +1,120 @@
+﻿<#@ template debug="false" hostspecific="true" language="C#" #>
+<#@ include file="Generic/ConfigurationBase.tt" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.IO" #>
+<#@ output extension=".cs" #>
+using ILGPU.Runtime;
+using System;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+<#
+    // Pick one representative for each 8/16/34/64-bit type.
+    // This reduces our permutations, since Float64 will behave the same as Int64.
+    var types = NumericTypes.Where(x => x.Name == "UInt8")
+        .Concat(NumericTypes.Where(x => x.Name == "Int16"))
+        .Concat(NumericTypes.Where(x => x.Name == "Int32"))
+        .Concat(NumericTypes.Where(x => x.Name == "Int64"))
+        .ToArray();
+
+    var permutations =
+        Enumerable.Range(1, types.Length)
+        .SelectMany(length => GetPermutations(types, length))
+        .ToArray();
+#>
+namespace ILGPU.Tests
+{
+    public abstract class ValueTuples : TestBase
+    {
+        protected ValueTuples(ITestOutputHelper output, TestContext testContext)
+            : base(output, testContext)
+        { }
+
+        public const int Length = 64;
+        private static readonly Random rnd = new Random();
+
+        private static unsafe byte GetRandomUInt8()
+        {
+            Span<byte> bytes = stackalloc byte[1];
+            rnd.NextBytes(bytes);
+            return bytes[0];
+        }
+
+        private static unsafe short GetRandomInt16()
+        {
+            Span<byte> bytes = stackalloc byte[2];
+            rnd.NextBytes(bytes);
+            return BitConverter.ToInt16(bytes);
+        }
+
+        private static unsafe int GetRandomInt32()
+        {
+            Span<byte> bytes = stackalloc byte[4];
+            rnd.NextBytes(bytes);
+            return BitConverter.ToInt32(bytes);
+        }
+
+        private static unsafe long GetRandomInt64()
+        {
+            Span<byte> bytes = stackalloc byte[8];
+            rnd.NextBytes(bytes);
+            return BitConverter.ToInt64(bytes);
+        }
+
+<#
+    foreach (var permutation in permutations) {
+        var permutationTypes = permutation.ToArray();
+        var testTypeNames = string.Join("", permutationTypes.Select(x => x.Name));
+        var testName = $"ValueTuple_{testTypeNames}";
+        var kernelName = $"{testName}_Kernel";
+        var permutationTypeNames =
+            string.Join(", ", permutationTypes.Select(x => x.Type));
+        var tupleType = $"ValueTuple<{permutationTypeNames}>";
+#>
+        internal static void <#= kernelName #>(
+            Index1 index,
+            ArrayView<<#= tupleType #>> input,
+            ArrayView<<#= tupleType #>> output)
+        {
+<#      for (var i = 1; i <= permutationTypes.Length; i++) { #>
+            output[index].Item<#= i #> = input[index].Item<#= i #>;
+<#      } #>
+        }
+
+        [Fact]
+        [KernelMethod(nameof(<#= kernelName #>))]
+        public void <#= testName #>()
+        {
+<#
+        var rndParams =
+            string.Join(", ", permutationTypes.Select(p => $"GetRandom{p.Name}()"));
+#>
+            var expected =
+                Enumerable.Range(1, Length)
+                .Select(n => new <#= tupleType #>(<#= rndParams #>))
+                .ToArray();
+            using var input = Accelerator.Allocate(expected);
+            using var output = Accelerator.AllocateZero<<#= tupleType #>>(Length);
+            Execute(Length, input.View, output.View);
+            Verify(output, expected);
+        }
+
+<#
+    }
+#>
+    }
+}
+
+<#+
+    IEnumerable<IEnumerable<T>> GetPermutations<T>(
+        IEnumerable<T> values,
+        int length)
+    {
+        if (length == 1)
+            return values.Select(x => new T[] { x });
+        return GetPermutations(values, length - 1)
+            .SelectMany(
+                x => values, 
+                (list, next) => list.Concat(new T[] { next }));
+    }
+#>

--- a/Src/ILGPU/ILGPU.csproj
+++ b/Src/ILGPU/ILGPU.csproj
@@ -172,6 +172,11 @@
           <AutoGen>True</AutoGen>
           <DependentUpon>IntrinsicMatchers.tt</DependentUpon>
         </Compile>
+        <Compile Update="IR\Types\ValueTuples.cs">
+          <DesignTime>True</DesignTime>
+          <AutoGen>True</AutoGen>
+          <DependentUpon>ValueTuples.tt</DependentUpon>
+        </Compile>
         <Compile Update="Runtime\ExchangeBufferExtensions.cs">
           <DesignTime>True</DesignTime>
           <AutoGen>True</AutoGen>
@@ -268,6 +273,10 @@
         <None Update="IR\Intrinsics\IntrinsicMatchers.tt">
           <Generator>TextTemplatingFileGenerator</Generator>
           <LastGenOutput>IntrinsicMatchers.cs</LastGenOutput>
+        </None>
+        <None Update="IR\Types\ValueTuples.tt">
+          <Generator>TextTemplatingFileGenerator</Generator>
+          <LastGenOutput>ValueTuples.cs</LastGenOutput>
         </None>
         <None Update="Runtime\ExchangeBufferExtensions.tt">
           <Generator>TextTemplatingFileGenerator</Generator>

--- a/Src/ILGPU/IR/Types/ValueTuples.tt
+++ b/Src/ILGPU/IR/Types/ValueTuples.tt
@@ -1,0 +1,91 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                        Copyright (c) 2016-2020 Marcel Koester
+//                                    www.ilgpu.net
+//
+// File: ValueTuples.tt/ValueTuples.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+<#@ template debug="false" hostspecific="true" language="C#" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ output extension=".cs" #>
+using System;
+using System.Reflection;
+<#
+    var MaxParams = 8;
+    var types =
+        from n in Enumerable.Range(1, MaxParams)
+        let range = Enumerable.Range(1, n)
+        select new
+        {
+            NumParams = n,
+            Range = range,
+            TypeParams = string.Join(", ", from r in range select $"T{r}")
+        };
+#>
+
+namespace ILGPU.IR.Types
+{
+    /// <summary>
+    /// Contains helper functions for supporting System.ValueTuple.
+    /// </summary>
+    internal static class ValueTuples
+    {
+        #region Static
+
+        /// <summary>
+        /// Retrieves the offsets for the fields in a value tuple that use the supplied
+        /// generic type arguments.
+        /// </summary>
+        /// <param name="types">The generic type arguments of the value tuple.</param>
+        /// <returns>Offsets for the fields of the value tuple.</returns>
+        public static int[] GetOffsets(Type[] types)
+        {
+            var methodInfo = types.Length switch
+            {
+<#  foreach (var type in types) { #>
+                <#= type.NumParams #> => GetOffsetsMethod<#= type.NumParams #>,
+<#  } #>
+                _ => throw new NotImplementedException()
+            };
+            var method = methodInfo.MakeGenericMethod(types);
+            return (int[])method.Invoke(null, null);
+        }
+
+        private static unsafe int CalculateOffset(byte* current, byte* baseline) =>
+            (int)(current - baseline);
+
+<#  foreach (var type in types) { #>
+        /// <summary>
+        /// Retrieves the offsets for the fields in the given value tuple.
+        /// </summary>
+        private static unsafe int[] GetOffsets<#= type.NumParams #><
+            <#= type.TypeParams #>>()
+<#      for (var i = 0; i < type.NumParams; i++) { #>
+            where T<#= i + 1 #> : unmanaged
+<#      } #>
+        {
+            ValueTuple<<#= type.TypeParams #>> input;
+            var offsets = new int[<#= type.NumParams #>];
+            byte* baseline = (byte*)&input;
+<#
+        for (var i = 0; i < type.NumParams; i++) {
+            var itemName = i + 1 == MaxParams ? "Rest" : $"Item{i + 1}";
+#>
+            offsets[<#= i #>] = CalculateOffset((byte*)&input.<#= itemName #>, baseline);
+<#      } #>
+            return offsets;
+        }
+
+        private static readonly MethodInfo GetOffsetsMethod<#= type.NumParams #> =
+            typeof(ValueTuples).GetMethod(
+                nameof(GetOffsets<#= type.NumParams #>),
+                BindingFlags.NonPublic | BindingFlags.Static);
+
+<#  } #>
+        #endregion
+    }
+}

--- a/Src/ILGPU/Interop.cs
+++ b/Src/ILGPU/Interop.cs
@@ -12,6 +12,7 @@
 using ILGPU.Frontend.Intrinsic;
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -58,6 +59,21 @@ namespace ILGPU
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int SizeOf<T>(T structure)
             where T : unmanaged => SizeOf<T>();
+
+        /// <summary>
+        /// Computes the size of the given type.
+        /// </summary>
+        /// <param name="type">The target type</param>
+        /// <remarks>Only supports unmanaged types.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int SizeOf(Type type) =>
+            (int)InteropSizeOfMethod.MakeGenericMethod(type).Invoke(null, null);
+
+        private static readonly MethodInfo InteropSizeOfMethod =
+            typeof(Interop).GetMethod(
+                nameof(SizeOf),
+                Type.EmptyTypes,
+                null);
 
         /// <summary>
         /// Computes number of elements of type <typeparamref name="TFirst"/>

--- a/Src/ILGPU/Util/TypeExtensions.cs
+++ b/Src/ILGPU/Util/TypeExtensions.cs
@@ -45,6 +45,32 @@ namespace ILGPU.Util
         }
 
         /// <summary>
+        /// Checks whether the given type is a value tuple type.
+        /// </summary>
+        /// <param name="type">The source type.</param>
+        /// <returns>True, in case of a value tuple.</returns>
+        public static bool IsValueTuple(this Type type)
+        {
+            if (type.IsGenericType)
+            {
+                // NB: System.ValueTuple with 9 or more generic arguments are
+                // currently not provided by any of the .NET frameworks. If that
+                // ever changes, we will need to update this list.
+                var genericType = type.GetGenericTypeDefinition();
+                return
+                    genericType == typeof(ValueTuple<>) ||
+                    genericType == typeof(ValueTuple<,>) ||
+                    genericType == typeof(ValueTuple<,,>) ||
+                    genericType == typeof(ValueTuple<,,,>) ||
+                    genericType == typeof(ValueTuple<,,,,>) ||
+                    genericType == typeof(ValueTuple<,,,,,>) ||
+                    genericType == typeof(ValueTuple<,,,,,,>) ||
+                    genericType == typeof(ValueTuple<,,,,,,,>);
+            }
+            return false;
+        }
+
+        /// <summary>
         /// Checks whether the given type is a specialized type.
         /// </summary>
         /// <param name="type">The source type.</param>


### PR DESCRIPTION
Fixes #266.

According to [this post](https://stackoverflow.com/a/54014473) from a developer on the C# compiler, `System.ValueTuple` can be used with the `unmanaged` constraint, even though it also uses `LayoutKind.Auto`.

However, when running the unit tests, there appears to be an issue with some tests.
It looks like copying the ValueTuples to the input buffer is correct, so I'm assuming it is related to the kernel.