### PR TITLE
New convenient alignment methods for views

### DIFF
--- a/Src/ILGPU.Tests/Generic/TestData.cs
+++ b/Src/ILGPU.Tests/Generic/TestData.cs
@@ -83,6 +83,47 @@ namespace ILGPU.Tests
         public override int GetHashCode() => 0;
     }
 
+    public static class PairStruct
+    {
+        public static PairStruct<float, float> MaxFloats =>
+            new PairStruct<float, float>(float.MaxValue, float.MaxValue);
+
+        public static PairStruct<double, double> MaxDoubles =>
+            new PairStruct<double, double>(double.MaxValue, double.MaxValue);
+    }
+
+    [Serializable]
+    public struct PairStruct<T1, T2> : IXunitSerializable
+        where T1 : struct
+        where T2 : struct
+    {
+        public PairStruct(T1 val0, T2 val1)
+        {
+            Val0 = val0;
+            Val1 = val1;
+        }
+
+        public T1 Val0;
+        public T2 Val1;
+
+        public void Deserialize(IXunitSerializationInfo info)
+        {
+            Val0 = info.GetValue<T1>(nameof(Val0));
+            Val1 = info.GetValue<T2>(nameof(Val1));
+        }
+
+        public void Serialize(IXunitSerializationInfo info)
+        {
+            info.AddValue(nameof(Val0), Val0);
+            info.AddValue(nameof(Val1), Val1);
+        }
+
+        public override int GetHashCode() =>
+            HashCode.Combine(Val0, Val1);
+
+        public override string ToString() => $"{Val0}, {Val1}";
+    }
+
     [Serializable]
     public struct TestStruct : IXunitSerializable, IEquatable<TestStruct>
     {

--- a/Src/ILGPU/ArrayView.cs
+++ b/Src/ILGPU/ArrayView.cs
@@ -132,7 +132,7 @@ namespace ILGPU
         {
             Trace.Assert(source != null, "Invalid source buffer");
             Trace.Assert(index >= 0L, "Index out of range");
-            Trace.Assert(length > 0L, "Length out of range");
+            Trace.Assert(length >= 0L, "Length out of range");
             Source = source;
             Index = index;
             Length = length;

--- a/Src/ILGPU/ArrayView.cs
+++ b/Src/ILGPU/ArrayView.cs
@@ -293,6 +293,32 @@ namespace ILGPU
         #region Methods
 
         /// <summary>
+        /// Aligns the current array view to the given alignment in bytes and returns a
+        /// view spanning the initial unaligned parts of the current view and another
+        /// view (main) spanning the remaining aligned elements of the current view.
+        /// </summary>
+        /// <param name="alignmentInBytes">The basic alignment in bytes.</param>
+        /// <returns>
+        /// The prefix and main views pointing to non-aligned and aligned sub-views of
+        /// this view.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [ViewIntrinsic(ViewIntrinsicKind.AlignTo)]
+        internal unsafe (ArrayView<T> prefix, ArrayView<T> main) AlignToInternal(
+            int alignmentInBytes)
+        {
+            long elementsToSkip = IntrinsicMath.Min(
+                Interop.ComputeAlignmentOffset(
+                    (long)LoadEffectiveAddress(),
+                    alignmentInBytes) / Interop.SizeOf<T>(),
+                Length);
+
+            return (
+                new ArrayView<T>(Source, 0, elementsToSkip),
+                new ArrayView<T>(Source, elementsToSkip, Length - elementsToSkip));
+        }
+
+        /// <summary>
         /// Loads a linear element address using the given multi-dimensional indices.
         /// </summary>
         /// <typeparam name="TIndex">The index type.</typeparam>

--- a/Src/ILGPU/ArrayViewExtensions.cs
+++ b/Src/ILGPU/ArrayViewExtensions.cs
@@ -19,7 +19,7 @@ namespace ILGPU
     /// <summary>
     /// Array view extension methods
     /// </summary>
-    public static class ArrayViewExtensions
+    public static partial class ArrayViewExtensions
     {
         #region ArrayView
 
@@ -37,6 +37,31 @@ namespace ILGPU
         public static unsafe void* LoadEffectiveAddress<T>(this ArrayView<T> view)
             where T : unmanaged =>
             view.LoadEffectiveAddress();
+
+        /// <summary>
+        /// Aligns the given array view to the specified alignment in bytes and returns a
+        /// view spanning the initial unaligned parts of the given view and another
+        /// view (main) spanning the remaining aligned elements of the given view.
+        /// </summary>
+        /// <param name="view">The source view.</param>
+        /// <param name="alignmentInBytes">The basic alignment in bytes.</param>
+        /// <returns>
+        /// The prefix and main views pointing to non-aligned and aligned sub-views of
+        /// the given view.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static (ArrayView<T> prefix, ArrayView<T> main) AlignTo<T>(
+            this ArrayView<T> view,
+            int alignmentInBytes)
+            where T : unmanaged
+        {
+            Trace.Assert(
+                alignmentInBytes > 0 &
+                (alignmentInBytes % Interop.SizeOf<T>() == 0),
+                "Invalid alignment in bytes");
+
+            return view.AlignToInternal(alignmentInBytes);
+        }
 
         /// <summary>
         /// Converts this view into a new 2D view.

--- a/Src/ILGPU/ArrayViews.tt
+++ b/Src/ILGPU/ArrayViews.tt
@@ -16,6 +16,7 @@
 <#@ import namespace="System.Text" #>
 <#@ import namespace="System.Collections.Generic" #>
 <#@ output extension=".cs" #>
+<# var alignmentValues = new int[] { 32, 64, 128, 256, 512 }; #>
 
 using ILGPU.Runtime;
 using System.Diagnostics;
@@ -24,6 +25,27 @@ using System.Runtime.InteropServices;
 
 namespace ILGPU
 {
+    partial class ArrayViewExtensions
+    {
+<#  foreach (var alignment in alignmentValues) { #>
+        /// <summary>
+        /// Aligns the given array view to the alignment of <#= alignment #> bytes and
+        /// returns a view spanning the initial unaligned parts of the given view and
+        /// another view (main) spanning the remaining aligned elements of the given view.
+        /// </summary>
+        /// <param name="view">The source view.</param>
+        /// <returns>
+        /// The prefix and main views pointing to non-aligned and aligned sub-views of
+        /// the given view.
+        /// </returns>
+        public static (ArrayView<T> prefix, ArrayView<T> main) AlignTo<#= alignment #><T>(
+            this ArrayView<T> view)
+            where T : unmanaged =>
+            AlignTo(view, <#= alignment #>);
+
+<#  } #>
+    }
+
 <#  foreach (var dim in IndexDimensions.Skip(1)) { #>
 <#      var dimension = dim.Dimension; #>
 <#      var typeName = $"ArrayView{dimension}D"; #>

--- a/Src/ILGPU/Backends/IBackendCodeGenerator.cs
+++ b/Src/ILGPU/Backends/IBackendCodeGenerator.cs
@@ -100,10 +100,22 @@ namespace ILGPU.Backends
         void GenerateCode(ConvertValue value);
 
         /// <summary>
+        /// Generates code for the given int to pointer cast.
+        /// </summary>
+        /// <param name="cast">The cast node.</param>
+        void GenerateCode(IntAsPointerCast cast);
+
+        /// <summary>
+        /// Generates code for the given pointer to int cast.
+        /// </summary>
+        /// <param name="cast">The cast node.</param>
+        void GenerateCode(PointerAsIntCast cast);
+
+        /// <summary>
         /// Generates code for the given value.
         /// </summary>
-        /// <param name="value">The node.</param>
-        void GenerateCode(PointerCast value);
+        /// <param name="cast">The cast node.</param>
+        void GenerateCode(PointerCast cast);
 
         /// <summary>
         /// Generates code for the given value.
@@ -370,7 +382,11 @@ namespace ILGPU.Backends
 
             /// <summary cref="IValueVisitor.Visit(IntAsPointerCast)"/>
             public void Visit(IntAsPointerCast value) =>
-                throw new InvalidCodeGenerationException();
+                CodeGenerator.GenerateCode(value);
+
+            /// <summary cref="IValueVisitor.Visit(PointerAsIntCast)"/>
+            public void Visit(PointerAsIntCast value) =>
+                CodeGenerator.GenerateCode(value);
 
             /// <summary cref="IValueVisitor.Visit(PointerCast)"/>
             public void Visit(PointerCast value) =>

--- a/Src/ILGPU/Backends/IBackendCodeGenerator.cs
+++ b/Src/ILGPU/Backends/IBackendCodeGenerator.cs
@@ -452,6 +452,10 @@ namespace ILGPU.Backends
             public void Visit(NewView value) =>
                 throw new InvalidCodeGenerationException();
 
+            /// <summary cref="IValueVisitor.Visit(AlignViewTo)"/>
+            public void Visit(AlignViewTo value) =>
+                throw new InvalidCodeGenerationException();
+
             /// <summary cref="IValueVisitor.Visit(GetViewLength)"/>
             public void Visit(GetViewLength value) =>
                 throw new InvalidCodeGenerationException();

--- a/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Values.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Values.cs
@@ -192,16 +192,28 @@ namespace ILGPU.Backends.OpenCL
             statement.AppendArgument(sourceValue);
         }
 
-        /// <summary cref="IBackendCodeGenerator.GenerateCode(PointerCast)"/>
-        public void GenerateCode(PointerCast value)
+        /// <summary>
+        /// Generates code for the given cast value.
+        /// </summary>
+        /// <param name="cast">The cast value to generte code for.</param>
+        private void GenerateCodeForCast(CastValue cast)
         {
-            var sourceValue = Load(value.Value);
+            var sourceValue = Load(cast.Value);
 
-            var target = Allocate(value);
+            var target = Allocate(cast);
             using var statement = BeginStatement(target);
-            statement.AppendCast(value.TargetType);
+            statement.AppendCast(cast.TargetType);
             statement.AppendArgument(sourceValue);
         }
+
+        /// <summary cref="IBackendCodeGenerator.GenerateCode(IntAsPointerCast)"/>
+        public void GenerateCode(IntAsPointerCast cast) => GenerateCodeForCast(cast);
+
+        /// <summary cref="IBackendCodeGenerator.GenerateCode(IntAsPointerCast)"/>
+        public void GenerateCode(PointerAsIntCast cast) => GenerateCodeForCast(cast);
+
+        /// <summary cref="IBackendCodeGenerator.GenerateCode(PointerCast)"/>
+        public void GenerateCode(PointerCast value) => GenerateCodeForCast(value);
 
         /// <summary cref="IBackendCodeGenerator.GenerateCode(FloatAsIntCast)"/>
         public void GenerateCode(FloatAsIntCast value)

--- a/Src/ILGPU/Backends/PTX/PTXCodeGenerator.Values.cs
+++ b/Src/ILGPU/Backends/PTX/PTXCodeGenerator.Values.cs
@@ -213,8 +213,14 @@ namespace ILGPU.Backends.PTX
             command.AppendArgument(sourceValue);
         }
 
+        /// <summary cref="IBackendCodeGenerator.GenerateCode(IntAsPointerCast)"/>
+        public void GenerateCode(IntAsPointerCast cast) => Alias(cast, cast.Value);
+
+        /// <summary cref="IBackendCodeGenerator.GenerateCode(PointerAsIntCast)"/>
+        public void GenerateCode(PointerAsIntCast cast) => Alias(cast, cast.Value);
+
         /// <summary cref="IBackendCodeGenerator.GenerateCode(PointerCast)"/>
-        public void GenerateCode(PointerCast value) => Alias(value, value.Value);
+        public void GenerateCode(PointerCast cast) => Alias(cast, cast.Value);
 
         /// <summary cref="IBackendCodeGenerator.GenerateCode(FloatAsIntCast)"/>
         public void GenerateCode(FloatAsIntCast value)

--- a/Src/ILGPU/Frontend/Intrinsic/ViewIntrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/ViewIntrinsics.cs
@@ -14,6 +14,7 @@ using ILGPU.IR.Types;
 using ILGPU.IR.Values;
 using ILGPU.Resources;
 using System;
+using System.Diagnostics;
 
 namespace ILGPU.Frontend.Intrinsic
 {
@@ -33,6 +34,7 @@ namespace ILGPU.Frontend.Intrinsic
         GetViewElementAddressByIndex,
         GetViewLinearElementAddress,
         AsLinearView,
+        AlignTo
     }
 
     /// <summary>
@@ -134,6 +136,11 @@ namespace ILGPU.Frontend.Intrinsic
                 ViewIntrinsicKind.GetViewLinearElementAddress =>
                     RemapToLinearElementAddress(ref context),
                 ViewIntrinsicKind.AsLinearView => instanceValue,
+                ViewIntrinsicKind.AlignTo =>
+                    builder.CreateAlignViewTo(
+                        location,
+                        instanceValue,
+                        context[paramOffset++]),
                 _ => throw context.Location.GetNotSupportedException(
                     ErrorMessages.NotSupportedViewIntrinsic,
                     attribute.IntrinsicKind.ToString()),

--- a/Src/ILGPU/IR/Analyses/PointerAlignments.cs
+++ b/Src/ILGPU/IR/Analyses/PointerAlignments.cs
@@ -141,6 +141,10 @@ namespace ILGPU.IR.Analyses
             {
                 case Alloca alloca:
                     return AllocaAlignments.GetInitialAlignment(alloca);
+                case AlignViewTo alignTo:
+                    // Use a compile-time known alignment constant for the alignment
+                    // information instead of type-based alignment reasoning
+                    return alignTo.GetAlignmentConstant();
                 case NewView _:
                 case BaseAddressSpaceCast _:
                 case SubViewValue _:

--- a/Src/ILGPU/IR/Construction/Cast.cs
+++ b/Src/ILGPU/IR/Construction/Cast.cs
@@ -35,6 +35,25 @@ namespace ILGPU.IR.Construction
         }
 
         /// <summary>
+        /// Creates a cast operation that casts a pointer into an integer.
+        /// </summary>
+        /// <param name="location">The current location.</param>
+        /// <param name="node">The operand.</param>
+        /// <param name="targetType">The target integer type.</param>
+        /// <returns>A node that represents the cast operation.</returns>
+        public ValueReference CreatePointerAsIntCast(
+            Location location,
+            Value node,
+            BasicValueType targetType)
+        {
+            location.Assert(node.Type.IsPointerType && targetType.IsInt());
+            return Append(new PointerAsIntCast(
+                GetInitializer(location),
+                node,
+                GetPrimitiveType(targetType)));
+        }
+
+        /// <summary>
         /// Creates a cast operation that casts the element type of a pointer
         /// but does not change its address space.
         /// </summary>

--- a/Src/ILGPU/IR/Construction/Views.cs
+++ b/Src/ILGPU/IR/Construction/Views.cs
@@ -11,6 +11,7 @@
 
 using ILGPU.IR.Types;
 using ILGPU.IR.Values;
+using ILGPU.Util;
 
 namespace ILGPU.IR.Construction
 {
@@ -77,6 +78,26 @@ namespace ILGPU.IR.Construction
                 GetInitializer(location),
                 view,
                 lengthType));
+        }
+
+        /// <summary>
+        /// Creates a node that aligns the given view to a given number of bytes.
+        /// </summary>
+        /// <param name="location">The current location.</param>
+        /// <param name="view">The source view.</param>
+        /// <param name="alignmentInBytes">The alignment in bytes.</param>
+        /// <returns>The created node.</returns>
+        public ValueReference CreateAlignViewTo(
+            Location location,
+            Value view,
+            Value alignmentInBytes)
+        {
+            location.Assert(alignmentInBytes.Type.BasicValueType.IsInt());
+
+            return Append(new AlignViewTo(
+                GetInitializer(location),
+                view,
+                alignmentInBytes));
         }
     }
 }

--- a/Src/ILGPU/IR/Construction/Views.cs
+++ b/Src/ILGPU/IR/Construction/Views.cs
@@ -99,5 +99,57 @@ namespace ILGPU.IR.Construction
                 view,
                 alignmentInBytes));
         }
+
+        /// <summary>
+        /// Creates a value that represents the alignment offset in bytes for the given
+        /// raw pointer value as integer (see
+        /// <see cref="Interop.ComputeAlignmentOffset(long, int)"/> for more information.
+        /// </summary>
+        /// <param name="location">The current location.</param>
+        /// <param name="intPtr">The raw integer pointer value.</param>
+        /// <param name="alignmentInBytes">The alignment in bytes.</param>
+        /// <returns>The created node.</returns>
+        public ValueReference CreateAlignmentOffset(
+            Location location,
+            Value intPtr,
+            Value alignmentInBytes)
+        {
+            // TODO: this is a software implementation that should be (?) implemented
+            // via a built-in IR value. This value could be lowered to the
+            // Interop.ComputeAlignmentOffset method in the future to avoid explicit
+            // code generation at this point.
+
+            // var baseOffset = (int)ptr & (alignmentInBytes - 1);
+            var baseOffset = CreateArithmetic(
+                location,
+                CreateConvertToInt32(location, intPtr),
+                CreateArithmetic(
+                    location,
+                    alignmentInBytes,
+                    CreatePrimitiveValue(location, 1),
+                    BinaryArithmeticKind.Sub),
+                BinaryArithmeticKind.And);
+
+            // offset = alignmentInBytes - baseOffset;
+            var offset = CreateArithmetic(
+                location,
+                alignmentInBytes,
+                baseOffset,
+                BinaryArithmeticKind.Sub);
+
+            // (long)(baseOffset == 0 ? baseOffset : offset)
+            var zero = CreatePrimitiveValue(location, 0);
+            return CreateConvertToInt64(
+                location,
+                CreatePredicate(
+                    location,
+                    CreateCompare(
+                        location,
+                        baseOffset,
+                        zero,
+                        CompareKind.Equal),
+                    zero,
+                    offset));
+        }
     }
 }

--- a/Src/ILGPU/IR/Transformations/LowerStructures.cs
+++ b/Src/ILGPU/IR/Transformations/LowerStructures.cs
@@ -606,6 +606,7 @@ namespace ILGPU.IR.Transformations
                 (_, value) => value.Type.IsStructureType, Keep);
             rewriter.Add<SetArrayElement>(
                 (_, value) => value.Type.IsStructureType, Keep);
+            rewriter.Add<AlignViewTo>(Keep);
 
             // Rewrite known values
             rewriter.Add<NullValue>((_, value) => value.Type.IsStructureType, Lower);

--- a/Src/ILGPU/IR/Transformations/LowerViews.cs
+++ b/Src/ILGPU/IR/Transformations/LowerViews.cs
@@ -76,7 +76,9 @@ namespace ILGPU.IR.Transformations
             RewriteConverter<
                 TypeLowering<ViewType>, ViewCast> viewCastConverter,
             RewriteConverter<
-                TypeLowering<ViewType>, LoadElementAddress> leaConverter)
+                TypeLowering<ViewType>, LoadElementAddress> leaConverter,
+            RewriteConverter<
+                TypeLowering<ViewType>, AlignViewTo> alignToConverter)
         {
             AddRewriters(rewriter);
 
@@ -92,6 +94,9 @@ namespace ILGPU.IR.Transformations
             rewriter.Add(
                 (converter, value) => value.IsViewAccess && Register(converter, value),
                 leaConverter);
+            rewriter.Add(
+                (converter, value) => Register(converter, value, value.View.Type),
+                alignToConverter);
         }
 
         /// <summary>

--- a/Src/ILGPU/IR/Values/IValueVisitor.cs
+++ b/Src/ILGPU/IR/Values/IValueVisitor.cs
@@ -74,6 +74,12 @@ namespace ILGPU.IR.Values
         /// Visits the node.
         /// </summary>
         /// <param name="value">The node.</param>
+        void Visit(PointerAsIntCast value);
+
+        /// <summary>
+        /// Visits the node.
+        /// </summary>
+        /// <param name="value">The node.</param>
         void Visit(PointerCast value);
 
         /// <summary>

--- a/Src/ILGPU/IR/Values/IValueVisitor.cs
+++ b/Src/ILGPU/IR/Values/IValueVisitor.cs
@@ -182,6 +182,12 @@ namespace ILGPU.IR.Values
         /// Visits the node.
         /// </summary>
         /// <param name="value">The node.</param>
+        void Visit(AlignViewTo value);
+
+        /// <summary>
+        /// Visits the node.
+        /// </summary>
+        /// <param name="value">The node.</param>
         void Visit(PrimitiveValue value);
 
         /// <summary>

--- a/Src/ILGPU/IR/Values/ValueKind.cs
+++ b/Src/ILGPU/IR/Values/ValueKind.cs
@@ -233,6 +233,11 @@ namespace ILGPU.IR
         GetViewLength,
 
         /// <summary>
+        /// A <see cref="Values.AlignViewTo"/> value.
+        /// </summary>
+        AlignViewTo,
+
+        /// <summary>
         /// A <see cref="Values.SubViewValue"/> value.
         /// </summary>
         SubView,

--- a/Src/ILGPU/IR/Values/ValueKind.cs
+++ b/Src/ILGPU/IR/Values/ValueKind.cs
@@ -74,6 +74,11 @@ namespace ILGPU.IR
         IntAsPointerCast,
 
         /// <summary>
+        /// A <see cref="Values.PointerAsIntCast"/> value.
+        /// </summary>
+        PointerAsIntCast,
+
+        /// <summary>
         /// A <see cref="Values.FloatAsIntCast"/> value.
         /// </summary>
         FloatAsIntCast,

--- a/Src/ILGPU/IR/Values/View.cs
+++ b/Src/ILGPU/IR/Values/View.cs
@@ -103,9 +103,43 @@ namespace ILGPU.IR.Values
     }
 
     /// <summary>
+    /// Represents a generic operation of an <see cref="ArrayView{T}"/>.
+    /// </summary>
+    public abstract class ViewOperationValue : Value
+    {
+        #region Instance
+
+        /// <summary>
+        /// Constructs a generic view operation.
+        /// </summary>
+        /// <param name="initializer">The value initializer.</param>
+        internal ViewOperationValue(in ValueInitializer initializer)
+            : base(initializer)
+        { }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Returns the underlying view.
+        /// </summary>
+        public ValueReference View => this[0];
+
+        #endregion
+
+        #region Object
+
+        /// <summary cref="Value.ToArgString"/>
+        protected override string ToArgString() => View.ToString();
+
+        #endregion
+    }
+
+    /// <summary>
     /// Represents a generic property of an <see cref="ArrayView{T}"/>.
     /// </summary>
-    public abstract class ViewPropertyValue : Value
+    public abstract class ViewPropertyValue : ViewOperationValue
     {
         #region Instance
 
@@ -127,11 +161,6 @@ namespace ILGPU.IR.Values
         #region Properties
 
         /// <summary>
-        /// Returns the underlying view.
-        /// </summary>
-        public ValueReference View => this[0];
-
-        /// <summary>
         /// Returns true if this is a 32bit element access.
         /// </summary>
         public bool Is32BitProperty => BasicValueType <= BasicValueType.Int32;
@@ -142,18 +171,10 @@ namespace ILGPU.IR.Values
         public bool Is64BitProperty => BasicValueType == BasicValueType.Int64;
 
         #endregion
-
-        #region Object
-
-        /// <summary cref="Value.ToArgString"/>
-        protected override string ToArgString() => View.ToString();
-
-        #endregion
     }
 
     /// <summary>
-    /// Represents the <see cref="ArrayView{T}.Length"/> property
-    /// inside the IR.
+    /// Represents the <see cref="ArrayView{T}.Length"/> property inside the IR.
     /// </summary>
     [ValueKind(ValueKind.GetViewLength)]
     public sealed class GetViewLength : ViewPropertyValue
@@ -213,6 +234,96 @@ namespace ILGPU.IR.Values
 
         /// <summary cref="Node.ToPrefixString"/>
         protected override string ToPrefixString() => "len";
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Aligns a view to a specified alignment in bytes.
+    /// </summary>
+    [ValueKind(ValueKind.AlignViewTo)]
+    public sealed class AlignViewTo : ViewOperationValue
+    {
+        #region Instance
+
+        /// <summary>
+        /// Constructs an aligned view.
+        /// </summary>
+        /// <param name="initializer">The value initializer.</param>
+        /// <param name="view">The underlying view.</param>
+        /// <param name="alignmentInBytes">The alignment in bytes.</param>
+        internal AlignViewTo(
+            in ValueInitializer initializer,
+            ValueReference view,
+            ValueReference alignmentInBytes)
+            : base(initializer)
+        {
+            Seal(view, alignmentInBytes);
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// The structure type.
+        /// </summary>
+        public StructureType StructureType => Type.As<StructureType>(this);
+
+        /// <summary>
+        /// Returns the alignment in bytes.
+        /// </summary>
+        public ValueReference AlignmentInBytes => this[1];
+
+        /// <summary cref="Value.ValueKind"/>
+        public override ValueKind ValueKind => ValueKind.AlignViewTo;
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Tries to determine an explicit alignment compile-time constant (primarily
+        /// for compiler analysis purposes). If this alignment information could not be
+        /// resolved, the function returns the worst-case alignment of 1.
+        /// </summary>
+        public int GetAlignmentConstant() =>
+            AlignmentInBytes.Resolve() is PrimitiveValue primitive
+            ? primitive.Int32Value
+            : 1;
+
+        /// <summary cref="Value.ComputeType(in ValueInitializer)"/>
+        protected override TypeNode ComputeType(in ValueInitializer initializer)
+        {
+            var context = initializer.Context;
+            var builder = context.CreateStructureType(2);
+            builder.Add(View.Type);
+            builder.Add(View.Type);
+            return builder.Seal();
+        }
+
+        /// <summary cref="Value.Rebuild(IRBuilder, IRRebuilder)"/>
+        protected internal override Value Rebuild(
+            IRBuilder builder,
+            IRRebuilder rebuilder) =>
+            builder.CreateAlignViewTo(
+                Location,
+                rebuilder.Rebuild(View),
+                rebuilder.Rebuild(AlignmentInBytes));
+
+        /// <summary cref="Value.Accept" />
+        public override void Accept<T>(T visitor) => visitor.Visit(this);
+
+        #endregion
+
+        #region Object
+
+        /// <summary cref="Node.ToPrefixString"/>
+        protected override string ToPrefixString() => "alignViewTo";
+
+        /// <summary cref="Value.ToArgString"/>
+        protected override string ToArgString() =>
+            $"{base.ToArgString()}, {AlignmentInBytes}";
 
         #endregion
     }


### PR DESCRIPTION
This PR adds support for `view.AlignTo<T>(int alignmentInBytes)` methods. These methods can be used to conveniently align the current array view to an explicitly defined `alignmentInBytes`. It also includes two new IR values, namely `PointerAsIntCast` and `AlignViewTo`. Both values have been added to all required static program analyses and program transformations. In addition, all backends have been adjusted to support the new operations.

There are also several utility methods that can be useful in most cases (see `ArrayViews.tt` for more information):
```c#
view.AlignTo128();
view.AlignTo256();
...
```

Sample usage:
```c#
var (prefix, main) = view.AlignTo128();
// prefix is the sub view, which includes all unaligned items at the beginning
// main is the sub view, which includes all remaining aligned items in the source view
```

Note that this PR also depends on #322, since the new `AlignViewTo` IR node is essentially implemented via a structure that can cause issues during lowering.