### PR TITLE
Fixed loading unsigned fields from structures. 

### DIFF
--- a/Src/ILGPU.Tests/StructureValues.cs
+++ b/Src/ILGPU.Tests/StructureValues.cs
@@ -323,6 +323,44 @@ namespace ILGPU.Tests
                 expected);
             Verify(buffer, new[] { expected });
         }
+
+        internal struct UnsignedFieldStruct
+        {
+            public byte x;
+            public ushort y;
+            public uint z;
+        }
+
+        internal static void StructureUnsignedFieldKernel(
+            Index1 index,
+            ArrayView<long> output,
+            UnsignedFieldStruct input)
+        {
+            output[index] = input.x;
+            output[index + 1] = input.y;
+            output[index + 2] = input.z;
+        }
+
+        [Fact]
+        [KernelMethod(nameof(StructureUnsignedFieldKernel))]
+        public void StructureUnsignedField()
+        {
+            var maxUInt8 = byte.MaxValue;
+            var maxUInt16 = ushort.MaxValue;
+            var maxUInt32= uint.MaxValue;
+            var expected = new long[] { maxUInt8, maxUInt16, maxUInt32 };
+
+            var input = new UnsignedFieldStruct
+            {
+                x = maxUInt8,
+                y = maxUInt16,
+                z = maxUInt32
+            };
+
+            using var output = Accelerator.Allocate<long>(3);
+            Execute(1, output.View, input);
+            Verify(output, expected);
+        }
     }
 }
 

--- a/Src/ILGPU/Frontend/CodeGenerator/Fields.cs
+++ b/Src/ILGPU/Frontend/CodeGenerator/Fields.cs
@@ -55,7 +55,16 @@ namespace ILGPU.Frontend
                     new FieldSpan(
                         absoluteIndex,
                         typeInfo.NumFlattendedFields));
-                Block.Push(getField);
+                if (typeInfo.NumFlattendedFields == 1)
+                {
+                    Block.Push(LoadOntoEvaluationStack(
+                        getField,
+                        field.FieldType.ToTargetUnsignedFlags()));
+                }
+                else
+                {
+                    Block.Push(getField);
+                }
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/m4rs-mt/ILGPU/issues/301.

<del>When calling `ToTargetUnsignedFlags()`, we use the original managed type of the variable. When we ask the original managed type if it is unsigned, structures return false (as expected). However, the ILGPU IR simplifies single element structures into a primitive type. In this case, if the primitive type is unsigned, `ToTargetUnsignedFlags()` incorrectly returns false (should be true).</del>

<del>The fix is to ask the managed type of the returned IR Type Node if it is unsigned.</del>