### PR TITLE
Fixed invalid Unix OpenCL library names.

### DIFF
--- a/Src/ILGPU/Runtime/OpenCL/CLAPI.xml
+++ b/Src/ILGPU/Runtime/OpenCL/CLAPI.xml
@@ -5,8 +5,8 @@
          NotSupportedException="RuntimeErrorMessages.CLNotSupported">
     <LibraryNames>
         <Windows>opencl</Windows>
-        <Linux>opencl</Linux>
-        <MacOS>opencl</MacOS>
+        <Linux>libOpenCL</Linux>
+        <MacOS>libOpenCL</MacOS>
     </LibraryNames>
 
     <!-- Devices -->


### PR DESCRIPTION
The names of the OpenCL libraries on Unix systems are called `libOpenCL` instead of `libopencl` by default. Many distributions seem to have multiple symlinks by default to work around this problem. This PR changes the library names on Unix platforms to the default naming scheme.