### PR TITLE
Removed support for .NET Core 2.

### DIFF
--- a/Src/ILGPU/ILGPU.csproj
+++ b/Src/ILGPU/ILGPU.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net47;netcoreapp2.0;netstandard2.1</TargetFrameworks>
-        <TargetFrameworks Condition="'$(OS)' == 'Unix'">netcoreapp2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net47;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks Condition="'$(OS)' == 'Unix'">netstandard2.1</TargetFrameworks>
         <OutputPath>../../Bin/$(Configuration)/</OutputPath>
         <DocumentationFile>../../Bin/$(Configuration)/ILGPU.xml</DocumentationFile>
         <Configurations>Debug;Release</Configurations>


### PR DESCRIPTION
.NET Core 2.0 is [no longer supported by Microsoft](https://dotnet.microsoft.com/platform/support/policy/dotnet-core).

NB: If this PR is merged before https://github.com/m4rs-mt/ILGPU/pull/320, need to update that PR to remove `netcoreapp2.0`.