### PR TITLE
Changed default inlining behavior to AggressiveInlining.

### DIFF
--- a/Src/ILGPU/ContextFlags.cs
+++ b/Src/ILGPU/ContextFlags.cs
@@ -124,6 +124,9 @@ namespace ILGPU
         /// Represents an aggressive inlining policy.
         /// (all functions will be inlined).
         /// </summary>
+        [Obsolete("AggressiveInlining is now enabled by default. To enable " +
+            "conservative inlining behavior specify the flag " +
+            "ContextFlags.ConservativeInlining.")]
         AggressiveInlining = 1 << 18,
 
         /// <summary>
@@ -136,6 +139,12 @@ namespace ILGPU
         /// (e.g. for debugging purposes).
         /// </summary>
         DisableConstantPropagation = 1 << 20,
+
+        /// <summary>
+        /// Enables basic inlining heuristics and disables aggressive inlining behavior
+        /// to reduce the overall code size.
+        /// </summary>
+        ConservativeInlining = 1 << 21,
 
         // Accelerator settings
 
@@ -221,9 +230,9 @@ namespace ILGPU
                 flags |= ContextFlags.EnableDebugSymbols;
 
             if (flags.HasFlags(ContextFlags.NoInlining))
-                flags &= ~ContextFlags.AggressiveInlining;
+                flags &= ~ContextFlags.ConservativeInlining;
 
-            if (flags.HasFlags(ContextFlags.AggressiveInlining))
+            if (flags.HasFlags(ContextFlags.ConservativeInlining))
                 flags &= ~ContextFlags.NoInlining;
 
             return flags;

--- a/Src/ILGPU/IR/Transformations/Inliner.cs
+++ b/Src/ILGPU/IR/Transformations/Inliner.cs
@@ -64,7 +64,7 @@ namespace ILGPU.IR.Transformations
             }
 
             // Evaluate a simple inlining heuristic
-            if (context.HasFlags(ContextFlags.AggressiveInlining) ||
+            if (!context.HasFlags(ContextFlags.ConservativeInlining) ||
                 disassembledMethod.Instructions.Length <= MaxNumILInstructionsToInline)
             {
                 method.AddFlags(MethodFlags.Inline);


### PR DESCRIPTION
The standard inlining mechanism currently uses a simple heuristic by default to decide whether a function will be inlined or not. Since GPU kernels are usually used in performance critical parts of the program, it is almost always preferable to avoid nested function calls to improve performance. This PR changes the default inlining functionality to inline all functions by default (an equivalent behavior could be achieved by using the context flag `ContextFlags.AggressiveInlining`). If you want to change this behavior to the "old" standard heuristic, make sure to specify the new context flag `ContextFlags.ConservativeInlining`.