### PR TITLE
Fixed misaligned field access for empty structures.

### DIFF
--- a/Src/ILGPU/IR/Types/TypeInformationManager.cs
+++ b/Src/ILGPU/IR/Types/TypeInformationManager.cs
@@ -45,7 +45,7 @@ namespace ILGPU.IR.Types
             /// <param name="fields">All managed fields.</param>
             /// <param name="fieldOffsets">All field offsets.</param>
             /// <param name="fieldTypes">All managed field types.</param>
-            /// <param name="numFlattenedFiels">The number of flattened fields.</param>
+            /// <param name="numFlattenedFields">The number of flattened fields.</param>
             /// <param name="isBlittable">True, if this type is blittable.</param>
             internal TypeInformation(
                 TypeInformationManager parent,
@@ -54,7 +54,7 @@ namespace ILGPU.IR.Types
                 ImmutableArray<FieldInfo> fields,
                 ImmutableArray<int> fieldOffsets,
                 ImmutableArray<Type> fieldTypes,
-                int numFlattenedFiels,
+                int numFlattenedFields,
                 bool isBlittable)
             {
                 Debug.Assert(parent != null, "Invalid parent");
@@ -67,7 +67,7 @@ namespace ILGPU.IR.Types
                 FieldOffsets = fieldOffsets;
                 FieldTypes = fieldTypes;
                 IsBlittable = isBlittable;
-                NumFlattendedFields = numFlattenedFiels;
+                NumFlattendedFields = numFlattenedFields;
             }
 
             #endregion
@@ -359,7 +359,11 @@ namespace ILGPU.IR.Types
 
                 var nestedTypeInfo = GetTypeInfoInternal(field.FieldType);
                 isBlittable &= nestedTypeInfo.IsBlittable;
-                flattenedFields += nestedTypeInfo.NumFlattendedFields;
+
+                // Empty structures are treated as having a single field.
+                flattenedFields += nestedTypeInfo.NumFlattendedFields > 0
+                    ? nestedTypeInfo.NumFlattendedFields
+                    : 1;
             }
 
             return new TypeInformation(


### PR DESCRIPTION
Empty structures in .NET occupy a hidden field.

```CSharp
struct EmptyStruct { }  // Size = 1 byte

struct ExampleStruct    // Size = 6 bytes
{
    public EmptyStruct Field1;   // Offset 0
    public ushort Field2;        // Offset 2
    public byte Field3;          // Offset 4
}
```

However, when building up the internal type information ILGPU would incorrectly treat `ExampleStruct` as having only 2 fields. Therefore, the access to `Field2` and `Field3` would use offset 0 and offset 2, rather than offset 2 and offset 4.