### PR TITLE
Relaxed data-length assertion in TestBase.

### DIFF
--- a/Src/ILGPU.Tests/Generic/TestBase.cs
+++ b/Src/ILGPU.Tests/Generic/TestBase.cs
@@ -228,8 +228,7 @@ namespace ILGPU.Tests
         {
             var data = buffer.GetAsArray(Accelerator.DefaultStream);
             var dataLength = length ?? data.Length;
-            Assert.True(dataLength <= data.Length);
-            Assert.Equal(dataLength, expected.Length);
+            Assert.True(dataLength <= data.Length && dataLength <= expected.Length);
             for (int i = offset ?? 0, e = dataLength; i < e; ++i)
                 Assert.Equal(expected[i], data[i]);
         }


### PR DESCRIPTION
#295 introduced an assertion issue in the `Test.Cuda` project affecting all `WarpOperation` tests. This PR relaxes the assertion added in #295 to circumvent this issue.