### PR TITLE
Fixed race condition of memory initialization in tests

### DIFF
--- a/Src/ILGPU.Tests/ExchangeBufferOperations.cs
+++ b/Src/ILGPU.Tests/ExchangeBufferOperations.cs
@@ -448,11 +448,14 @@ namespace ILGPU.Tests
             int extent)
         {
             using var stream = Accelerator.CreateStream();
-            using var exchangeBuffer =
-                    Accelerator.AllocateExchangeBuffer<long>(bufferSize);
+            using var exchangeBuffer = Accelerator.AllocateExchangeBuffer<long>(
+                bufferSize);
+            exchangeBuffer.Buffer.MemSetToZero(stream);
+            stream.Synchronize();
+
+            // Fill data on the CPU side
             for (int i = 0; i < bufferSize; ++i)
                 exchangeBuffer[i] = constant;
-            exchangeBuffer.Buffer.MemSetToZero();
 
             // Start copying, create the expected array in the meantime
             exchangeBuffer.CopyToAccelerator(stream, cpuOffset, accelOffset, extent);
@@ -490,8 +493,12 @@ namespace ILGPU.Tests
             int extent)
         {
             using var stream = Accelerator.CreateStream();
-            using var exchangeBuffer =
-                    Accelerator.AllocateExchangeBuffer<long>(bufferSize);
+            using var exchangeBuffer = Accelerator.AllocateExchangeBuffer<long>(
+                bufferSize);
+            exchangeBuffer.Buffer.MemSetToZero(stream);
+            stream.Synchronize();
+
+            // Fill data on the CPU side
             for (int i = 0; i < bufferSize; ++i)
                 exchangeBuffer[i] = constant;
 


### PR DESCRIPTION
This PR fixes a race condition in the `ExchangeBufferOperation` tests that can appear during the initialization phase. This issues caused the PR #297 to fail on the remote build machine.