### PR TITLE
Prevent using SharedMemory in implicitly grouped kernels.

### DIFF
--- a/Src/ILGPU.Tests/SharedMemory.cs
+++ b/Src/ILGPU.Tests/SharedMemory.cs
@@ -153,5 +153,19 @@ namespace ILGPU.Tests
 
             Verify(buffer, expected);
         }
+
+        internal static void ImplicitSharedMemoryKernel(Index1 index, ArrayView<int> data)
+        {
+            data[index] = AllocateSharedMemoryNested();
+        }
+
+        [Fact]
+        [KernelMethod(nameof(ImplicitSharedMemoryKernel))]
+        public void ImplicitlyGroupedSharedMemory()
+        {
+            using var buffer = Accelerator.Allocate<int>(10);
+            Assert.Throws<InternalCompilerException>(() =>
+                Execute(buffer.Length, buffer.View));
+        }
     }
 }

--- a/Src/ILGPU/Backends/Backend.cs
+++ b/Src/ILGPU/Backends/Backend.cs
@@ -679,6 +679,13 @@ namespace ILGPU.Backends
                     entry,
                     backendContext,
                     specialization);
+                if (entryPoint.IsImplictlyGrouped &&
+                    backendContext.SharedMemorySpecification.HasSharedMemory)
+                {
+                    throw new NotSupportedException(
+                        ErrorMessages.NotSupportedSharedImplicitlyGroupedKernel);
+                }
+
                 return Compile(entryPoint, backendContext, specialization);
             }
             catch (TypeLoadException tle)

--- a/Src/ILGPU/Resources/ErrorMessages.Designer.cs
+++ b/Src/ILGPU/Resources/ErrorMessages.Designer.cs
@@ -583,6 +583,15 @@ namespace ILGPU.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Shared memory is not supported by implicitly grouped kernels..
+        /// </summary>
+        internal static string NotSupportedSharedImplicitlyGroupedKernel {
+            get {
+                return ResourceManager.GetString("NotSupportedSharedImplicitlyGroupedKernel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The shared memory intrinsic &apos;{0}&apos; is not supported.
         /// </summary>
         internal static string NotSupportedSharedMemoryIntrinsic {

--- a/Src/ILGPU/Resources/ErrorMessages.resx
+++ b/Src/ILGPU/Resources/ErrorMessages.resx
@@ -336,4 +336,7 @@
   <data name="NotSupportedWriteFormatConstant" xml:space="preserve">
     <value>Not supported write format '{0}; must be a constant string reference</value>
   </data>
+  <data name="NotSupportedSharedImplicitlyGroupedKernel" xml:space="preserve">
+    <value>Shared memory is not supported by implicitly grouped kernels.</value>
+  </data>
 </root>


### PR DESCRIPTION
Fixes https://github.com/m4rs-mt/ILGPU/issues/51 and https://github.com/m4rs-mt/ILGPU/issues/348.