### PR TITLE
Changed version suffix on nuget packaging.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,12 @@ jobs:
               exit 1
             }
           } else {
-            $params = "--version-suffix", $(git rev-parse --short HEAD)
+            # WORKAROUND: Add letter prefix to ensure that MSBuild treats
+            # the suffix as a string. e.g. '0313071' will fail as an invalid
+            # version string, but 'G0313071' will succeeded. It looks like
+            # the parser does not like numbers with a leading zero.
+            $suffix = 'g' + $(git rev-parse --short HEAD)
+            $params = "--version-suffix", $suffix
           }
           dotnet pack --configuration=Release @params Src
       - name: Fix NuGet Symbols Package


### PR DESCRIPTION
When creating nuget packages, the CI pipeline will use the short commit id as as version suffix. There seems to be an issue when the commit id is purely numeric, and begins with leading zero. To workaround the issue, we use an alphabetic character prefix to convince the packager that our suffix is really a string.