### PR TITLE
Graduated O2 optimizations in PTX backend to O1.

### DIFF
--- a/Src/ILGPU/Backends/PTX/PTXBackend.cs
+++ b/Src/ILGPU/Backends/PTX/PTXBackend.cs
@@ -176,8 +176,8 @@ namespace ILGPU.Backends.PTX
             builder.AppendLine((PointerSize * 8).ToString());
             builder.AppendLine();
 
-            // Creates pointer alignment information in the context of O2 or higher
-            var alignments = Context.OptimizationLevel >= OptimizationLevel.O2
+            // Creates pointer alignment information in the context of O1 or higher
+            var alignments = Context.OptimizationLevel >= OptimizationLevel.O1
                 ? PointerAlignments.Create(
                     backendContext.KernelMethod,
                     DefaultGlobalMemoryAlignment)


### PR DESCRIPTION
Vectorized instruction generation in the scope of the `PTXBackend` is currently enabled in O2 only. This PR enables vectorized instruction generation in `Release` an `O2` modes by default.