### PR TITLE
Added support for printf-like output in Kernels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -257,6 +257,7 @@ Src/ILGPU/IR/Construction/CompareOperations.cs
 Src/ILGPU/IR/Intrinsics/IntrinsicMatchers.cs
 Src/ILGPU/IR/Types/ValueTuples.cs
 Src/ILGPU/IndexTypes.cs
+Src/ILGPU/Interop.Generated.cs
 Src/ILGPU/IntrinsicMath.CPUOnly.cs
 Src/ILGPU/ReductionOperations.cs
 Src/ILGPU/Runtime/ExchangeBufferExtensions.cs

--- a/Src/ILGPU.Tests/Configurations.txt
+++ b/Src/ILGPU.Tests/Configurations.txt
@@ -13,6 +13,7 @@ SizeOfValues: Debug, Release, O2
 SpecializedKernels: Debug, Release, O2
 StructureValues: Debug, Release, O2
 ValueTuples: Debug, Release, O2
+InteropTests: Debug, Release, O2
 
 BinaryIntOperations: Debug, Release, O2
 UnaryIntOperations: Debug, Release, O2

--- a/Src/ILGPU.Tests/InteropTests.cs
+++ b/Src/ILGPU.Tests/InteropTests.cs
@@ -1,0 +1,61 @@
+﻿using Xunit;
+using Xunit.Abstractions;
+
+namespace ILGPU.Tests
+{
+    public abstract class InteropTests : TestBase
+    {
+        protected InteropTests(
+            ITestOutputHelper output,
+            TestContext testContext)
+            : base(output, testContext)
+        { }
+
+        internal static void PrintFKernel(
+            Index1 index,
+            ArrayView<int> data,
+            byte b,
+            short s,
+            int i,
+            long l,
+            float f,
+            double d)
+        {
+            bool t = b > 0;
+            Interop.Write(
+                "Current Thread:\t{0}, {1}+{2} (3) - {3} [{2}]",
+                (int)index,
+                b,
+                s,
+                i);
+            Interop.WriteLine(
+                " => %%:\t{0}, {1}\t{2}/{3}",
+                l,
+                f,
+                d,
+                t);
+        }
+
+        [Fact]
+        [KernelMethod(nameof(PrintFKernel))]
+        public void PrintF()
+        {
+            const int Length = 4;
+            using var buffer = Accelerator.Allocate<int>(Length);
+
+            Execute(
+                Length,
+                buffer.View,
+                byte.MaxValue,
+                short.MinValue,
+                int.MaxValue,
+                long.MinValue,
+                float.MaxValue,
+                double.MinValue);
+
+            // We cannot verify the output of the kernel since the redirection of the
+            // Stdout/Stderr stream(s) does not seem to work depending on the platform
+            // on the driver. However, we can verify whether the program fails.
+        }
+    }
+}

--- a/Src/ILGPU/Backends/IBackendCodeGenerator.cs
+++ b/Src/ILGPU/Backends/IBackendCodeGenerator.cs
@@ -544,6 +544,10 @@ namespace ILGPU.Backends
             public void Visit(DebugOperation debug) =>
                 CodeGenerator.GenerateCode(debug);
 
+            /// <summary cref="IValueVisitor.Visit(WriteToOutput)"/>
+            public void Visit(WriteToOutput writeToOutput) =>
+                throw new InvalidCodeGenerationException();
+
             /// <summary cref="IValueVisitor.Visit(ReturnTerminator)"/>
             public void Visit(ReturnTerminator returnTerminator) =>
                 CodeGenerator.GenerateCode(returnTerminator);

--- a/Src/ILGPU/Backends/OpenCL/CLBackend.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLBackend.cs
@@ -10,10 +10,10 @@
 // ---------------------------------------------------------------------------------------
 
 using ILGPU.Backends.EntryPoints;
+using ILGPU.Backends.OpenCL.Transformations;
 using ILGPU.IR;
 using ILGPU.IR.Analyses;
 using ILGPU.IR.Transformations;
-using ILGPU.IR.Types;
 using ILGPU.Runtime;
 using ILGPU.Runtime.OpenCL;
 using System.Text;
@@ -23,30 +23,13 @@ namespace ILGPU.Backends.OpenCL
     /// <summary>
     /// Represents an OpenCL source backend.
     /// </summary>
-    public sealed partial class CLBackend :
+    public sealed class CLBackend :
         CodeGeneratorBackend<
             CLIntrinsic.Handler,
             CLCodeGenerator.GeneratorArgs,
             CLCodeGenerator,
             StringBuilder>
     {
-        #region Nested Types
-
-        /// <summary>
-        /// The OpenCL accelerator specializer.
-        /// </summary>
-        private sealed class CLAcceleratorSpecializer : AcceleratorSpecializer
-        {
-            public CLAcceleratorSpecializer(PrimitiveType pointerType)
-                : base(
-                      AcceleratorType.OpenCL,
-                      null,
-                      pointerType)
-            { }
-        }
-
-        #endregion
-
         #region Static
 
         /// <summary>

--- a/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Emitter.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Emitter.cs
@@ -442,6 +442,17 @@ namespace ILGPU.Backends.OpenCL
             /// Appends a constant.
             /// </summary>
             /// <param name="value">The constant to append.</param>
+            public void AppendConstant(string value)
+            {
+                AppendOperation("\"");
+                AppendOperation(value);
+                AppendOperation("\"");
+            }
+
+            /// <summary>
+            /// Appends a constant.
+            /// </summary>
+            /// <param name="value">The constant to append.</param>
             public void AppendConstant(long value) =>
                 stringBuilder.Append(value);
 

--- a/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Values.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Values.cs
@@ -405,7 +405,9 @@ namespace ILGPU.Backends.OpenCL
         /// <summary cref="IBackendCodeGenerator.GenerateCode(StringValue)"/>
         public void GenerateCode(StringValue value)
         {
-            // Ignore string values for now
+            var target = Allocate(value);
+            using var statement = BeginStatement(target);
+            statement.AppendConstant(value.String);
         }
 
         /// <summary cref="IBackendCodeGenerator.GenerateCode(NullValue)"/>

--- a/Src/ILGPU/Backends/OpenCL/CLTypeGenerator.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLTypeGenerator.cs
@@ -183,7 +183,7 @@ namespace ILGPU.Backends.OpenCL
 
             // Declare primitive types
             mapping[typeContext.VoidType] = "void";
-            mapping[typeContext.StringType] = "char*";
+            mapping[typeContext.StringType] = "__constant char*";
 
             foreach (var basicValueType in IRTypeContext.BasicValueTypes)
             {

--- a/Src/ILGPU/Backends/OpenCL/Transformations/CLAcceleratorSpecializer.cs
+++ b/Src/ILGPU/Backends/OpenCL/Transformations/CLAcceleratorSpecializer.cs
@@ -1,0 +1,107 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                        Copyright (c) 2016-2020 Marcel Koester
+//                                    www.ilgpu.net
+//
+// File: CLAcceleratorSpecializer.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+
+using ILGPU.Frontend;
+using ILGPU.IR;
+using ILGPU.IR.Rewriting;
+using ILGPU.IR.Transformations;
+using ILGPU.IR.Types;
+using ILGPU.IR.Values;
+using ILGPU.Runtime;
+using System.Reflection;
+
+namespace ILGPU.Backends.OpenCL.Transformations
+{
+    /// <summary>
+    /// The OpenCL accelerator specializer.
+    /// </summary>
+    public sealed class CLAcceleratorSpecializer : AcceleratorSpecializer
+    {
+        #region External Functions
+
+        /// <summary>
+        /// Represents the native OpenCL printf function.
+        /// </summary>
+        /// <param name="str">The string format.</param>
+        /// <remarks>
+        /// The variable number of arguments are not reflected in this declaration.
+        /// </remarks>
+        [External("printf")]
+        private static unsafe void PrintF(string str)
+        { }
+
+        /// <summary>
+        /// A handle to the <see cref="PrintF(string)"/> method.
+        /// </summary>
+        private static readonly MethodInfo PrintFMethod =
+            typeof(CLAcceleratorSpecializer).GetMethod(
+                nameof(PrintF),
+                BindingFlags.Static | BindingFlags.NonPublic);
+
+        /// <summary>
+        /// Gets or declares the <see cref="PrintF(string)"/> method in the current
+        /// context.
+        /// </summary>
+        public static Method GetPrintFMethod(in RewriterContext context) =>
+            context.GetIRContext().Declare(PrintFMethod, out bool _);
+
+        #endregion
+
+        /// <summary>
+        /// Constructs a new OpenCL accelerator specializer.
+        /// </summary>
+        /// <param name="pointerType">The actual pointer type to use.</param>
+        public CLAcceleratorSpecializer(PrimitiveType pointerType)
+            : base(
+                  AcceleratorType.OpenCL,
+                  null,
+                  pointerType)
+        { }
+
+        #region Methods
+
+        /// <summary>
+        /// Maps internal <see cref="WriteToOutput"/> values to
+        /// <see cref="PrintF(string)"/> method calls.
+        /// </summary>
+        protected override void Specialize(
+            in RewriterContext context,
+            WriteToOutput writeToOutput)
+        {
+            var builder = context.Builder;
+            var location = writeToOutput.Location;
+
+            // Convert to format string constant
+            var expressionString = writeToOutput.ToEscapedPrintFExpression();
+            var expression = builder.CreatePrimitiveValue(
+                location,
+                expressionString);
+
+            // Create a call to the native printf
+            var callBuilder = builder.CreateCall(location, GetPrintFMethod(context));
+            callBuilder.Add(expression);
+            foreach (Value argument in writeToOutput.Arguments)
+            {
+                var converted = WriteToOutput.ConvertToPrintFArgument(
+                    builder,
+                    location,
+                    argument);
+                callBuilder.Add(converted);
+            }
+
+            // Replace the write node with the call
+            var call = callBuilder.Seal();
+            context.ReplaceAndRemove(writeToOutput, call);
+        }
+
+        #endregion
+    }
+}

--- a/Src/ILGPU/Backends/PTX/PTXBackend.cs
+++ b/Src/ILGPU/Backends/PTX/PTXBackend.cs
@@ -14,7 +14,6 @@ using ILGPU.Backends.PTX.Transformations;
 using ILGPU.IR;
 using ILGPU.IR.Analyses;
 using ILGPU.IR.Transformations;
-using ILGPU.IR.Types;
 using ILGPU.Runtime;
 using ILGPU.Runtime.Cuda;
 using System.Text;
@@ -51,23 +50,6 @@ namespace ILGPU.Backends.PTX
         /// vectorized IO operations in most cases.
         /// </summary>
         public const int DefaultSharedMemoryAlignment = 4;
-
-        #endregion
-
-        #region Nested Types
-
-        /// <summary>
-        /// The PTX accelerator specializer.
-        /// </summary>
-        private sealed class PTXAcceleratorSpecializer : AcceleratorSpecializer
-        {
-            public PTXAcceleratorSpecializer(PrimitiveType pointerType)
-                : base(
-                      AcceleratorType.Cuda,
-                      PTXBackend.WarpSize,
-                      pointerType)
-            { }
-        }
 
         #endregion
 

--- a/Src/ILGPU/Backends/PTX/PTXCodeGenerator.Values.cs
+++ b/Src/ILGPU/Backends/PTX/PTXCodeGenerator.Values.cs
@@ -647,10 +647,11 @@ namespace ILGPU.Backends.PTX
         public void GenerateCode(StringValue value)
         {
             // Check for already existing global constant
-            if (!stringConstants.TryGetValue(value.String, out string stringBinding))
+            var key = (value.Encoding, value.String);
+            if (!stringConstants.TryGetValue(key, out string stringBinding))
             {
                 stringBinding = "__strconst" + value.Id;
-                stringConstants.Add(value.String, stringBinding);
+                stringConstants.Add(key, stringBinding);
             }
 
             var register = AllocatePlatformRegister(

--- a/Src/ILGPU/Backends/PTX/PTXCodeGenerator.cs
+++ b/Src/ILGPU/Backends/PTX/PTXCodeGenerator.cs
@@ -321,8 +321,8 @@ namespace ILGPU.Backends.PTX
         private int labelCounter = 0;
         private readonly Dictionary<BasicBlock, string> blockLookup =
             new Dictionary<BasicBlock, string>();
-        private readonly Dictionary<string, string> stringConstants =
-            new Dictionary<string, string>();
+        private readonly Dictionary<(Encoding, string), string> stringConstants =
+            new Dictionary<(Encoding, string), string>();
         private readonly string labelPrefix;
 
         /// <summary>
@@ -887,9 +887,13 @@ namespace ILGPU.Backends.PTX
             var declBuilder = new StringBuilder();
             foreach (var stringConstant in stringConstants)
             {
-                declBuilder.Append(".global .align 2 .b8 ");
+                var (encoding, stringValue) = stringConstant.Key;
+                declBuilder.Append(".global .align ");
+                declBuilder.Append(encoding.GetMaxByteCount(1));
+                declBuilder.Append(" .b8 ");
                 declBuilder.Append(stringConstant.Value);
-                var stringBytes = Encoding.Unicode.GetBytes(stringConstant.Key);
+
+                var stringBytes = encoding.GetBytes(stringValue);
                 declBuilder.Append("[");
                 declBuilder.Append(stringBytes.Length + 1);
                 declBuilder.Append("]");

--- a/Src/ILGPU/Backends/PTX/PTXIntrinsics.cs
+++ b/Src/ILGPU/Backends/PTX/PTXIntrinsics.cs
@@ -25,6 +25,9 @@ namespace ILGPU.Backends.PTX
     {
         #region Debugging
 
+        /// <remarks>
+        /// All strings must be in the generic address space.
+        /// </remarks>
         [External("__assertfail")]
         private static void AssertFail(
             string message,

--- a/Src/ILGPU/Backends/PTX/Transformations/PTXAcceleratorSpecializer.cs
+++ b/Src/ILGPU/Backends/PTX/Transformations/PTXAcceleratorSpecializer.cs
@@ -1,0 +1,137 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                        Copyright (c) 2016-2020 Marcel Koester
+//                                    www.ilgpu.net
+//
+// File: PTXAcceleratorSpecializer.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+
+using ILGPU.Frontend;
+using ILGPU.IR;
+using ILGPU.IR.Construction;
+using ILGPU.IR.Rewriting;
+using ILGPU.IR.Transformations;
+using ILGPU.IR.Types;
+using ILGPU.IR.Values;
+using ILGPU.Runtime;
+using System.Reflection;
+using System.Text;
+
+namespace ILGPU.Backends.PTX.Transformations
+{
+    /// <summary>
+    /// The PTX accelerator specializer.
+    /// </summary>
+    public sealed class PTXAcceleratorSpecializer : AcceleratorSpecializer
+    {
+        #region External Functions
+
+        /// <summary>
+        /// Represents the intrinsic Cuda printf function.
+        /// </summary>
+        /// <param name="str">The string format.</param>
+        /// <param name="args">A pointer to the argument structure.</param>
+        /// <remarks>
+        /// Both pointers must be in the generic address space.
+        /// </remarks>
+        [External("vprintf")]
+        private static unsafe int PrintF(string str, void* args) => 0;
+
+        /// <summary>
+        /// A handle to the <see cref="PrintF(string, void*)"/> method.
+        /// </summary>
+        private static readonly MethodInfo PrintFMethod =
+            typeof(PTXAcceleratorSpecializer).GetMethod(
+                nameof(PrintF),
+                BindingFlags.Static | BindingFlags.NonPublic);
+
+        /// <summary>
+        /// Gets or declares the <see cref="PrintF(string, void*)"/> method in the current
+        /// context.
+        /// </summary>
+        public static Method GetPrintFMethod(in RewriterContext context) =>
+            context.GetIRContext().Declare(PrintFMethod, out bool _);
+
+        #endregion
+
+        #region Instance
+
+        /// <summary>
+        /// Constructs a new PTX accelerator specializer.
+        /// </summary>
+        /// <param name="pointerType">The actual pointer type to use.</param>
+        public PTXAcceleratorSpecializer(PrimitiveType pointerType)
+            : base(
+                  AcceleratorType.Cuda,
+                  PTXBackend.WarpSize,
+                  pointerType)
+        { }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Maps internal <see cref="WriteToOutput"/> values to
+        /// <see cref="PrintF(string, void*)"/> method calls.
+        /// </summary>
+        protected override void Specialize(
+            in RewriterContext context,
+            WriteToOutput writeToOutput)
+        {
+            var builder = context.Builder;
+            var location = writeToOutput.Location;
+
+            // Convert to format string constant
+            var expressionString = writeToOutput.ToPrintFExpression();
+            var expression = builder.CreatePrimitiveValue(
+                location,
+                expressionString,
+                Encoding.ASCII);
+
+            // Create an argument structure that can be passed via local memory
+            var argumentBuilder = builder.CreateDynamicStructure(
+                location,
+                writeToOutput.Count);
+            foreach (Value argument in writeToOutput.Arguments)
+            {
+                var converted = WriteToOutput.ConvertToPrintFArgument(
+                    builder,
+                    location,
+                    argument);
+                argumentBuilder.Add(converted);
+            }
+            var argumentStructure = argumentBuilder.Seal();
+
+            // Create local alloca to store all data
+            var alloca = builder.CreateAlloca(
+                location,
+                argumentStructure.Type,
+                MemoryAddressSpace.Local);
+
+            // Store structure into chunk of local memory
+            builder.CreateStore(location, alloca, argumentStructure);
+
+            // Cast alloca to the generic address space to satisfy the requirements of
+            // of the printf method
+            alloca = builder.CreateAddressSpaceCast(
+                location,
+                alloca,
+                MemoryAddressSpace.Generic);
+
+            // Create a call to the native printf
+            var callBuilder = builder.CreateCall(location, GetPrintFMethod(context));
+            callBuilder.Add(expression);
+            callBuilder.Add(alloca);
+
+            // Replace the write node with the call
+            var call = callBuilder.Seal();
+            context.ReplaceAndRemove(writeToOutput, call);
+        }
+
+        #endregion
+    }
+}

--- a/Src/ILGPU/Backends/VariableAllocator.cs
+++ b/Src/ILGPU/Backends/VariableAllocator.cs
@@ -150,6 +150,26 @@ namespace ILGPU.Backends
         }
 
         /// <summary>
+        /// A string variable.
+        /// </summary>
+        public sealed class StringVariable : TypedVariable
+        {
+            /// <summary>
+            /// Constructs a new object variable.
+            /// </summary>
+            /// <param name="id">The current variable id.</param>
+            /// <param name="type">The object type.</param>
+            internal StringVariable(int id, StringType type)
+                : base(id, type)
+            { }
+
+            /// <summary>
+            /// Returns the represented IR string type.
+            /// </summary>
+            public new StringType Type => base.Type as StringType;
+        }
+
+        /// <summary>
         /// An object variable.
         /// </summary>
         public sealed class ObjectVariable : TypedVariable
@@ -264,6 +284,7 @@ namespace ILGPU.Backends
                     primitiveType.BasicValueType),
                 PointerType pointerType => AllocatePointerType(pointerType),
                 ObjectType objectType => new ObjectVariable(idCounter++, objectType),
+                StringType stringType => new StringVariable(idCounter++, stringType),
                 PaddingType paddingType => AllocateType(
                     paddingType.PrimitiveType.BasicValueType),
                 _ => throw new NotSupportedException(),

--- a/Src/ILGPU/ILGPU.csproj
+++ b/Src/ILGPU/ILGPU.csproj
@@ -64,6 +64,11 @@
           <AutoGen>True</AutoGen>
           <DependentUpon>IndexTypes.tt</DependentUpon>
         </None>
+        <None Include="Interop.Generated.cs">
+          <DesignTime>True</DesignTime>
+          <AutoGen>True</AutoGen>
+          <DependentUpon>Interop.Generated.tt</DependentUpon>
+        </None>
         <None Include="IntrinsicMath.CPUOnly.cs">
           <DesignTime>True</DesignTime>
           <AutoGen>True</AutoGen>
@@ -156,6 +161,11 @@
           <DesignTime>True</DesignTime>
           <AutoGen>True</AutoGen>
           <DependentUpon>IndexTypes.tt</DependentUpon>
+        </Compile>
+        <Compile Update="Interop.Generated.cs">
+          <DesignTime>True</DesignTime>
+          <AutoGen>True</AutoGen>
+          <DependentUpon>Interop.Generated.tt</DependentUpon>
         </Compile>
         <Compile Update="IntrinsicMath.CPUOnly.cs">
           <DesignTime>True</DesignTime>
@@ -258,6 +268,10 @@
         <None Update="IndexTypes.tt">
           <Generator>TextTemplatingFileGenerator</Generator>
           <LastGenOutput>IndexTypes.cs</LastGenOutput>
+        </None>
+        <None Update="Interop.Generated.tt">
+          <Generator>TextTemplatingFileGenerator</Generator>
+          <LastGenOutput>Interop.Generated.cs</LastGenOutput>
         </None>
         <None Update="IntrinsicMath.CPUOnly.tt">
           <Generator>TextTemplatingFileGenerator</Generator>

--- a/Src/ILGPU/IR/Construction/IOValues.cs
+++ b/Src/ILGPU/IR/Construction/IOValues.cs
@@ -1,0 +1,39 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                        Copyright (c) 2016-2020 Marcel Koester
+//                                    www.ilgpu.net
+//
+// File: IOValues.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+
+using ILGPU.IR.Values;
+using FormatArray = System.Collections.Immutable.ImmutableArray<
+    ILGPU.IR.Values.WriteToOutput.FormatExpression>;
+using ValueList = ILGPU.Util.InlineList<ILGPU.IR.Values.ValueReference>;
+
+namespace ILGPU.IR.Construction
+{
+    partial class IRBuilder
+    {
+        /// <summary>
+        /// Creates a <see cref="System.Console.Write(string, object[])"/>-like output
+        /// operation using typed expression formats.
+        /// </summary>
+        /// <param name="location">The current location.</param>
+        /// <param name="expressions">The list of all format expressions.</param>
+        /// <param name="arguments">The arguments to format.</param>
+        /// <returns>A node that represents the output operation.</returns>
+        public ValueReference CreateWriteToOutput(
+            Location location,
+            FormatArray expressions,
+            ref ValueList arguments) =>
+            Append(new WriteToOutput(
+                GetInitializer(location),
+                expressions,
+                ref arguments,
+                VoidType));
+    }
+}

--- a/Src/ILGPU/IR/Construction/Methods.cs
+++ b/Src/ILGPU/IR/Construction/Methods.cs
@@ -11,6 +11,7 @@
 
 using ILGPU.IR.Types;
 using ILGPU.IR.Values;
+using System;
 using System.Runtime.CompilerServices;
 using ValueList = ILGPU.Util.InlineList<ILGPU.IR.Values.ValueReference>;
 
@@ -75,16 +76,5 @@ namespace ILGPU.IR.Construction
                 type));
             return new PhiValue.Builder(phiNode, capacity);
         }
-
-        /// <summary>
-        /// Declares a method.
-        /// </summary>
-        /// <param name="declaration">The method declaration.</param>
-        /// <param name="created">True, if the method has been created.</param>
-        /// <returns>The declared method.</returns>
-        public Method DeclareMethod(
-            in MethodDeclaration declaration,
-            out bool created) =>
-            Context.Declare(declaration, out created);
     }
 }

--- a/Src/ILGPU/IR/Construction/Values.cs
+++ b/Src/ILGPU/IR/Construction/Values.cs
@@ -15,6 +15,7 @@ using ILGPU.Resources;
 using ILGPU.Util;
 using System;
 using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace ILGPU.IR.Construction
 {
@@ -110,14 +111,26 @@ namespace ILGPU.IR.Construction
         /// <returns>A reference to the requested value.</returns>
         public ValueReference CreatePrimitiveValue(
             Location location,
-            string @string)
-        {
-            if (@string == null)
-                throw location.GetArgumentNullException(nameof(@string));
-            return Append(new StringValue(
+            string @string) =>
+            CreatePrimitiveValue(location, @string, Encoding.Unicode);
+
+        /// <summary>
+        /// Creates a new string constant.
+        /// </summary>
+        /// <param name="location">The current location.</param>
+        /// <param name="string">The string value.</param>
+        /// <param name="encoding">The specific encoding.</param>
+        /// <returns>A reference to the requested value.</returns>
+        public ValueReference CreatePrimitiveValue(
+            Location location,
+            string @string,
+            Encoding encoding) =>
+            @string == null
+            ? throw location.GetArgumentNullException(nameof(@string))
+            : Append(new StringValue(
                 GetInitializer(location),
-                @string));
-        }
+                @string,
+                encoding));
 
         /// <summary>
         /// Creates a primitive <see cref="bool"/> value.

--- a/Src/ILGPU/IR/Rewriting/IRewriterContext.cs
+++ b/Src/ILGPU/IR/Rewriting/IRewriterContext.cs
@@ -105,6 +105,15 @@ namespace ILGPU.IR.Rewriting
             context.ReplaceAndRemove(value, newValue.Resolve());
 
         /// <summary>
+        /// Returns the parent IR context.
+        /// </summary>
+        /// <typeparam name="T">The context type.</typeparam>
+        /// <param name="context">The context instance.</param>
+        /// <returns>The parent IR context.</returns>
+        public static IRContext GetIRContext<T>(this T context)
+            where T : IRewriterContext => context.Builder.Context;
+
+        /// <summary>
         /// Returns the parent method.
         /// </summary>
         /// <typeparam name="T">The context type.</typeparam>

--- a/Src/ILGPU/IR/Rewriting/RewriterContext.cs
+++ b/Src/ILGPU/IR/Rewriting/RewriterContext.cs
@@ -9,6 +9,7 @@
 // Source License. See LICENSE.txt for details
 // ---------------------------------------------------------------------------------------
 
+using ILGPU.IR.Types;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -48,7 +49,7 @@ namespace ILGPU.IR.Rewriting
         /// <summary>
         /// Returns the associated block.
         /// </summary>
-        public BasicBlock Block => Builder.BasicBlock;
+        public readonly BasicBlock Block => Builder.BasicBlock;
 
         /// <summary>
         /// The set of all converted nodes.
@@ -64,7 +65,8 @@ namespace ILGPU.IR.Rewriting
         /// </summary>
         /// <param name="newBuilder">The new builder to use.</param>
         /// <returns>The specialized rewriter context.</returns>
-        public RewriterContext SpecializeBuilder(BasicBlock.Builder newBuilder) =>
+        public readonly RewriterContext SpecializeBuilder(
+            BasicBlock.Builder newBuilder) =>
             new RewriterContext(newBuilder, Converted);
 
         /// <summary>
@@ -72,14 +74,14 @@ namespace ILGPU.IR.Rewriting
         /// </summary>
         /// <param name="value">The value to check.</param>
         /// <returns>True, if the given value has been converted.</returns>
-        public bool IsConverted(Value value) => Converted.Contains(value);
+        public readonly bool IsConverted(Value value) => Converted.Contains(value);
 
         /// <summary>
         /// Marks the given value as converted.
         /// </summary>
         /// <param name="value">The value to mark.</param>
         /// <returns>True, if the element has been added to the set of value.</returns>
-        public bool MarkConverted(Value value) => Converted.Add(value);
+        public readonly bool MarkConverted(Value value) => Converted.Add(value);
 
         /// <summary>
         /// Replaces the given value with the new value.
@@ -88,7 +90,7 @@ namespace ILGPU.IR.Rewriting
         /// <param name="value">The current value.</param>
         /// <param name="newValue">The new value.</param>
         /// <returns>Returns the new value.</returns>
-        public TValue Replace<TValue>(Value value, TValue newValue)
+        public readonly TValue Replace<TValue>(Value value, TValue newValue)
             where TValue : Value
         {
             value.Replace(newValue);
@@ -103,7 +105,7 @@ namespace ILGPU.IR.Rewriting
         /// <param name="value">The current value.</param>
         /// <param name="newValue">The new value.</param>
         /// <returns>Returns the new value.</returns>
-        public TValue ReplaceAndRemove<TValue>(Value value, TValue newValue)
+        public readonly TValue ReplaceAndRemove<TValue>(Value value, TValue newValue)
             where TValue : Value
         {
             var replaced = Replace(value, newValue);
@@ -115,7 +117,7 @@ namespace ILGPU.IR.Rewriting
         /// Removes the given value from the block.
         /// </summary>
         /// <param name="value">The current value.</param>
-        public void Remove(Value value)
+        public readonly void Remove(Value value)
         {
             MarkConverted(value);
             Builder.Remove(value);

--- a/Src/ILGPU/IR/Transformations/AcceleratorSpecializer.cs
+++ b/Src/ILGPU/IR/Transformations/AcceleratorSpecializer.cs
@@ -130,6 +130,17 @@ namespace ILGPU.IR.Transformations
             context.ReplaceAndRemove(value, convert);
         }
 
+        /// <summary>
+        /// Specializes IO output operations via the instance method
+        /// <see cref="Specialize(in RewriterContext, WriteToOutput)"/> of the parent
+        /// <paramref name="specializer"/> instance.
+        /// </summary>
+        private static void Specialize(
+            RewriterContext context,
+            AcceleratorSpecializer specializer,
+            WriteToOutput value) =>
+            specializer.Specialize(context, value);
+
         #endregion
 
         #region Rewriter
@@ -147,6 +158,8 @@ namespace ILGPU.IR.Transformations
         {
             Rewriter.Add<AcceleratorTypeValue>(Specialize);
             Rewriter.Add<WarpSizeValue>(Specialize);
+            Rewriter.Add<WriteToOutput>(Specialize);
+
             Rewriter.Add<IntAsPointerCast>(CanSpecialize, Specialize);
             Rewriter.Add<PointerAsIntCast>(CanSpecialize, Specialize);
         }
@@ -199,6 +212,17 @@ namespace ILGPU.IR.Transformations
         /// </summary>
         protected override bool PerformTransformation(Method.Builder builder) =>
             Rewriter.Rewrite(builder.SourceBlocks, builder, this);
+
+        /// <summary>
+        /// Specializes IO output operations (if any). Note that this default
+        /// implementation removes the output operations from the current program.
+        /// </summary>
+        /// <param name="context">The current rewriter context.</param>
+        /// <param name="writeToOutput">The IO output operation.</param>
+        protected virtual void Specialize(
+            in RewriterContext context,
+            WriteToOutput writeToOutput) =>
+            context.Remove(writeToOutput);
 
         #endregion
     }

--- a/Src/ILGPU/IR/Transformations/InferAddressSpaces.cs
+++ b/Src/ILGPU/IR/Transformations/InferAddressSpaces.cs
@@ -49,7 +49,7 @@ namespace ILGPU.IR.Transformations
                         // We cannot remove casts to other address spaces in case of a
                         // method invocation if the address spaces do not match
                         if (!call.Target.HasImplementation)
-                            break;
+                            return false;
                         var targetParam = call.Target.Parameters[use.Index];
                         if (targetParam.ParameterType is IAddressSpaceType paramType &&
                             paramType.AddressSpace == targetSpace)

--- a/Src/ILGPU/IR/Values/Constants.cs
+++ b/Src/ILGPU/IR/Values/Constants.cs
@@ -15,6 +15,7 @@ using ILGPU.Util;
 using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace ILGPU.IR.Values
 {
@@ -323,10 +324,15 @@ namespace ILGPU.IR.Values
         /// </summary>
         /// <param name="initializer">The value initializer.</param>
         /// <param name="value">The string value.</param>
-        internal StringValue(in ValueInitializer initializer, string value)
+        /// <param name="encoding">The string encoding.</param>
+        internal StringValue(
+            in ValueInitializer initializer,
+            string value,
+            Encoding encoding)
             : base(initializer, initializer.Context.StringType)
         {
             String = value;
+            Encoding = encoding;
         }
 
         #endregion
@@ -346,6 +352,11 @@ namespace ILGPU.IR.Values
         /// </summary>
         public string String { get; }
 
+        /// <summary>
+        /// Returns the associated encoding.
+        /// </summary>
+        public Encoding Encoding { get; }
+
         #endregion
 
         #region Methods
@@ -364,7 +375,8 @@ namespace ILGPU.IR.Values
         #region Object
 
         /// <summary cref="Node.ToPrefixString"/>
-        protected override string ToPrefixString() => "const.str";
+        protected override string ToPrefixString() =>
+            "const.str." + Encoding.EncodingName.ToLower();
 
         /// <summary cref="Value.ToArgString"/>
         protected override string ToArgString() => String;

--- a/Src/ILGPU/IR/Values/IOValues.cs
+++ b/Src/ILGPU/IR/Values/IOValues.cs
@@ -168,6 +168,136 @@ namespace ILGPU.IR.Values
 
         #endregion
 
+        #region Constants
+
+        /// <summary>
+        /// All native PrintF formats for all arithmetic basic value types.
+        /// </summary>
+        private static readonly ImmutableArray<string> PrintFFormats =
+            ImmutableArray.Create(
+                "%n",
+                "%u",
+
+                "%d",
+                "%d",
+                "%d",
+                "%ld",
+
+                "%n",
+                "%f",
+                "%lf",
+
+                "%i",
+                "%i",
+                "%i",
+                "%lu");
+
+        /// <summary>
+        /// The native PrintF pointer format.
+        /// </summary>
+        private const string PrintFPointerFormat = "%p";
+
+        /// <summary>
+        /// The native PrintF percent format.
+        /// </summary>
+        private const string PrintFPercentFormat = "%%";
+
+        #endregion
+
+        #region Static
+
+        /// <summary>
+        /// Returns the native PrintF format for the given basic value type.
+        /// </summary>
+        /// <param name="valueType">The basic value type.</param>
+        /// <returns>The resolved PrintF format.</returns>
+        public static string GetPrintFFormat(ArithmeticBasicValueType valueType) =>
+            PrintFFormats[(int)valueType];
+
+        /// <summary>
+        /// Converts the given value into a printf compatible argument.
+        /// </summary>
+        /// <param name="builder">The current builder.</param>
+        /// <param name="location">The current location.</param>
+        /// <param name="value">The value to convert.</param>
+        /// <returns>The converted value.</returns>
+        public static Value ConvertToPrintFArgument(
+            IRBuilder builder,
+            Location location,
+            Value value)
+        {
+            switch (value.BasicValueType)
+            {
+                case BasicValueType.Int1:
+                case BasicValueType.Int8:
+                case BasicValueType.Int16:
+                    return builder.CreateConvertToInt32(location, value);
+                case BasicValueType.Float16:
+                case BasicValueType.Float32:
+                    return builder.CreateConvert(
+                        location,
+                        value,
+                        BasicValueType.Float64);
+                default:
+                    return value;
+            }
+        }
+
+        /// <summary>
+        /// Parses the given format expression into an array of format expressions.
+        /// </summary>
+        /// <param name="formatExpression">The format expression.</param>
+        /// <param name="expressions">The array of managed format expressions.</param>
+        /// <returns>True, if all expressions could be parsed successfully.</returns>
+        public static bool TryParse(string formatExpression, out FormatArray expressions)
+        {
+            expressions = FormatArray.Empty;
+
+            // Search for '{xyz}' patterns
+            var result = ImmutableArray.CreateBuilder<FormatExpression>(10);
+            while (formatExpression.Length > 0)
+            {
+                // Search for next {
+                int startIndex = formatExpression.IndexOf('{', 0);
+                if (startIndex < 0)
+                {
+                    result.Add(new FormatExpression(formatExpression));
+                    break;
+                }
+                else if (startIndex > 0)
+                {
+                    result.Add(new FormatExpression(
+                        formatExpression.Substring(0, startIndex)));
+                }
+
+                // Search for next }
+                int endIndex = formatExpression.IndexOf('}', startIndex);
+                if (endIndex < 0)
+                {
+                    result.Add(new FormatExpression(formatExpression));
+                    break;
+                }
+
+                // Check sub expression
+                var subExpr = formatExpression.Substring(
+                    startIndex + 1,
+                    endIndex - startIndex - 1);
+
+                // Check whether the argument can be resolved to an integer
+                if (!int.TryParse(subExpr, out int argument) || argument < 0)
+                    return false;
+
+                // Append current argument
+                result.Add(new FormatExpression(argument));
+                formatExpression = formatExpression.Substring(endIndex + 1);
+            }
+
+            expressions = result.ToImmutable();
+            return true;
+        }
+
+        #endregion
+
         #region Instance
 
         /// <summary>
@@ -235,12 +365,75 @@ namespace ILGPU.IR.Values
         /// <summary cref="Value.Accept"/>
         public override void Accept<T>(T visitor) => visitor.Visit(this);
 
+        /// <summary>
+        /// Converts the internal format expressions into a printf string.
+        /// </summary>
+        /// <returns>The converted printf string.</returns>
+        [SuppressMessage(
+            "Globalization",
+            "CA1307:Specify StringComparison",
+            Justification = "There are no affected characters")]
+        public string ToPrintFExpression()
+        {
+            var result = new StringBuilder();
+            foreach (var expression in Expressions)
+            {
+                if (expression.HasArgument)
+                {
+                    // TODO: extend this functionality in the future to support
+                    // typed signed/unsigned outputs
+                    var argument = this[expression.Argument];
+                    string argumentFormat = argument.Type.IsPointerType
+                        ? PrintFPointerFormat
+                        : GetPrintFFormat(
+                            argument.BasicValueType.GetArithmeticBasicValueType(false));
+                    result.Append(argumentFormat);
+                }
+                else
+                {
+                    // Append the underlying expression string and escape % characters
+                    result.Append(
+                        expression.String.Replace(
+                            "%",
+                            PrintFPercentFormat));
+                }
+            }
+            return result.ToString();
+        }
+
+        /// <summary>
+        /// Converts the internal format expressions into an escaped sequence.
+        /// </summary>
+        [SuppressMessage(
+            "Globalization",
+            "CA1307:Specify StringComparison",
+            Justification = "There are no affected characters")]
+        public string ToEscapedPrintFExpression() =>
+            ToPrintFExpression()
+            .Replace("\t", @"\t")
+            .Replace("\r", @"\r")
+            .Replace("\n", @"\n")
+            .Replace("\"", "\\\"")
+            .Replace("\\", @"\\");
+
         #endregion
 
         #region Methods
 
         /// <summary cref="Node.ToPrefixString"/>
         protected override string ToPrefixString() => "write";
+
+
+        /// <summary cref="Value.ToArgString"/>
+        [SuppressMessage(
+            "Globalization",
+            "CA1307:Specify StringComparison",
+            Justification = "There are no affected characters")]
+        protected override string ToArgString() =>
+            ToPrintFExpression().Replace(
+                Environment.NewLine,
+                string.Empty) +
+            " " + base.ToArgString();
 
         #endregion
     }

--- a/Src/ILGPU/IR/Values/IOValues.cs
+++ b/Src/ILGPU/IR/Values/IOValues.cs
@@ -1,0 +1,247 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                        Copyright (c) 2016-2020 Marcel Koester
+//                                    www.ilgpu.net
+//
+// File: IOValues.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+
+using ILGPU.IR.Construction;
+using ILGPU.IR.Types;
+using ILGPU.Util;
+using System;
+using System.Collections;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Text;
+using FormatArray = System.Collections.Immutable.ImmutableArray<
+    ILGPU.IR.Values.WriteToOutput.FormatExpression>;
+using ValueList = ILGPU.Util.InlineList<ILGPU.IR.Values.ValueReference>;
+
+namespace ILGPU.IR.Values
+{
+    /// <summary>
+    /// Represents an abstract Input/Output (IO) value with side effects.
+    /// </summary>
+    public abstract class IOValue : MemoryValue
+    {
+        #region Instance
+
+        /// <summary>
+        /// Constructs a new debug operation.
+        /// </summary>
+        /// <param name="initializer">The value initializer.</param>
+        /// <param name="staticType">The static type.</param>
+        internal IOValue(in ValueInitializer initializer, TypeNode staticType)
+            : base(initializer, staticType)
+        { }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Represents a console output.
+    /// </summary>
+    [ValueKind(ValueKind.WriteToOutput)]
+    public sealed class WriteToOutput : IOValue
+    {
+        #region Nested Types
+
+        /// <summary>
+        /// Represents a single format command.
+        /// </summary>
+        public readonly struct FormatExpression
+        {
+            /// <summary>
+            /// Constructs a new format expression.
+            /// </summary>
+            /// <param name="string">The string expression.</param>
+            public FormatExpression(string @string)
+            {
+                String = @string ?? string.Empty;
+                Argument = -1;
+            }
+
+            /// <summary>
+            /// Constructs a new format expression.
+            /// </summary>
+            /// <param name="argument">The argument reference.</param>
+            public FormatExpression(int argument)
+            {
+                String = null;
+                Argument = argument;
+            }
+
+            /// <summary>
+            /// Returns the string to output (if any).
+            /// </summary>
+            public string String { get; }
+
+            /// <summary>
+            /// Returns the argument reference to output.
+            /// </summary>
+            public int Argument { get; }
+
+            /// <summary>
+            /// Returns true if the current expression has an argument reference.
+            /// </summary>
+            public readonly bool HasArgument => String is null;
+        }
+
+        /// <summary>
+        /// Represents an write argument collection.
+        /// </summary>
+        public readonly ref struct ArgumentCollection
+        {
+            #region Nested Types
+
+            /// <summary>
+            /// Returns an enumerator to enumerate all values in argument collection.
+            /// </summary>
+            public ref struct Enumerator
+            {
+                private FormatArray.Enumerator enumerator;
+
+                /// <summary>
+                /// Constructs a new use enumerator.
+                /// </summary>
+                /// <param name="writeToOutput">The parent write node.</param>
+                internal Enumerator(WriteToOutput writeToOutput)
+                {
+                    WriteToOutput = writeToOutput;
+                    enumerator = writeToOutput.Expressions.GetEnumerator();
+                    Current = default;
+                }
+
+                /// <summary>
+                /// Returns the associated node.
+                /// </summary>
+                public WriteToOutput WriteToOutput { get; }
+
+                /// <summary>
+                /// Returns the current use.
+                /// </summary>
+                public Value Current { get; private set; }
+
+                /// <summary cref="IEnumerator.MoveNext"/>
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public bool MoveNext()
+                {
+                    while (enumerator.MoveNext())
+                    {
+                        if (!enumerator.Current.HasArgument)
+                            continue;
+                        Current = WriteToOutput[enumerator.Current.Argument];
+                        return true;
+                    }
+                    return false;
+                }
+            }
+
+            #endregion
+
+            /// <summary>
+            /// Constructs a new argument collection.
+            /// </summary>
+            /// <param name="writeToOutput">The parent write node.</param>
+            internal ArgumentCollection(WriteToOutput writeToOutput)
+            {
+                WriteToOutput = writeToOutput;
+            }
+
+            /// <summary>
+            /// Returns the associated node.
+            /// </summary>
+            public WriteToOutput WriteToOutput { get; }
+
+            /// <summary>
+            /// Returns an enumerator to enumerate all uses in the context
+            /// of the parent scope.
+            /// </summary>
+            /// <returns>The enumerator.</returns>
+            public readonly Enumerator GetEnumerator() => new Enumerator(WriteToOutput);
+        }
+
+        #endregion
+
+        #region Instance
+
+        /// <summary>
+        /// Constructs a new debug operation.
+        /// </summary>
+        /// <param name="initializer">The value initializer.</param>
+        /// <param name="expressions">The list of all format expressions.</param>
+        /// <param name="arguments">The arguments to format.</param>
+        /// <param name="voidType">The void type.</param>
+        internal WriteToOutput(
+            in ValueInitializer initializer,
+            FormatArray expressions,
+            ref ValueList arguments,
+            VoidType voidType)
+            : base(initializer, voidType)
+        {
+            foreach (var argument in arguments)
+                this.Assert(argument.BasicValueType != BasicValueType.None);
+            foreach (var expression in expressions)
+            {
+                this.Assert(
+                    !expression.HasArgument ||
+                    expression.Argument >= 0 && expression.Argument < arguments.Count);
+            }
+
+            Expressions = expressions;
+            Seal(ref arguments);
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary cref="Value.ValueKind"/>
+        public override ValueKind ValueKind => ValueKind.WriteToOutput;
+
+        /// <summary>
+        /// Returns the underlying native format expressions.
+        /// </summary>
+        public FormatArray Expressions { get; }
+
+        /// <summary>
+        /// Returns all direct argument references for further processing.
+        /// </summary>
+        public ArgumentCollection Arguments => new ArgumentCollection(this);
+
+        #endregion
+
+        #region Methods
+
+        /// <summary cref="Value.Rebuild(IRBuilder, IRRebuilder)"/>
+        protected internal override Value Rebuild(
+            IRBuilder builder,
+            IRRebuilder rebuilder)
+        {
+            var arguments = ValueList.Create(Count);
+            foreach (Value argument in this)
+                arguments.Add(rebuilder[argument]);
+            return builder.CreateWriteToOutput(
+                Location,
+                Expressions,
+                ref arguments);
+        }
+
+        /// <summary cref="Value.Accept"/>
+        public override void Accept<T>(T visitor) => visitor.Visit(this);
+
+        #endregion
+
+        #region Methods
+
+        /// <summary cref="Node.ToPrefixString"/>
+        protected override string ToPrefixString() => "write";
+
+        #endregion
+    }
+}

--- a/Src/ILGPU/IR/Values/IValueVisitor.cs
+++ b/Src/ILGPU/IR/Values/IValueVisitor.cs
@@ -309,10 +309,18 @@ namespace ILGPU.IR.Values
         // Debug operations
 
         /// <summary>
-        /// Visits the node.
+        /// Visits the debug operation.
         /// </summary>
         /// <param name="debug">The node.</param>
         void Visit(DebugOperation debug);
+
+        // IO operations
+
+        /// <summary>
+        /// Visits the IO write node.
+        /// </summary>
+        /// <param name="writeToOutput">The write node.</param>
+        void Visit(WriteToOutput writeToOutput);
 
         // Terminators
 

--- a/Src/ILGPU/IR/Values/Memory.cs
+++ b/Src/ILGPU/IR/Values/Memory.cs
@@ -29,6 +29,15 @@ namespace ILGPU.IR.Values
             : base(initializer)
         { }
 
+        /// <summary>
+        /// Constructs a new memory value.
+        /// </summary>
+        /// <param name="initializer">The value initializer.</param>
+        /// <param name="staticType">The static type.</param>
+        internal MemoryValue(in ValueInitializer initializer, TypeNode staticType)
+            : base(initializer, staticType)
+        { }
+
         #endregion
     }
 

--- a/Src/ILGPU/IR/Values/ValueKind.cs
+++ b/Src/ILGPU/IR/Values/ValueKind.cs
@@ -298,6 +298,13 @@ namespace ILGPU.IR
         /// </summary>
         Debug,
 
+        // IO
+
+        /// <summary>
+        /// A <see cref="Values.WriteToOutput"/> value.
+        /// </summary>
+        WriteToOutput,
+
         // Internal use
 
         /// <summary>

--- a/Src/ILGPU/Interop.Generated.tt
+++ b/Src/ILGPU/Interop.Generated.tt
@@ -1,0 +1,72 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                        Copyright (c) 2016-2020 Marcel Koester
+//                                    www.ilgpu.net
+//
+// File: Interop.Generated.tt/Interop.Generated.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+
+<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ include file="Static/TypeInformation.ttinclude" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ output extension=".cs" #>
+<# var typeParameterRanges = Enumerable.Range(0, 14); #>
+<# var paramRange = from r in typeParameterRanges
+    let range = Enumerable.Range(1, r + 1)
+    select new
+    {
+        TypeParams = string.Join(", ", from rangeIdx in range select $"T{rangeIdx}"),
+        Params = string.Join(", ", from rangeIdx in range select $"T{rangeIdx} arg{rangeIdx}"),
+        Arguments = string.Join(", ", from rangeIdx in range select $"arg{rangeIdx}.ToString()"),
+        ParamDocumentation = string.Join("        /// ", from rangeIdx in range select
+            $"<param name=\"arg{rangeIdx}\">Argument {rangeIdx} to format.</param>{Environment.NewLine}"),
+        TypeRestrictions = string.Join(" ", from rangeIdx in range select $"where T{rangeIdx} : unmanaged"),
+        TypeParamDocumentation = string.Join("        /// ", from rangeIdx in range select
+            $"<typeparam name=\"T{rangeIdx}\">Parameter type of parameter {rangeIdx}.</typeparam>{Environment.NewLine}"),
+    }; #>
+using ILGPU.Frontend.Intrinsic;
+
+// disable: max_line_length
+
+namespace ILGPU
+{
+    partial class Interop
+    {
+<# foreach (var @params in paramRange) { #>
+        /// <summary>
+        /// Writes the given arguments using the format provided.
+        /// </summary>
+        /// <#= @params.TypeParamDocumentation #>
+        /// <param name="format">The format expression.</param>
+        /// <#= @params.ParamDocumentation #>
+        [InteropIntrinsic(InteropIntrinsicKind.Write)]
+        public static void Write<<#= @params.TypeParams #>>(
+            string format,
+            <#= @params.Params #>)
+            <#= @params.TypeRestrictions #> =>
+            WriteImplementation(format, <#= @params.Arguments #>);
+
+        /// <summary>
+        /// Writes the given arguments using the format provided.
+        /// </summary>
+        /// <#= @params.TypeParamDocumentation #>
+        /// <param name="format">The format expression.</param>
+        /// <#= @params.ParamDocumentation #>
+        [InteropIntrinsic(InteropIntrinsicKind.WriteLine)]
+        public static void WriteLine<<#= @params.TypeParams #>>(
+            string format,
+            <#= @params.Params #>)
+            <#= @params.TypeRestrictions #> =>
+            WriteImplementation(
+                GetWriteLineFormat(format),
+                <#= @params.Arguments #>);
+
+<#  } #>
+    }
+}

--- a/Src/ILGPU/Resources/ErrorMessages.Designer.cs
+++ b/Src/ILGPU/Resources/ErrorMessages.Designer.cs
@@ -673,6 +673,42 @@ namespace ILGPU.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Not supported write format &apos;{0}&apos;.
+        /// </summary>
+        internal static string NotSupportedWriteFormat {
+            get {
+                return ResourceManager.GetString("NotSupportedWriteFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Not supported write format argument reference &apos;{1}&apos; in &apos;{0}&apos;.
+        /// </summary>
+        internal static string NotSupportedWriteFormatArgumentRef {
+            get {
+                return ResourceManager.GetString("NotSupportedWriteFormatArgumentRef", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Not supported write format argument type &apos;{1} in &apos;{0}&apos;.
+        /// </summary>
+        internal static string NotSupportedWriteFormatArgumentType {
+            get {
+                return ResourceManager.GetString("NotSupportedWriteFormatArgumentType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Not supported write format &apos;{0}; must be a constant string reference.
+        /// </summary>
+        internal static string NotSupportedWriteFormatConstant {
+            get {
+                return ResourceManager.GetString("NotSupportedWriteFormatConstant", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to There are no uses to resolve.
         /// </summary>
         internal static string NoUses {

--- a/Src/ILGPU/Resources/ErrorMessages.resx
+++ b/Src/ILGPU/Resources/ErrorMessages.resx
@@ -324,4 +324,16 @@
   <data name="NotSupportedLocalMemoryIntrinsic" xml:space="preserve">
     <value>The local memory intrinsic '{0}' is not supported</value>
   </data>
+  <data name="NotSupportedWriteFormat" xml:space="preserve">
+    <value>Not supported write format '{0}'</value>
+  </data>
+  <data name="NotSupportedWriteFormatArgumentRef" xml:space="preserve">
+    <value>Not supported write format argument reference '{1}' in '{0}'</value>
+  </data>
+  <data name="NotSupportedWriteFormatArgumentType" xml:space="preserve">
+    <value>Not supported write format argument type '{1} in '{0}'</value>
+  </data>
+  <data name="NotSupportedWriteFormatConstant" xml:space="preserve">
+    <value>Not supported write format '{0}; must be a constant string reference</value>
+  </data>
 </root>


### PR DESCRIPTION
Cuda and OpenCL provide the ability to print/output basic values into the console output stream for debugging. This is especially useful for device-specific concurrency problems that need to be analyzed. This PR provides platform independent support for `ILGPU.Interop.Write` and `ILGPU.Interop.WriteLine` that accept (very) basic .Net-like format specifiers of the form `Test output {0} and test output {1}` (can be formatted to "`Test output 1.0 and test output -45`" using `Interop.Write("Test output {0} and test output {1}", 1.0, -45)`).

Note that more advanced formatting options are not currently available.
Also note that the argument types are automatically derived by the compiler.
Note that only elementary value types are supported.