### PR TITLE
Fixed calling ambiguous OpenCL 64-bit atomic functions.

### DIFF
--- a/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Values.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Values.cs
@@ -286,7 +286,9 @@ namespace ILGPU.Backends.OpenCL
             statement.BeginArguments();
             statement.AppendAtomicCast(atomic.ArithmeticBasicValueType);
             statement.AppendArgument(target);
-            statement.AppendArgument(value);
+            statement.AppendArgument();
+            statement.AppendCast(atomic.ArithmeticBasicValueType);
+            statement.Append(value);
             statement.EndArguments();
         }
 


### PR DESCRIPTION
When running `ILGPU.Algorithms.Tests.OpenCL.CLHistogramTests.Histogram1D_CreateBinUInt64FromUInt64`, noticed a failure to call the 64-bit OpenCL atomic functions.

Error message appears to be because there are multiple potential candidates.
```
3:137:16: error: call to 'atomic_fetch_add' is ambiguous
        long var51 =  atomic_fetch_add ((atomic_ulong*)var49, 1);
                      ^~~~~~~~~~~~~~~~
./opencl-c.h:13733:14: note: candidate function
ulong __ovld atomic_fetch_add(volatile atomic_ulong *object, ulong operand);
             ^
./opencl-c.h:13785:18: note: candidate function
uintptr_t __ovld atomic_fetch_add(volatile atomic_uintptr_t *object, ptrdiff_t operand);
```

This PR fixes the issue by applying a typecast to the second parameter, to avoid the ambiguity.