### PR TITLE
Added convenience Launch methods to Accelerator class.

### DIFF
--- a/Src/ILGPU/ContextFlags.cs
+++ b/Src/ILGPU/ContextFlags.cs
@@ -197,7 +197,8 @@ namespace ILGPU
         DisableAcceleratorGC =
             DisableKernelCaching |
             DisableAutomaticBufferDisposal |
-            DisableAutomaticKernelDisposal,
+            DisableAutomaticKernelDisposal |
+            DisableKernelLaunchCaching,
 
         /// <summary>
         /// Enforces the use of the default PTX backend features.
@@ -209,6 +210,17 @@ namespace ILGPU
         /// the kernel programs being generated.
         /// </summary>
         EnhancedPTXBackendFeatures = 1 << 28,
+
+        /// <summary>
+        /// Disables the implicit kernel launch cache.
+        /// </summary>
+        /// <remarks>
+        /// However, IR nodes, type information and debug information will still
+        /// be cached, since they are used for different kernel compilation operations.
+        /// If you want to clear those caches as well, you will have to clear them
+        /// manually using <see cref="Context.ClearCache(ClearCacheMode)"/>.
+        /// </remarks>
+        DisableKernelLaunchCaching = 1 << 29,
     }
 
     /// <summary>

--- a/Src/ILGPU/Runtime/Accelerator.Launchers.cs
+++ b/Src/ILGPU/Runtime/Accelerator.Launchers.cs
@@ -1,0 +1,129 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                        Copyright (c) 2016-2020 Marcel Koester
+//                                    www.ilgpu.net
+//
+// File: Accelerator.Launchers.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace ILGPU.Runtime
+{
+    partial class Accelerator
+    {
+        #region Nested Types
+
+        /// <summary>
+        /// Represents an abstract kernel-launch loader.
+        /// </summary>
+        /// <typeparam name="TSource">The source delegate type.</typeparam>
+        /// <typeparam name="TTarget">The target delegate type.</typeparam>
+        private interface IKernelLaunchLoader<TSource, TTarget>
+            where TSource : Delegate
+            where TTarget : Delegate
+        {
+            /// <summary>
+            /// Loads the internal launcher delegate using the <paramref name="source"/>
+            /// CPU kernel delegate.
+            /// </summary>
+            /// <param name="accelerator">The parent accelerator.</param>
+            /// <param name="source">The source kernel delegate to use.</param>
+            /// <returns>
+            /// The loaded launcher of type <typeparamref name="TTarget"/>.
+            /// </returns>
+            TTarget Load(Accelerator accelerator, TSource source);
+        }
+
+        #endregion
+
+        #region Instance
+
+        /// <summary>
+        /// The internal async launch cache dictionary.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private Dictionary<Delegate, Delegate> launchCache;
+
+        /// <summary>
+        /// Initializes the local launch cache.
+        /// </summary>
+        private void InitLaunchCache()
+        {
+            if (Context.HasFlags(ContextFlags.DisableKernelLaunchCaching))
+                return;
+
+            launchCache = new Dictionary<Delegate, Delegate>();
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Returns true if the launcher cache is enabled.
+        /// </summary>
+        private bool LaunchCacheEnabled => launchCache != null;
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Gets or loads the given action using the provided launcher loaded.
+        /// </summary>
+        /// <typeparam name="TSource">The source delegate type load.</typeparam>
+        /// <typeparam name="TTarget">The target kernel delegate type.</typeparam>
+        /// <typeparam name="TLaunchLoader">The specialized launcher loader.</typeparam>
+        /// <param name="action">The action to load.</param>
+        /// <returns>The loaded target delegate launcher.</returns>
+        private TTarget GetOrLoadLauncher<TSource, TTarget, TLaunchLoader>(
+            TSource action)
+            where TLaunchLoader : struct, IKernelLaunchLoader<TSource, TTarget>
+            where TSource : Delegate
+            where TTarget : Delegate
+        {
+            if (action is null)
+                throw new ArgumentNullException(nameof(action));
+
+            // Create a new launcher loader.
+            TLaunchLoader loader = default;
+
+            // Early exit for disabled launch caches
+            if (!LaunchCacheEnabled)
+                return loader.Load(this, action);
+
+            // Synchronizes accesses with the launch cache
+            lock (syncRoot)
+            {
+                // Try to load a previously loaded delegate and ensure that the loaded
+                // launcher is compatible with the desired target delegate type
+                if (!launchCache.TryGetValue(action, out var launcher) ||
+                    !(launcher is TTarget))
+                {
+                    // Load the launcher using the provided loader
+                    launcher = loader.Load(this, action);
+                    launchCache.Add(action, launcher);
+                }
+                return launcher as TTarget;
+            }
+        }
+
+        /// <summary>
+        /// Clears the internal cache.
+        /// </summary>
+        private void ClearLaunchCache_SyncRoot()
+        {
+            if (!LaunchCacheEnabled)
+                return;
+            launchCache.Clear();
+        }
+
+        #endregion
+    }
+}

--- a/Src/ILGPU/Runtime/Accelerator.cs
+++ b/Src/ILGPU/Runtime/Accelerator.cs
@@ -153,6 +153,7 @@ namespace ILGPU.Runtime
             AutomaticKernelDisposalEnabled = !context.HasFlags(
                 ContextFlags.DisableAutomaticKernelDisposal);
             InitKernelCache();
+            InitLaunchCache();
             InitGC();
 
             memoryCache = new MemoryBufferCache(this);
@@ -442,6 +443,7 @@ namespace ILGPU.Runtime
             {
                 Backend.ClearCache(mode);
                 ClearKernelCache_SyncRoot();
+                ClearLaunchCache_SyncRoot();
                 base.ClearCache(mode);
             }
         }

--- a/Src/ILGPU/Runtime/KernelLoaders.tt
+++ b/Src/ILGPU/Runtime/KernelLoaders.tt
@@ -24,11 +24,16 @@
         TypeParams = string.Join(", ", from rangeIdx in range select $"T{rangeIdx}"),
         DefaultStreamLambdaParams = string.Join(", ", from rangeIdx in range select $"T{rangeIdx} param{rangeIdx}"),
         DefaultStreamArgs = string.Join(", ", from rangeIdx in range select $"param{rangeIdx}"),
+        KernelLaunchArgs = string.Join(", ", from rangeIdx in range select $"arg{rangeIdx}"),
+        KernelLaunchParams = string.Join(", ", from rangeIdx in range select $"T{rangeIdx} arg{rangeIdx}"),
+        KernelLaunchParamsDocumentation = string.Join("        /// ", from rangeIdx in range select
+            $"<param name=\"arg{rangeIdx}\">Argument {rangeIdx} of the underlying kernel.</param>{Environment.NewLine}"),
         TypeRestrictions = string.Join(" ", from rangeIdx in range select $"where T{rangeIdx} : struct"),
         TypeParamDocumentation = string.Join("        /// ", from rangeIdx in range select
-            $"<typeparam name=\"T{rangeIdx}\">Parameter type of parameter {rangeIdx}.</typeparam>{Environment.NewLine}"), 
+            $"<typeparam name=\"T{rangeIdx}\">Parameter type of parameter {rangeIdx}.</typeparam>{Environment.NewLine}"),
     }; #>
 using System;
+using System.Runtime.CompilerServices;
 
 #pragma warning disable IDE0046 // Convert to conditional expression
 
@@ -471,6 +476,112 @@ namespace ILGPU.Runtime
             return (TIndex index, <#= delegateParams.DefaultStreamLambdaParams #>) =>
                 baseKernel(accelerator.DefaultStream, index, <#= delegateParams.DefaultStreamArgs #>);
         }
+
+<#  } #>
+    }
+
+    // Additional accelerator launch methods
+
+    partial class Accelerator
+    {
+        #region Nested Types
+
+<# foreach (var delegateParams in delegateRange) { #>
+        /// <summary>
+        /// Wraps an explicit kernel loader.
+        /// </summary>
+        private readonly struct KernelLaunchLoader<<#= delegateParams.TypeParams #>> : IKernelLaunchLoader<
+            Action<<#= delegateParams.TypeParams #>>,
+            Action<AcceleratorStream, KernelConfig, <#= delegateParams.TypeParams #>>>
+            <#= delegateParams.TypeRestrictions #>
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public readonly Action<AcceleratorStream, KernelConfig, <#= delegateParams.TypeParams #>> Load(
+                Accelerator accelerator,
+                Action<<#= delegateParams.TypeParams #>> source) =>
+                KernelLoaders.LoadKernel(accelerator, source);
+        }
+
+        /// <summary>
+        /// Wraps an automatically grouped kernel loader.
+        /// </summary>
+        private readonly struct KernelLaunchAutoGroupedLoader<TIndex, <#= delegateParams.TypeParams #>> : IKernelLaunchLoader<
+            Action<TIndex, <#= delegateParams.TypeParams #>>,
+            Action<AcceleratorStream, TIndex, <#= delegateParams.TypeParams #>>>
+            where TIndex : struct, IIndex
+            <#= delegateParams.TypeRestrictions #>
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public readonly Action<AcceleratorStream, TIndex, <#= delegateParams.TypeParams #>> Load(
+                Accelerator accelerator,
+                Action<TIndex, <#= delegateParams.TypeParams #>> source) =>
+                KernelLoaders.LoadAutoGroupedKernel(accelerator, source);
+        }
+
+<# } #>
+
+        #endregion
+
+<# foreach (var delegateParams in delegateRange) { #>
+<#      // Launch #>
+        /// <summary>
+        /// Loads the given kernel and launches it immediately using the given arguments.
+        /// </summary>
+        /// <#= delegateParams.TypeParamDocumentation #>
+        /// <param name="action">The action to compile into a kernel.</param>
+        /// <param name="stream">The stream to use.</param>
+        /// <param name="kernelConfig">The launch configuration.</param>
+        /// <#= delegateParams.KernelLaunchParamsDocumentation #>
+        /// <remarks>
+        /// Uses the internal launcher cache that explicitly caches all launched kernels
+        /// using strong references. To avoid caching use the context flag
+        /// <see cref="ContextFlags.DisableKernelLaunchCaching" />.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Launch<<#= delegateParams.TypeParams #>>(
+            Action<<#= delegateParams.TypeParams #>> action,
+            AcceleratorStream stream,
+            in KernelConfig kernelConfig,
+            <#= delegateParams.KernelLaunchParams #>)
+            <#= delegateParams.TypeRestrictions #> =>
+            GetOrLoadLauncher<
+                Action<<#= delegateParams.TypeParams #>>,
+                Action<AcceleratorStream, KernelConfig, <#= delegateParams.TypeParams #>>,
+                KernelLaunchLoader<<#= delegateParams.TypeParams #>>>(action)(
+                stream,
+                kernelConfig,
+                <#= delegateParams.KernelLaunchArgs #>);
+
+<#      // LaunchAutoGrouped #>
+        /// <summary>
+        /// Loads the given kernel and launches it immediately using the given arguments.
+        /// </summary>
+        /// <typeparam name="TIndex">The index type.</typeparam>
+        /// <#= delegateParams.TypeParamDocumentation #>
+        /// <param name="action">The action to compile into a kernel.</param>
+        /// <param name="stream">The stream to use.</param>
+        /// <param name="extent">The launch extent.</param>
+        /// <#= delegateParams.KernelLaunchParamsDocumentation #>
+        /// <remarks>
+        /// Uses the internal launcher cache that explicitly caches all launched kernels
+        /// using strong references. To avoid caching use the context flag
+        /// <see cref="ContextFlags.DisableKernelLaunchCaching" />.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void LaunchAutoGrouped<TIndex, <#= delegateParams.TypeParams #>>(
+            Action<TIndex, <#= delegateParams.TypeParams #>> action,
+            AcceleratorStream stream,
+            TIndex extent,
+            <#= delegateParams.KernelLaunchParams #>)
+            where TIndex : struct, IGenericIndex<TIndex>
+            <#= delegateParams.TypeRestrictions #> =>
+            GetOrLoadLauncher<
+                Action<TIndex, <#= delegateParams.TypeParams #>>,
+                Action<AcceleratorStream, TIndex, <#= delegateParams.TypeParams #>>,
+                KernelLaunchAutoGroupedLoader<TIndex, <#= delegateParams.TypeParams #>>>(action)(
+                stream,
+                extent,
+                <#= delegateParams.KernelLaunchArgs #>);
 
 <#  } #>
     }


### PR DESCRIPTION
Many people in the community requested simplified and "immediate" kernel launch methods (similar to those provided by other frameworks). This PR adds additional direct `Launch` methods to the `Accelerator` class using a new strong-reference based kernel cache. This new cache is used for the launch methods only and can be disabled via the flag `ContextFlags.DisableKernelLaunchCaching`.