### PR TITLE
Added MemSet functions.

### DIFF
--- a/Src/ILGPU/Runtime/CPU/CPUMemoryBuffer.cs
+++ b/Src/ILGPU/Runtime/CPU/CPUMemoryBuffer.cs
@@ -118,18 +118,25 @@ namespace ILGPU.Runtime.CPU
             binding.Recover();
         }
 
-        /// <summary cref="MemoryBuffer.MemSetToZero(AcceleratorStream)"/>
-        public unsafe override void MemSetToZero(AcceleratorStream stream)
+        /// <inheritdoc/>
+        protected internal override unsafe void MemSetInternal(
+            AcceleratorStream stream,
+            byte value,
+            long offsetInBytes,
+            long lengthInBytes)
         {
             stream.Synchronize();
             ref byte targetAddress = ref Unsafe.AsRef<byte>(NativePtr.ToPointer());
-            for (long offset = 0, e = LengthInBytes; offset < e; offset += uint.MaxValue)
+            for (
+                long offset = offsetInBytes, e = offsetInBytes + lengthInBytes;
+                offset < e;
+                offset += uint.MaxValue)
             {
                 Unsafe.InitBlock(
                     ref Unsafe.AddByteOffset(
                         ref targetAddress,
                         new IntPtr(offset)),
-                    0,
+                    value,
                     (uint)Math.Min(uint.MaxValue, e - offset));
             }
         }

--- a/Src/ILGPU/Runtime/Cuda/CudaMemoryBuffer.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaMemoryBuffer.cs
@@ -12,6 +12,7 @@
 using ILGPU.Resources;
 using ILGPU.Util;
 using System;
+using System.Runtime.CompilerServices;
 using static ILGPU.Runtime.Cuda.CudaAPI;
 
 namespace ILGPU.Runtime.Cuda
@@ -123,16 +124,20 @@ namespace ILGPU.Runtime.Cuda
             binding.Recover();
         }
 
-        /// <summary cref="MemoryBuffer.MemSetToZero(AcceleratorStream)"/>
-        public override void MemSetToZero(AcceleratorStream stream)
+        /// <inheritdoc/>
+        protected internal override unsafe void MemSetInternal(
+            AcceleratorStream stream,
+            byte value,
+            long offsetInBytes,
+            long lengthInBytes)
         {
             var binding = Accelerator.BindScoped();
 
             CudaException.ThrowIfFailed(
                 CurrentAPI.Memset(
-                    NativePtr,
-                    0,
-                    new IntPtr(LengthInBytes),
+                    new IntPtr(NativePtr.ToInt64() + offsetInBytes),
+                    value,
+                    new IntPtr(lengthInBytes),
                     stream));
 
             binding.Recover();

--- a/Src/ILGPU/Runtime/ExchangeBuffer.cs
+++ b/Src/ILGPU/Runtime/ExchangeBuffer.cs
@@ -144,7 +144,7 @@ namespace ILGPU.Runtime
         /// <param name="mode">The exchange buffer mode to use.</param>
         internal ExchangeBufferBase(MemoryBuffer<T, TIndex> buffer,
             ExchangeBufferMode mode)
-            : base(buffer.Accelerator, buffer.Extent.Size)
+            : base(buffer.Accelerator, buffer.Extent.Size, ElementSize)
         {
             cpuMemory = buffer.Accelerator is CudaAccelerator &&
                 mode == ExchangeBufferMode.PreferPagedLockedMemory
@@ -168,11 +168,6 @@ namespace ILGPU.Runtime
         /// Returns an array view that can access this array.
         /// </summary>
         public ArrayView<T, TIndex> View { get; protected set; }
-
-        /// <summary>
-        /// Returns the length of this buffer in bytes.
-        /// </summary>
-        public long LengthInBytes => Buffer.LengthInBytes;
 
         /// <summary>
         /// Returns the extent of this buffer.
@@ -210,11 +205,22 @@ namespace ILGPU.Runtime
         #region Methods
 
         /// <summary>
-        /// Sets the contents of the current buffer to zero.
+        /// Sets the contents of the current buffer to the given byte value.
         /// </summary>
         /// <param name="stream">The used accelerator stream.</param>
-        public override void MemSetToZero(AcceleratorStream stream) =>
-            Buffer.MemSetToZero(stream);
+        /// <param name="value">The value to write into the memory buffer.</param>
+        /// <param name="offsetInBytes">The raw offset in bytes.</param>
+        /// <param name="lengthInBytes">The raw length in bytes.</param>
+        protected internal override void MemSetInternal(
+            AcceleratorStream stream,
+            byte value,
+            long offsetInBytes,
+            long lengthInBytes) =>
+            Buffer.MemSetInternal(
+                stream,
+                value,
+                offsetInBytes,
+                lengthInBytes);
 
         /// <summary>
         /// Copies the current contents into a new byte array.

--- a/Src/ILGPU/Runtime/MemoryBuffers.tt
+++ b/Src/ILGPU/Runtime/MemoryBuffers.tt
@@ -63,7 +63,7 @@ namespace ILGPU.Runtime
         /// </summary>
         /// <param name="buffer">The wrapped buffer.</param>
         internal <#= typeName #>(MemoryBuffer<T, <#= indexType #>> buffer)
-            : base(buffer.Accelerator, buffer.Extent.Size)
+            : base(buffer.Accelerator, buffer.Extent.Size, ElementSize)
         {
             this.buffer = buffer;
 
@@ -93,11 +93,6 @@ namespace ILGPU.Runtime
         ArrayView<T, <#= indexType #>> IMemoryBuffer<T, <#= indexType #>>.View => View;
 
         /// <summary>
-        /// Returns the length of this buffer in bytes.
-        /// </summary>
-        public long LengthInBytes => buffer.LengthInBytes;
-
-        /// <summary>
         /// Returns the extent of this buffer.
         /// </summary>
         public <#= indexType #> Extent { get; }
@@ -107,11 +102,22 @@ namespace ILGPU.Runtime
         #region MemoryBuffer Methods
 
         /// <summary>
-        /// Sets the contents of the current buffer to zero.
+        /// Sets the contents of the current buffer to the given byte value.
         /// </summary>
         /// <param name="stream">The used accelerator stream.</param>
-        public override void MemSetToZero(AcceleratorStream stream) =>
-            buffer.MemSetToZero(stream);
+        /// <param name="value">The value to write into the memory buffer.</param>
+        /// <param name="offsetInBytes">The raw offset in bytes.</param>
+        /// <param name="lengthInBytes">The raw length in bytes.</param>
+        protected internal override void MemSetInternal(
+            AcceleratorStream stream,
+            byte value,
+            long offsetInBytes,
+            long lengthInBytes) =>
+            buffer.MemSetInternal(
+                stream,
+                value,
+                offsetInBytes,
+                lengthInBytes);
 
         /// <summary>
         /// Copies the current contents into a new byte array.


### PR DESCRIPTION
This PR refactors and extends the existing `MemSetToZero` functions by adding new `MemSet` functions. They allow to set the buffer contents of a `MemoryBuffer` instance to a particular `byte` value.