### PR TITLE
Added simple 64-bit-based LongGlobalIndex helper.

### DIFF
--- a/Src/ILGPU/Grid.cs
+++ b/Src/ILGPU/Grid.cs
@@ -150,6 +150,11 @@ namespace ILGPU
             Index,
             Group.Index);
 
+        /// <summary>
+        /// Returns the global index using 64-bit integers.
+        /// </summary>
+        public static LongIndex3 LongGlobalIndex => GlobalIndex;
+
         #endregion
 
         #region Methods


### PR DESCRIPTION
This PR adds a simple 64-bit index getter named `LongGlobalIndex` to the `Grid` class. This allows users to conveniently work with 64-bit addresses in the scope of explicitly grouped kernels.