### PR TITLE
Fixed invalid constant propagation of comparison operations

### DIFF
--- a/Src/ILGPU.Tests/CompareIntOperations.tt
+++ b/Src/ILGPU.Tests/CompareIntOperations.tt
@@ -9,6 +9,7 @@ using Xunit.Abstractions;
 
 #pragma warning disable xUnit1025 // InlineData should be unique within the Theory it
                                   // belongs to
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
 
 <#
 var operationConfigurations = new (string, string)[]
@@ -20,11 +21,24 @@ var operationConfigurations = new (string, string)[]
         ("Equal", "=="),
         ("NotEqual", "!="),
     };
+var testValueFormats = new (int, string, string)[]
+    {
+        (0, "{0}.MaxValue", "({0})1"),
+        (1, "{0}.MinValue", "{0}.MaxValue"),
+        (2, "{0}.MinValue + 1", "{0}.MaxValue"),
+        (3, "({0})0", "{0}.MaxValue"),
+        (4, "({0})0", "{0}.MaxValue - 1"),
+        (5, "({0})1", "({0})1"),
+        (6, "({0})6", "({0})2"),
+        (7, "({0})5", "({0})19")
+    };
 #>
 namespace ILGPU.Tests
 {
     public abstract class CompareIntOperations : TestBase
     {
+        private const int Length = 32;
+
         protected CompareIntOperations(ITestOutputHelper output, TestContext testContext)
             : base(output, testContext)
         { }
@@ -45,30 +59,75 @@ namespace ILGPU.Tests
         }
 
         [Theory]
-        [InlineData(<#= type.Type #>.MaxValue, (<#= type.Type #>)1)]
-        [InlineData(<#= type.Type #>.MinValue, <#= type.Type #>.MaxValue)]
-        [InlineData(<#= type.Type #>.MinValue + 1, <#= type.Type #>.MaxValue)]
-        [InlineData((<#= type.Type #>)0, <#= type.Type #>.MaxValue)]
-        [InlineData((<#= type.Type #>)0, <#= type.Type #>.MaxValue - 1)]
-        [InlineData((<#= type.Type #>)1, (<#= type.Type #>)1)]
-        [InlineData((<#= type.Type #>)6, (<#= type.Type #>)2)]
-        [InlineData((<#= type.Type #>)5, (<#= type.Type #>)19)]
+<#          foreach (var (_, lhs, rhs) in testValueFormats) { #>
+        [InlineData(
+            <#= string.Format(lhs, type.Type) #>,
+            <#= string.Format(rhs, type.Type) #>)]
+<#          } #>
         [KernelMethod(nameof(<#= kernelName #>))]
         public void <#= testName #>(
             <#= type.Type #> left,
             <#= type.Type #> right)
         {
-            const int length = 32;
-            using var a = Accelerator.Allocate<<#= type.Type #>>(length);
-            using var b = Accelerator.Allocate<<#= type.Type #>>(length);
-            using var c = Accelerator.Allocate<int>(length);
+            using var a = Accelerator.Allocate<<#= type.Type #>>(Length);
+            using var b = Accelerator.Allocate<<#= type.Type #>>(Length);
+            using var c = Accelerator.Allocate<int>(Length);
             Initialize(a, left);
             Initialize(b, right);
-            Execute(length, a.View, b.View, c.View);
+            Execute(Length, a.View, b.View, c.View);
 
             var result = left <#= infix #> right ? 1 : 0;
-            var reference = Enumerable.Repeat(result, length).ToArray();
+            var reference = Enumerable.Repeat(result, Length).ToArray();
             Verify(c, reference);
+        }
+
+        internal static void <#= kernelName #>_Const(
+            Index1 index,
+            ArrayView<<#= type.Type #>> a,
+            ArrayView2D<int> b,
+            ArrayView2D<int> c)
+        {
+<#          foreach (var (index, lhs, rhs) in testValueFormats) { #>
+            b[index, <#= index #>] = (<#= string.Format(lhs, type.Type) #> <#= infix #>
+                a[index]) ? 1 : 0;
+            c[index, <#= index #>] = (a[index] <#= infix #>
+                <#= string.Format(rhs, type.Type) #>) ? 1 : 0;
+<#          } #>
+        }
+
+        [Theory]
+<#          foreach (var (_, lhs, rhs) in testValueFormats) { #>
+        [InlineData(<#= string.Format(lhs, type.Type) #>)]
+        [InlineData(<#= string.Format(rhs, type.Type) #>)]
+<#          } #>
+        [KernelMethod(nameof(<#= kernelName #>_Const))]
+        public void <#= testName #>_Const(<#= type.Type #> value)
+        {
+            using var a = Accelerator.Allocate<<#= type.Type #>>(Length);
+            using var b = Accelerator.Allocate<int>(
+                Length,
+                <#= testValueFormats.Length #>);
+            using var c = Accelerator.Allocate<int>(
+                Length,
+                <#= testValueFormats.Length #>);
+            Initialize(a, value);
+            Execute(Length, a.View, b.View, c.View);
+
+            // Generate reference data
+            var expectedB = new int[Length, <#= testValueFormats.Length #>];
+            var expectedC = new int[Length, <#= testValueFormats.Length #>];
+            for (int index = 0; index < Length; ++index)
+            {
+<#          foreach (var (index, lhs, rhs) in testValueFormats) { #>
+                expectedB[index, <#= index #>] = (<#= string.Format(lhs, type.Type) #>
+                    <#= infix #> value) ? 1 : 0;
+                expectedC[index, <#= index #>] = (value <#= infix #>
+                    <#= string.Format(rhs, type.Type) #>) ? 1 : 0;
+<#          } #>
+            }
+
+            Verify2D(b, expectedB);
+            Verify2D(c, expectedC);
         }
 
 <#      } #>
@@ -76,5 +135,6 @@ namespace ILGPU.Tests
     }
 }
 
+#pragma warning restore CA1814 // Prefer jagged arrays over multidimensional
 #pragma warning restore xUnit1025 // InlineData should be unique within the Theory it
                                   // belongs to

--- a/Src/ILGPU.Tests/Generic/TestBase.cs
+++ b/Src/ILGPU.Tests/Generic/TestBase.cs
@@ -2,6 +2,7 @@
 using ILGPU.Runtime;
 using ILGPU.Util;
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Xunit;
 using Xunit.Abstractions;
@@ -232,6 +233,26 @@ namespace ILGPU.Tests
             Assert.Equal(dataLength, expected.Length);
             for (int i = offset ?? 0, e = dataLength; i < e; ++i)
                 Assert.Equal(expected[i], data[i]);
+        }
+
+        /// <summary>
+        /// Verifies the contents of the given 2D memory buffer.
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <param name="buffer">The target buffer.</param>
+        /// <param name="expected">The expected values.</param>
+        [SuppressMessage(
+            "Performance",
+            "CA1814:Prefer jagged arrays over multidimensional",
+            Justification = "Used for testing purposes")]
+        public void Verify2D<T>(MemoryBuffer2D<T> buffer, T[,] expected)
+            where T : unmanaged
+        {
+            var data = buffer.GetAs2DArray(Accelerator.DefaultStream);
+            Assert.Equal(data.Length, expected.Length);
+            for (int i = 0; i < data.GetLength(0); ++i)
+                for (int j = 0; j < data.GetLength(1); ++j)
+                Assert.Equal(expected[i, j], data[i, j]);
         }
 
         /// <summary>

--- a/Src/ILGPU/IR/Construction/Arithmetic.cs
+++ b/Src/ILGPU/IR/Construction/Arithmetic.cs
@@ -98,22 +98,21 @@ namespace ILGPU.IR.Construction
             Location location,
             CompareValue compareValue)
         {
-            // When the comparison is inverted, and we are comparing
-            // floats, toggle between ordered/unordered float
-            // comparison
-            var compareFlags = compareValue.Flags;
-            if (compareValue.Left.BasicValueType.IsFloat() &&
-                compareValue.Right.BasicValueType.IsFloat())
-            {
-                compareFlags ^= CompareFlags.UnsignedOrUnordered;
-            }
+            // Invert the operation kind and adjust the flags
+            var flags = compareValue.Flags;
+            var kind = CompareValue.Invert(
+                compareValue.Kind,
+                compareValue.Left.BasicValueType,
+                compareValue.Right.BasicValueType,
+                ref flags);
 
+            // Create a new compare value using the updated kind and flags
             return CreateCompare(
                 location,
                 compareValue.Left,
                 compareValue.Right,
-                CompareValue.Invert(compareValue.Kind),
-                compareFlags);
+                kind,
+                flags);
         }
 
         /// <summary>

--- a/Src/ILGPU/IR/Construction/Compare.cs
+++ b/Src/ILGPU/IR/Construction/Compare.cs
@@ -11,7 +11,6 @@
 
 using ILGPU.IR.Types;
 using ILGPU.IR.Values;
-using ILGPU.Util;
 
 namespace ILGPU.IR.Construction
 {
@@ -67,25 +66,23 @@ namespace ILGPU.IR.Construction
                         flags);
                 }
 
+                // Check whether we should move constants to the RHS
                 if (leftValue != null)
                 {
-                    // If the comparison was inverted, and we are comparing floats,
-                    // toggle between ordered/unordered float comparison.
-                    var compareKind = CompareValue.InvertIfNonCommutative(kind);
-                    var compareFlags = flags;
-                    if (compareKind != kind &&
-                        left.BasicValueType.IsFloat() &&
-                        right.BasicValueType.IsFloat())
-                    {
-                        compareFlags ^= CompareFlags.UnsignedOrUnordered;
-                    }
+                    // Adjust the compare kind and flags for swapping both operands
+                    kind = CompareValue.SwapOperands(
+                        kind,
+                        left.BasicValueType,
+                        right.BasicValueType,
+                        ref flags);
 
+                    // Create a new compare value using the updated kind and flags
                     return CreateCompare(
                         location,
                         right,
                         left,
-                        compareKind,
-                        compareFlags);
+                        kind,
+                        flags);
                 }
 
                 if (left.Type is PrimitiveType leftType &&


### PR DESCRIPTION
There is a critical issue with the current optimization of constant propagation that affects `>=` and `<=` comparison operations. This PR fixes these problems and adds additional test cases to check the constant propagation rules for comparison operations.