### PR TITLE
Fixed invalid assignment of flags in `IfBranch`.

### DIFF
--- a/Src/ILGPU/IR/Values/Terminators.cs
+++ b/Src/ILGPU/IR/Values/Terminators.cs
@@ -483,6 +483,7 @@ namespace ILGPU.IR.Values
             Location.Assert(
                 condition.Type.IsPrimitiveType &&
                 condition.Type.BasicValueType == BasicValueType.Int1);
+            Flags = flags;
 
             var targets = BlockList.Create(trueTarget, falseTarget);
             SealTargets(ref targets);


### PR DESCRIPTION
The PTX block scheduling PR #274 contains a small issue that causes the PTX backend to emit slower code than before when using `O2`. This patch fixes this performance issue by adding a missing assignment.