### PR TITLE
Enhanced allocation alignment

### DIFF
--- a/Src/ILGPU/Backends/PTX/PTXBackend.cs
+++ b/Src/ILGPU/Backends/PTX/PTXBackend.cs
@@ -46,6 +46,12 @@ namespace ILGPU.Backends.PTX
         /// </remarks>
         public const int DefaultGlobalMemoryAlignment = 256;
 
+        /// <summary>
+        /// Returns the default shared memory alignment in bytes to benefit from
+        /// vectorized IO operations in most cases.
+        /// </summary>
+        public const int DefaultSharedMemoryAlignment = 4;
+
         #endregion
 
         #region Nested Types

--- a/Src/ILGPU/Backends/PTX/PTXCodeGenerator.cs
+++ b/Src/ILGPU/Backends/PTX/PTXCodeGenerator.cs
@@ -451,6 +451,15 @@ namespace ILGPU.Backends.PTX
         #region General Code Generation
 
         /// <summary>
+        /// Returns the alignment in bytes for the given alloca.
+        /// </summary>
+        /// <param name="alloca">The alloca to get the alignment information for.</param>
+        /// <returns>The determined and used alignment in bytes.</returns>
+        protected int GetAllocaAlignment(Alloca alloca) =>
+            PointerAlignments?.GetAllocaAlignment(alloca) ??
+            AllocaAlignments.GetInitialAlignment(alloca);
+
+        /// <summary>
         /// Declares a new label.
         /// </summary>
         /// <returns>The declared label.</returns>
@@ -599,8 +608,7 @@ namespace ILGPU.Backends.PTX
                 Builder.Append(addressSpacePrefix);
 
                 Builder.Append(".align ");
-                Builder.Append(
-                    PointerAlignments.GetInitialAlignment(allocaInfo.Alloca));
+                Builder.Append(GetAllocaAlignment(allocaInfo.Alloca));
                 Builder.Append(" .b8 ");
 
                 var name = namePrefix + offset++;

--- a/Src/ILGPU/Backends/PTX/PTXKernelFunctionGenerator.cs
+++ b/Src/ILGPU/Backends/PTX/PTXKernelFunctionGenerator.cs
@@ -121,12 +121,12 @@ namespace ILGPU.Backends.PTX
                 return;
 
             // Get global alignment information
-            int sharedAlignmentInBytes = 1;
+            int sharedAlignmentInBytes = PTXBackend.DefaultSharedMemoryAlignment;
             foreach (var alloca in Allocas.DynamicSharedAllocations)
             {
                 sharedAlignmentInBytes = Math.Max(
                     sharedAlignmentInBytes,
-                    PointerAlignments.GetInitialAlignment(alloca.Alloca));
+                    GetAllocaAlignment(alloca.Alloca));
             }
             sharedAlignmentInBytes = Math.Min(
                 sharedAlignmentInBytes,

--- a/Src/ILGPU/IR/Values/Memory.cs
+++ b/Src/ILGPU/IR/Values/Memory.cs
@@ -11,7 +11,6 @@
 
 using ILGPU.IR.Construction;
 using ILGPU.IR.Types;
-using System.Diagnostics;
 
 namespace ILGPU.IR.Values
 {
@@ -55,10 +54,9 @@ namespace ILGPU.IR.Values
             MemoryAddressSpace addressSpace)
             : base(initializer)
         {
-            Debug.Assert(
+            this.Assert(
                 addressSpace == MemoryAddressSpace.Local ||
-                addressSpace == MemoryAddressSpace.Shared,
-                "Invalid alloca address space");
+                addressSpace == MemoryAddressSpace.Shared);
 
             AllocaType = allocaType;
             AddressSpace = addressSpace;

--- a/Src/ILGPU/IR/Values/PointerValues.cs
+++ b/Src/ILGPU/IR/Values/PointerValues.cs
@@ -53,6 +53,21 @@ namespace ILGPU.IR.Values
         /// </summary>
         public bool Is64bitAccess => Offset.BasicValueType == BasicValueType.Int64;
 
+        /// <summary>
+        /// Returns the view element type.
+        /// </summary>
+        public IAddressSpaceType AddressSpaceType => Type as IAddressSpaceType;
+
+        /// <summary>
+        /// Returns the pointer address space.
+        /// </summary>
+        public MemoryAddressSpace AddressSpace => AddressSpaceType.AddressSpace;
+
+        /// <summary>
+        /// Returns the element type.
+        /// </summary>
+        public TypeNode ElementType => AddressSpaceType.ElementType;
+
         #endregion
     }
 


### PR DESCRIPTION
The current allocation alignment rules (for shared and local memory) are based on the actual type used to perform the allocation:
```c#
var sharedMemory = SharedMemory.Allocate<int>(42);
```

Since the available memory size (e.g. in the case of shared memory) is usually limited, many programmers often tend to leverage reinterpret casts to use the available space in combination with different types:

```c#
var sharedMemory = SharedMemory.Allocate<int>(42);
...

var float2Shared = sharedMemory.Cast<Float2>();
```

Unfortunately, ILGPU is currently not able to use efficiently vectorized-IO operations in these cases. This is caused by the alignment information that has been determined using the initially allocated type (`int` in this case). Many programmers currently seem to work around this limitation by adapting their programs in a way that they use the "largest" type when allocating a chunk of memory and then use additional reinterpret casts, as shown in the following example:
```c#
var allocatedMemory = SharedMemory.Allocate<Float2>(42);
...
var sharedMemory = allocatedMemory.Cast<Float2>();
...

var float2Shared = allocatedMemory.Cast<Float2>();
```

This PR automatically determines the "best" alignment (given by the maximal alignment of all potentially involved types) for each allocation. Hence, it is no longer required to work around this limitation.

Note that this feature in enabled in the scope of the `O2` pipeline.