### PR TITLE
Added support for .NET 5.0.

### DIFF
--- a/Src/ILGPU.Tests.CPU/ILGPU.Tests.CPU.csproj
+++ b/Src/ILGPU.Tests.CPU/ILGPU.Tests.CPU.csproj
@@ -7,6 +7,10 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Channel)' == 'experimental'">
+    <TargetFrameworks>$(TargetFrameworks);net5.0</TargetFrameworks>
+  </PropertyGroup>
+
   <PropertyGroup>
     <RunSettingsFilePath>$(MSBuildProjectDirectory)\..\ILGPU.Tests\.test.runsettings</RunSettingsFilePath>
   </PropertyGroup>

--- a/Src/ILGPU.Tests.Cuda/ILGPU.Tests.Cuda.csproj
+++ b/Src/ILGPU.Tests.Cuda/ILGPU.Tests.Cuda.csproj
@@ -7,6 +7,10 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Channel)' == 'experimental'">
+    <TargetFrameworks>$(TargetFrameworks);net5.0</TargetFrameworks>
+  </PropertyGroup>
+
   <PropertyGroup>
     <RunSettingsFilePath>$(MSBuildProjectDirectory)\..\ILGPU.Tests\.test.runsettings</RunSettingsFilePath>
   </PropertyGroup>

--- a/Src/ILGPU.Tests.OpenCL/ILGPU.Tests.OpenCL.csproj
+++ b/Src/ILGPU.Tests.OpenCL/ILGPU.Tests.OpenCL.csproj
@@ -7,6 +7,10 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Channel)' == 'experimental'">
+    <TargetFrameworks>$(TargetFrameworks);net5.0</TargetFrameworks>
+  </PropertyGroup>
+
   <PropertyGroup>
     <RunSettingsFilePath>$(MSBuildProjectDirectory)\..\ILGPU.Tests\.test.runsettings</RunSettingsFilePath>
   </PropertyGroup>

--- a/Src/ILGPU.Tests/ExchangeBufferOperations.cs
+++ b/Src/ILGPU.Tests/ExchangeBufferOperations.cs
@@ -134,10 +134,6 @@ namespace ILGPU.Tests
         // No need for kernel, assuming copy tests pass.
         // Just going to confirm integrity in this test.
         [Fact]
-        [SuppressMessage(
-            "Microsoft.Performance",
-            "CA1814: PreferJaggedArraysOverMultidimensional",
-            Target = "target")]
         public void GetAsArray()
         {
             using var exchangeBuffer = Accelerator.AllocateExchangeBuffer<long>(

--- a/Src/ILGPU.Tests/ILGPU.Tests.csproj
+++ b/Src/ILGPU.Tests/ILGPU.Tests.csproj
@@ -7,6 +7,10 @@
     <StartupObject />
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Channel)' == 'experimental'">
+    <TargetFrameworks>$(TargetFrameworks);net5.0</TargetFrameworks>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/Src/ILGPU/ArrayView.cs
+++ b/Src/ILGPU/ArrayView.cs
@@ -93,10 +93,6 @@ namespace ILGPU
     /// Represents an abstract array view.
     /// </summary>
     /// <typeparam name="T">The element type.</typeparam>
-    [SuppressMessage(
-        "Microsoft.Design",
-        "CA1040: AvoidEmptyInterfaces",
-        Justification = "Can be used in generic constraints")]
     public interface IArrayView<T> : IArrayView<T, Index1, LongIndex1>
         where T : unmanaged
     { }

--- a/Src/ILGPU/Backends/EntryPoints/ParameterCollection.cs
+++ b/Src/ILGPU/Backends/EntryPoints/ParameterCollection.cs
@@ -15,6 +15,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
 
 namespace ILGPU.Backends.EntryPoints
 {
@@ -127,9 +128,9 @@ namespace ILGPU.Backends.EntryPoints
 
             var specializedParameters =
                 ImmutableArray.CreateBuilder<SpecializedParameter>(parameterTypes.Length);
-            for (int i = 0, e = Count; i < e; ++i)
+            for (int i = 0, e = ParameterTypes.Length; i < e; ++i)
             {
-                var paramType = this[i];
+                var paramType = GetParameterType(ParameterTypes, i);
                 if (paramType.IsSpecializedType(out var nestedType))
                 {
                     specializedParameters.Add(new SpecializedParameter(
@@ -170,18 +171,26 @@ namespace ILGPU.Backends.EntryPoints
         /// </summary>
         /// <param name="index">The parameter index.</param>
         /// <returns>The desired parameter type.</returns>
-        public Type this[int index]
-        {
-            get
-            {
-                var type = ParameterTypes[index];
-                return type.IsByRef ? type.GetElementType() : type;
-            }
-        }
+        public Type this[int index] => GetParameterType(ParameterTypes, index);
 
         #endregion
 
         #region Methods
+
+        /// <summary>
+        /// Returns the underlying parameter type (without references).
+        /// </summary>
+        /// <param name="parameterTypes">The parameter types.</param>
+        /// <param name="parameterIndex">The parameter index.</param>
+        /// <returns>The desired parameter type.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Type GetParameterType(
+            ImmutableArray<Type> parameterTypes,
+            int parameterIndex)
+        {
+            var type = parameterTypes[parameterIndex];
+            return type.IsByRef ? type.GetElementType() : type;
+        }
 
         /// <summary>
         /// Returns true if the specified parameter is passed by reference.

--- a/Src/ILGPU/ILGPU.csproj
+++ b/Src/ILGPU/ILGPU.csproj
@@ -7,6 +7,10 @@
         <Configurations>Debug;Release</Configurations>
     </PropertyGroup>
 
+    <PropertyGroup Condition="'$(Channel)' == 'experimental'">
+        <TargetFrameworks>$(TargetFrameworks);net5.0</TargetFrameworks>
+    </PropertyGroup>
+
     <PropertyGroup>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <VersionPrefix>0.10.0-beta1</VersionPrefix>

--- a/Src/ILGPU/IR/BasicBlockCollection.cs
+++ b/Src/ILGPU/IR/BasicBlockCollection.cs
@@ -99,10 +99,6 @@ namespace ILGPU.IR
             /// </summary>
             public struct Enumerator : IEnumerator<BasicBlock.ValueEntry>
             {
-                [SuppressMessage(
-                    "Style",
-                    "IDE0044:Add readonly modifier",
-                    Justification = "This instance variable will be modified")]
                 private BasicBlockCollection<TOrder, TDirection>.Enumerator
                     blockEnumerator;
                 private BasicBlock.Enumerator valueEnumerator;

--- a/Src/ILGPU/Runtime/Cuda/CudaException.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaException.cs
@@ -69,7 +69,9 @@ namespace ILGPU.Runtime.Cuda
 
         /// <summary cref="Exception.GetObjectData(
         /// SerializationInfo, StreamingContext)"/>
+#if !NET5_0
         [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
+#endif
         public override void GetObjectData(
             SerializationInfo info,
             StreamingContext context)

--- a/Src/ILGPU/Runtime/OpenCL/CLException.cs
+++ b/Src/ILGPU/Runtime/OpenCL/CLException.cs
@@ -66,7 +66,9 @@ namespace ILGPU.Runtime.OpenCL
         #region Methods
 
         /// <summary cref="Exception.GetObjectData(SerializationInfo, StreamingContext)"/>
+#if !NET5_0
         [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
+#endif
         public override void GetObjectData(
             SerializationInfo info, StreamingContext context)
         {


### PR DESCRIPTION
ILGPU already supports .NET 5.0 through .NET Standard 2.1. This PR adds explicit support for .NET 5.0, and fixes a few minor issues found with the new compiler.

QUESTION: Should the unit tests be updated to .NET 5.0? or multi-targeted with .NET 5.0?