### PR TITLE
Added support for unit tests running on net47.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -288,6 +288,7 @@ Src/ILGPU.Tests/ReinterpretCasts.cs
 Src/ILGPU.Tests/UnaryIntOperations.cs
 Src/ILGPU.Tests/ValueTuples.cs
 
+Src/ILGPU.Tests/.test.runsettings
 Src/ILGPU.Tests.CPU/Configurations.cs
 Src/ILGPU.Tests.CPU/TestContexts.cs
 Src/ILGPU.Tests.Cuda/Configurations.cs

--- a/Src/ILGPU.Tests.CPU/ILGPU.Tests.CPU.csproj
+++ b/Src/ILGPU.Tests.CPU/ILGPU.Tests.CPU.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net47;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Unix'">netcoreapp3.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Src/ILGPU.Tests.CPU/ILGPU.Tests.CPU.csproj
+++ b/Src/ILGPU.Tests.CPU/ILGPU.Tests.CPU.csproj
@@ -6,6 +6,10 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <RunSettingsFilePath>$(MSBuildProjectDirectory)\..\ILGPU.Tests\.test.runsettings</RunSettingsFilePath>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="1.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">

--- a/Src/ILGPU.Tests.Cuda/ILGPU.Tests.Cuda.csproj
+++ b/Src/ILGPU.Tests.Cuda/ILGPU.Tests.Cuda.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net47;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Unix'">netcoreapp3.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Src/ILGPU.Tests.Cuda/ILGPU.Tests.Cuda.csproj
+++ b/Src/ILGPU.Tests.Cuda/ILGPU.Tests.Cuda.csproj
@@ -6,6 +6,10 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <RunSettingsFilePath>$(MSBuildProjectDirectory)\..\ILGPU.Tests\.test.runsettings</RunSettingsFilePath>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="1.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">

--- a/Src/ILGPU.Tests.OpenCL/ILGPU.Tests.OpenCL.csproj
+++ b/Src/ILGPU.Tests.OpenCL/ILGPU.Tests.OpenCL.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net47;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Unix'">netcoreapp3.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Src/ILGPU.Tests.OpenCL/ILGPU.Tests.OpenCL.csproj
+++ b/Src/ILGPU.Tests.OpenCL/ILGPU.Tests.OpenCL.csproj
@@ -6,6 +6,10 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <RunSettingsFilePath>$(MSBuildProjectDirectory)\..\ILGPU.Tests\.test.runsettings</RunSettingsFilePath>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="1.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">

--- a/Src/ILGPU.Tests/.test.tt
+++ b/Src/ILGPU.Tests/.test.tt
@@ -1,0 +1,14 @@
+﻿<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ assembly name="System.Core" #>
+<#@ output extension=".runsettings" #>
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <!-- Run on native platform architecture. -->
+<# if (Environment.Is64BitOperatingSystem) { #>
+    <TargetPlatform>x64</TargetPlatform>
+<# } else { #>
+    <TargetPlatform>x86</TargetPlatform>
+<# } #>
+  </RunConfiguration>
+</RunSettings>

--- a/Src/ILGPU.Tests/ILGPU.Tests.csproj
+++ b/Src/ILGPU.Tests/ILGPU.Tests.csproj
@@ -16,6 +16,10 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <RunSettingsFilePath>$(MSBuildProjectDirectory)\.test.runsettings</RunSettingsFilePath>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Remove="Generic\Verifier.cs" />
   </ItemGroup>
@@ -173,6 +177,15 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update=".test.runsettings">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>.test.tt</DependentUpon>
+    </None>
+    <None Update=".test.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>.test.runsettings</LastGenOutput>
+    </None>
     <None Update="AtomicCASOperations.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>AtomicCASOperations.cs</LastGenOutput>

--- a/Src/ILGPU.Tests/ILGPU.Tests.csproj
+++ b/Src/ILGPU.Tests/ILGPU.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net47;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Unix'">netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <StartupObject />
   </PropertyGroup>
@@ -34,6 +35,11 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net47'">
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.0" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/ILGPU.Tests/ValueTuples.tt
+++ b/Src/ILGPU.Tests/ValueTuples.tt
@@ -35,30 +35,54 @@ namespace ILGPU.Tests
 
         private static unsafe byte GetRandomUInt8()
         {
+#if NETFRAMEWORK
+            byte[] bytes = new byte[1];
+            rnd.NextBytes(bytes);
+            return bytes[0];
+#else
             Span<byte> bytes = stackalloc byte[1];
             rnd.NextBytes(bytes);
             return bytes[0];
+#endif
         }
 
         private static unsafe short GetRandomInt16()
         {
+#if NETFRAMEWORK
+            byte[] bytes = new byte[2];
+            rnd.NextBytes(bytes);
+            return BitConverter.ToInt16(bytes, 0);
+#else
             Span<byte> bytes = stackalloc byte[2];
             rnd.NextBytes(bytes);
             return BitConverter.ToInt16(bytes);
+#endif
         }
 
         private static unsafe int GetRandomInt32()
         {
+#if NETFRAMEWORK
+            byte[] bytes = new byte[4];
+            rnd.NextBytes(bytes);
+            return BitConverter.ToInt32(bytes, 0);
+#else
             Span<byte> bytes = stackalloc byte[4];
             rnd.NextBytes(bytes);
             return BitConverter.ToInt32(bytes);
+#endif
         }
 
         private static unsafe long GetRandomInt64()
         {
+#if NETFRAMEWORK
+            byte[] bytes = new byte[8];
+            rnd.NextBytes(bytes);
+            return BitConverter.ToInt64(bytes, 0);
+#else
             Span<byte> bytes = stackalloc byte[8];
             rnd.NextBytes(bytes);
             return BitConverter.ToInt64(bytes);
+#endif
         }
 
 <#


### PR DESCRIPTION
Some of the ArrayViewAlignment tests are failing. Will need further investigation.

```
ILGPU.Tests.CPU.CPUArrayViews_Debug.ArrayViewAlignment<PairStruct<Double, Double>>(alignmentInBytes: 32, value: 1.79769313486232E+308, 1.79769313486232E+308) Failed	74 ms		Assert.Equal() Failure Expected: 0 Actual:   24
ILGPU.Tests.CPU.CPUArrayViews_Debug.ArrayViewAlignment<PairStruct<Double, Double>>(alignmentInBytes: 64, value: 1.79769313486232E+308, 1.79769313486232E+308) Failed	82 ms		Assert.Equal() Failure Expected: 0 Actual:   56
ILGPU.Tests.CPU.CPUArrayViews_Debug.ArrayViewAlignment<PairStruct<Double, Double>>(alignmentInBytes: 128, value: 1.79769313486232E+308, 1.79769313486232E+308) Failed	52 ms		Assert.Equal() Failure Expected: 0 Actual:   120
ILGPU.Tests.CPU.CPUArrayViews_Debug.ArrayViewAlignment<PairStruct<Double, Double>>(alignmentInBytes: 256, value: 1.79769313486232E+308, 1.79769313486232E+308) Failed	132 ms		Assert.Equal() Failure Expected: 0 Actual:   248

ILGPU.Tests.CPU.CPUArrayViews_Release.ArrayViewAlignment<PairStruct<Double, Double>>(alignmentInBytes: 32, value: 1.79769313486232E+308, 1.79769313486232E+308) Failed	22 ms		Assert.Equal() Failure Expected: 0 Actual:   24
ILGPU.Tests.CPU.CPUArrayViews_Release.ArrayViewAlignment<PairStruct<Double, Double>>(alignmentInBytes: 64, value: 1.79769313486232E+308, 1.79769313486232E+308) Failed	13 ms		Assert.Equal() Failure Expected: 0 Actual:   56
ILGPU.Tests.CPU.CPUArrayViews_Release.ArrayViewAlignment<PairStruct<Double, Double>>(alignmentInBytes: 128, value: 1.79769313486232E+308, 1.79769313486232E+308) Failed	35 ms		Assert.Equal() Failure Expected: 0 Actual:   120
ILGPU.Tests.CPU.CPUArrayViews_Release.ArrayViewAlignment<PairStruct<Double, Double>>(alignmentInBytes: 256, value: 1.79769313486232E+308, 1.79769313486232E+308) Failed	23 ms		Assert.Equal() Failure Expected: 0 Actual:   248
ILGPU.Tests.CPU.CPUArrayViews_Release.ArrayViewAlignment<PairStruct<Double, Double>>(alignmentInBytes: 512, value: 1.79769313486232E+308, 1.79769313486232E+308) Failed	36 ms		Assert.Equal() Failure Expected: 0 Actual:   504

ILGPU.Tests.CPU.CPUArrayViews_O2.ArrayViewAlignment<PairStruct<Double, Double>>(alignmentInBytes: 128, value: 1.79769313486232E+308, 1.79769313486232E+308) Failed	24 ms		Assert.Equal() Failure Expected: 0 Actual:   120
ILGPU.Tests.CPU.CPUArrayViews_O2.ArrayViewAlignment<PairStruct<Double, Double>>(alignmentInBytes: 256, value: 1.79769313486232E+308, 1.79769313486232E+308) Failed	19 ms		Assert.Equal() Failure Expected: 0 Actual:   248

```