### PR TITLE
Upgraded UCE transformation.

### DIFF
--- a/Src/ILGPU/IR/BasicBlock.cs
+++ b/Src/ILGPU/IR/BasicBlock.cs
@@ -38,6 +38,18 @@ namespace ILGPU.IR
         #region Nested Types
 
         /// <summary>
+        /// A block reference formatter.
+        /// </summary>
+        public readonly struct ToReferenceFormatter : InlineList.IFormatter<BasicBlock>
+        {
+            /// <summary>
+            /// Formats a block by returning reference string.
+            /// </summary>
+            readonly string InlineList.IFormatter<BasicBlock>.Format(BasicBlock item) =>
+                item.ToReferenceString();
+        }
+
+        /// <summary>
         /// An equality comparer for basic blocks.
         /// </summary>
         public readonly struct Comparer : IEqualityComparer<BasicBlock>

--- a/Src/ILGPU/IR/Construction/BasicBlock.Builder.cs
+++ b/Src/ILGPU/IR/Construction/BasicBlock.Builder.cs
@@ -281,7 +281,7 @@ namespace ILGPU.IR
                     if (!(value.Value is PhiValue phiValue))
                         continue;
                     SetupInsertPosition(value);
-                    phiValue.RemapArguments(this, remapper);
+                    phiValue.RemapArguments(MethodBuilder, remapper);
                 }
             }
 

--- a/Src/ILGPU/IR/Construction/Method.Builder.cs
+++ b/Src/ILGPU/IR/Construction/Method.Builder.cs
@@ -596,7 +596,7 @@ namespace ILGPU.IR
             /// CAUTION: Applying a control-flow update to all blocks will cause all
             /// block instances to be modified.
             /// </remarks>
-            internal BasicBlockCollection<ReversePostOrder, Forwards> UpdateControlFlow()
+            public BasicBlockCollection<ReversePostOrder, Forwards> UpdateControlFlow()
             {
                 if (!updateControlFlow)
                     return SourceBlocks;

--- a/Src/ILGPU/IR/Transformations/LoopUnrolling.cs
+++ b/Src/ILGPU/IR/Transformations/LoopUnrolling.cs
@@ -84,6 +84,12 @@ namespace ILGPU.IR.Transformations
                 blocks.Contains(Source, new BasicBlock.Comparer());
 
             /// <summary>
+            /// Returns true if the given phi value references the loop entry.
+            /// </summary>
+            public readonly bool CanRemap(PhiValue phiValue) =>
+                CanRemap(phiValue.Sources);
+
+            /// <summary>
             /// Remaps the given block to the target block in the case of the source
             /// block. It returns the given block otherwise.
             /// </summary>
@@ -94,7 +100,10 @@ namespace ILGPU.IR.Transformations
             /// Returns always true and remaps the new block using
             /// <see cref="Remap(BasicBlock)"/>.
             /// </summary>
-            public readonly bool TryRemap(BasicBlock block, out BasicBlock newBlock)
+            public readonly bool TryRemap(
+                PhiValue phiValue,
+                BasicBlock block,
+                out BasicBlock newBlock)
             {
                 newBlock = Remap(block);
                 return true;
@@ -103,7 +112,10 @@ namespace ILGPU.IR.Transformations
             /// <summary>
             /// Remaps the given value to the target value (if defined).
             /// </summary>
-            public readonly Value RemapValue(BasicBlock updatedBlock, Value value) =>
+            public readonly Value RemapValue(
+                PhiValue phiValue,
+                BasicBlock updatedBlock,
+                Value value) =>
                 updatedBlock == Target ? TargetValue : value;
         }
 
@@ -291,7 +303,7 @@ namespace ILGPU.IR.Transformations
                 foreach (var entry in phiMapping)
                 {
                     entry.Key.RemapArguments(
-                        Builder[entry.Key.BasicBlock],
+                        Builder,
                         new LoopRemapper(
                             BackEdge,
                             backEdgeBlock,

--- a/Src/ILGPU/IR/Transformations/Optimizer.cs
+++ b/Src/ILGPU/IR/Transformations/Optimizer.cs
@@ -199,6 +199,7 @@ namespace ILGPU.IR.Transformations
             builder.Add(dce);
 
             builder.Add(new LoopUnrolling());
+            builder.Add(new UnreachableCodeElimination());
             builder.Add(dce);
             builder.Add(scf);
 

--- a/Src/ILGPU/IR/Values/PhiValue.cs
+++ b/Src/ILGPU/IR/Values/PhiValue.cs
@@ -407,9 +407,14 @@ namespace ILGPU.IR.Values
 
         /// <summary cref="Value.ToArgString"/>
         protected override string ToArgString() =>
-            Count < 1
-            ? string.Empty
-            : Nodes.ToString(new ValueReference.ToReferenceFormatter());
+            Count < 1 ? string.Empty : ToFullArgString();
+
+        /// <summary>
+        /// Returns a full argument string representation.
+        /// </summary>
+        private string ToFullArgString() =>
+            Nodes.ToString(new ValueReference.ToReferenceFormatter()) +
+            $" [{Sources.ToString(new BasicBlock.ToReferenceFormatter())}]";
 
         #endregion
     }

--- a/Src/ILGPU/IR/Values/PhiValue.cs
+++ b/Src/ILGPU/IR/Values/PhiValue.cs
@@ -32,23 +32,32 @@ namespace ILGPU.IR.Values
         /// <summary>
         /// Remaps phi argument blocks.
         /// </summary>
-        public interface IArgumentRemapper : TerminatorValue.IBlockRemapper
+        public interface IArgumentRemapper
         {
+            /// <summary>
+            /// Returns true if the given phi contains a block to remap.
+            /// </summary>
+            /// <param name="phiValue">The source phi.</param>
+            /// <returns>True, if the given phi contains the old block.</returns>
+            bool CanRemap(PhiValue phiValue);
+
             /// <summary>
             /// Tries to remap the given block to a new one.
             /// </summary>
+            /// <param name="phiValue">The source phi.</param>
             /// <param name="block">The old block to remap.</param>
             /// <param name="newBlock">The (possible) remapped new block.</param>
             /// <returns>True, if the block could be remapped.</returns>
-            bool TryRemap(BasicBlock block, out BasicBlock newBlock);
+            bool TryRemap(PhiValue phiValue, BasicBlock block, out BasicBlock newBlock);
 
             /// <summary>
             /// Remaps the given value.
             /// </summary>
+            /// <param name="phiValue">The source phi.</param>
             /// <param name="updatedBlock">The updated source information.</param>
             /// <param name="value">The original source value passed to the phi.</param>
             /// <returns>The new value to use instead.</returns>
-            Value RemapValue(BasicBlock updatedBlock, Value value);
+            Value RemapValue(PhiValue phiValue, BasicBlock updatedBlock, Value value);
         }
 
         /// <summary>
@@ -80,18 +89,20 @@ namespace ILGPU.IR.Values
             /// <summary>
             /// Returns true if the given blocks contain the old block.
             /// </summary>
-            /// <param name="blocks">The blocks to check.</param>
             /// <returns>True, if the given blocks contain the old block.</returns>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public readonly bool CanRemap(in ReadOnlySpan<BasicBlock> blocks) =>
-                blocks.Contains(OldBlock, new BasicBlock.Comparer());
+            public readonly bool CanRemap(PhiValue phiValue) =>
+                phiValue.Sources.Contains(OldBlock, new BasicBlock.Comparer());
 
             /// <summary>
             /// Tries to remap the old block to the new block.
             /// </summary>
             /// <returns>Returns always true.</returns>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public readonly bool TryRemap(BasicBlock block, out BasicBlock newBlock)
+            public readonly bool TryRemap(
+                PhiValue phiValue,
+                BasicBlock block,
+                out BasicBlock newBlock)
             {
                 newBlock = block == OldBlock ? NewBlock : block;
                 return true;
@@ -100,7 +111,10 @@ namespace ILGPU.IR.Values
             /// <summary>
             /// Returns the value of <paramref name="value"/>.
             /// </summary>
-            public readonly Value RemapValue(BasicBlock updatedBlock, Value value) =>
+            public readonly Value RemapValue(
+                PhiValue phiValue,
+                BasicBlock updatedBlock,
+                Value value) =>
                 value;
         }
 
@@ -331,35 +345,36 @@ namespace ILGPU.IR.Values
         /// Remaps the current phi arguments.
         /// </summary>
         /// <typeparam name="TArgumentRemaper">The argument remapper type.</typeparam>
-        /// <param name="blockBuilder">The current block builder.</param>
+        /// <param name="methodBuilder">The parent method builder.</param>
         /// <param name="remapper">The remapper instance.</param>
         /// <returns>The remapped phi value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public PhiValue RemapArguments<TArgumentRemaper>(
-            BasicBlock.Builder blockBuilder,
+        public Value RemapArguments<TArgumentRemaper>(
+            Method.Builder methodBuilder,
             in TArgumentRemaper remapper)
             where TArgumentRemaper : IArgumentRemapper
         {
             // Check for a valid block association
-            this.Assert(blockBuilder.BasicBlock == BasicBlock);
-            if (!remapper.CanRemap(Sources))
+            this.Assert(methodBuilder.Method == BasicBlock.Method);
+            if (!remapper.CanRemap(this))
                 return this;
 
+            var blockBuilder = methodBuilder[BasicBlock];
             var phiBuilder = blockBuilder.CreatePhi(Location, Type);
             for (int i = 0, e = Nodes.Length; i < e; ++i)
             {
-                if (!remapper.TryRemap(Sources[i], out var newSource))
+                if (!remapper.TryRemap(this, Sources[i], out var newSource))
                     continue;
 
                 phiBuilder.AddArgument(
                     newSource,
-                    remapper.RemapValue(newSource, Nodes[i]));
+                    remapper.RemapValue(this, newSource, Nodes[i]));
             }
 
             var newPhi = phiBuilder.Seal();
             Replace(newPhi);
             blockBuilder.Remove(this);
-            return newPhi;
+            return newPhi.TryRemoveTrivialPhi(methodBuilder);
         }
 
         /// <summary cref="Value.ComputeType(in ValueInitializer)"/>


### PR DESCRIPTION
This PR updates the currently implemented (but disabled) `UnreachableCodeElimination` transformation and adds it to the `O2` pipeline. Applying UCE can improve runtime performance of the generated kernel programs by removing unnecessary parts of the program and simplifying control-flow patterns. Moreover, this PR enhances the simplification of `PhiValues` that can be trivially removed on-the-fly.