### PR TITLE
Fixed returning correct length of dynamic shared memory buffer.

### DIFF
--- a/Src/ILGPU/Backends/IBackendCodeGenerator.cs
+++ b/Src/ILGPU/Backends/IBackendCodeGenerator.cs
@@ -264,6 +264,12 @@ namespace ILGPU.Backends
         /// <summary>
         /// Generates code for the given value.
         /// </summary>
+        /// <param name="value">The node.</param>
+        void GenerateCode(DynamicMemoryLengthValue value);
+
+        /// <summary>
+        /// Generates code for the given value.
+        /// </summary>
         /// <param name="barrier">The node.</param>
         void GenerateCode(PredicateBarrier barrier);
 
@@ -510,6 +516,10 @@ namespace ILGPU.Backends
 
             /// <summary cref="IValueVisitor.Visit(LaneIdxValue)"/>
             public void Visit(LaneIdxValue value) =>
+                CodeGenerator.GenerateCode(value);
+
+            /// <summary cref="IValueVisitor.Visit(DynamicMemoryLengthValue)"/>
+            public void Visit(DynamicMemoryLengthValue value) =>
                 CodeGenerator.GenerateCode(value);
 
             /// <summary cref="IValueVisitor.Visit(PredicateBarrier)"/>

--- a/Src/ILGPU/Backends/OpenCL/CLArgumentMapper.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLArgumentMapper.cs
@@ -384,10 +384,10 @@ namespace ILGPU.Backends.OpenCL
             emitter.Emit(OpCodes.Ldc_I4_0);
             emitter.Emit(LocalOperation.Store, resultLocal);
 
-            // Compute the base offset that can reserves an additional parameter
-            // of dynamic shared memory allocations
+            // Compute the base offset that reserves additional parameters for dynamic
+            // shared memory allocations - buffer and buffer size.
             int baseOffset = entryPoint.SharedMemory.HasDynamicMemory
-                ? 1
+                ? 2
                 : 0;
 
             // Map all views

--- a/Src/ILGPU/Backends/OpenCL/CLVariableAllocator.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLVariableAllocator.cs
@@ -10,6 +10,7 @@
 // ---------------------------------------------------------------------------------------
 
 using ILGPU.IR.Analyses;
+using ILGPU.IR.Values;
 using System;
 using System.Runtime.CompilerServices;
 
@@ -52,6 +53,36 @@ namespace ILGPU.Backends.OpenCL
             public override string ToString() => Name;
         }
 
+        /// <summary>
+        /// A virtual globally accessible shared memory length variable.
+        /// </summary>
+        /// <remarks>
+        /// Instances of this class will not return valid variable ids.
+        /// </remarks>
+        private sealed class GloballySharedMemoryLengthVariable : TypedVariable
+        {
+            /// <summary>
+            /// Constructs a new variable instance.
+            /// </summary>
+            /// <param name="allocaInfo">The source allocation info.</param>
+            public GloballySharedMemoryLengthVariable(in AllocaInformation allocaInfo)
+                : base(-1, allocaInfo.Alloca.Type)
+            {
+                Name = GetSharedMemoryAllocationLengthName(allocaInfo);
+            }
+
+            /// <summary>
+            /// Returns the allocation name.
+            /// </summary>
+            public string Name { get; }
+
+            /// <summary>
+            /// Returns the allocation name.
+            /// </summary>
+            /// <returns>The allocation name.</returns>
+            public override string ToString() => Name;
+        }
+
         #endregion
 
         #region Static
@@ -75,6 +106,35 @@ namespace ILGPU.Backends.OpenCL
         public static string GetSharedMemoryAllocationName(
             in AllocaInformation allocaInfo) =>
             "shared_var_" + allocaInfo.Alloca.Id;
+
+        /// <summary>
+        /// Returns a shared memory allocation length variable reference.
+        /// </summary>
+        /// <param name="allocaInfo">The source allocation info.</param>
+        /// <returns>
+        /// The allocation variable reference pointing to the allocation object.
+        /// </returns>
+        public static Variable GetSharedMemoryAllocationLengthVariable(
+            in AllocaInformation allocaInfo) =>
+            new GloballySharedMemoryLengthVariable(allocaInfo);
+
+        /// <summary>
+        /// Returns a unique shared memory allocation length name.
+        /// </summary>
+        /// <param name="allocaInfo">The source allocation info.</param>
+        /// <returns>The allocation name.</returns>
+        public static string GetSharedMemoryAllocationLengthName(
+            in AllocaInformation allocaInfo) =>
+            GetSharedMemoryAllocationLengthName(allocaInfo.Alloca);
+
+        /// <summary>
+        /// Returns a unique shared memory allocation length name.
+        /// </summary>
+        /// <param name="alloca">The source allocation operation.</param>
+        /// <returns>The allocation name.</returns>
+        internal static string GetSharedMemoryAllocationLengthName(
+            Alloca alloca) =>
+            "shared_var_len_" + alloca.Id;
 
         #endregion
 

--- a/Src/ILGPU/Backends/PTX/PTXRegisterAllocator.cs
+++ b/Src/ILGPU/Backends/PTX/PTXRegisterAllocator.cs
@@ -77,6 +77,11 @@ namespace ILGPU.Backends.PTX
         /// The LaneId register.
         /// </summary>
         LaneId,
+
+        /// <summary>
+        /// The DynamicSharedMemorySize register.
+        /// </summary>
+        DynamicSharedMemorySize,
     }
 
     /// <summary>
@@ -176,6 +181,7 @@ namespace ILGPU.Backends.PTX
                 PTXRegisterKind.NtId => "ntid." +
                     ResolveDeviceConstantValue(register),
                 PTXRegisterKind.LaneId => "laneid",
+                PTXRegisterKind.DynamicSharedMemorySize => "dynamic_smem_size",
                 _ => throw new InvalidCodeGenerationException(),
             };
 

--- a/Src/ILGPU/IR/Analyses/Allocas.cs
+++ b/Src/ILGPU/IR/Analyses/Allocas.cs
@@ -40,12 +40,24 @@ namespace ILGPU.IR.Analyses
             Index = index;
             Alloca = alloca;
 
-            ArraySize = alloca.IsArrayAllocation(out var length)
-                ? length.Int32Value
-                : alloca.IsSimpleAllocation
-                    ? 1
-                    : throw new NotSupportedException(
-                        ErrorMessages.NotSupportedDynamicAllocation);
+            if (alloca.IsArrayAllocation(out var length))
+            {
+                ArraySize = length.Int32Value;
+            }
+            else if (alloca.IsSimpleAllocation)
+            {
+                ArraySize = 1;
+            }
+            else if (alloca.IsDynamicAllocation)
+            {
+                // Size determined at run-time.
+                ArraySize = -1;
+            }
+            else
+            {
+                throw new NotSupportedException(
+                    ErrorMessages.NotSupportedDynamicAllocation);
+            }
         }
 
         #endregion

--- a/Src/ILGPU/IR/Construction/IRBuilder.cs
+++ b/Src/ILGPU/IR/Construction/IRBuilder.cs
@@ -107,6 +107,22 @@ namespace ILGPU.IR.Construction
             Append(new LaneIdxValue(GetInitializer(location)));
 
         /// <summary>
+        /// Creates a node that represents the length of dynamic memory.
+        /// </summary>
+        /// <param name="location">The current location.</param>
+        /// <param name="elementType">The element type.</param>
+        /// <param name="addressSpace">The target address space.</param>
+        /// <returns>A reference to the requested value.</returns>
+        internal ValueReference CreateDynamicMemoryLengthValue(
+            Location location,
+            TypeNode elementType,
+            MemoryAddressSpace addressSpace) =>
+            Append(new DynamicMemoryLengthValue(
+                GetInitializer(location),
+                elementType,
+                addressSpace));
+
+        /// <summary>
         /// Creates a node that represents a <see cref="Grid.Index"/> property.
         /// </summary>
         /// <param name="location">The current location.</param>

--- a/Src/ILGPU/IR/Construction/Memory.cs
+++ b/Src/ILGPU/IR/Construction/Memory.cs
@@ -77,7 +77,7 @@ namespace ILGPU.IR.Construction
             MemoryAddressSpace addressSpace) =>
             CreateStaticAllocaArray(
                 location,
-                CreatePrimitiveValue(location, -1),
+                CreateDynamicMemoryLengthValue(location, type, addressSpace),
                 type,
                 addressSpace);
 

--- a/Src/ILGPU/IR/Values/DeviceConstants.cs
+++ b/Src/ILGPU/IR/Values/DeviceConstants.cs
@@ -437,4 +437,71 @@ namespace ILGPU.IR.Values
 
         #endregion
     }
+
+    /// <summary>
+    /// Represents the value returned by calling the <see cref="ArrayView{T}.Length"/>
+    /// property on a dynamic memory view.
+    /// </summary>
+    [ValueKind(ValueKind.DynamicMemoryLength)]
+    public sealed class DynamicMemoryLengthValue : DeviceConstantValue
+    {
+        #region Instance
+
+        /// <summary>
+        /// Constructs a new value.
+        /// </summary>
+        /// <param name="initializer">The value initializer.</param>
+        /// <param name="elementType">The element type node.</param>
+        /// <param name="addressSpace">The target address space.</param>
+        internal DynamicMemoryLengthValue(
+            in ValueInitializer initializer,
+            TypeNode elementType,
+            MemoryAddressSpace addressSpace)
+            : base(
+                  initializer,
+                  initializer.Context.GetPrimitiveType(BasicValueType.Int32))
+        {
+            ElementType = elementType;
+            AddressSpace = addressSpace;
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary cref="Value.ValueKind"/>
+        public override ValueKind ValueKind => ValueKind.DynamicMemoryLength;
+
+        /// <summary>
+        /// Returns the element type node.
+        /// </summary>
+        public TypeNode ElementType { get; }
+
+        /// <summary>
+        /// Returns the address space of this allocation.
+        /// </summary>
+        public MemoryAddressSpace AddressSpace { get; }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary cref="Value.Rebuild(IRBuilder, IRRebuilder)"/>
+        protected internal override Value Rebuild(
+            IRBuilder builder,
+            IRRebuilder rebuilder) =>
+            builder.CreateDynamicMemoryLengthValue(Location, ElementType, AddressSpace);
+
+        /// <summary cref="Value.Accept" />
+        public override void Accept<T>(T visitor) => visitor.Visit(this);
+
+        #endregion
+
+        #region Object
+
+        /// <summary cref="Node.ToPrefixString"/>
+        protected override string ToPrefixString() => "dynamicMemLength";
+
+        #endregion
+    }
 }

--- a/Src/ILGPU/IR/Values/IValueVisitor.cs
+++ b/Src/ILGPU/IR/Values/IValueVisitor.cs
@@ -267,6 +267,12 @@ namespace ILGPU.IR.Values
         /// <summary>
         /// Visits the node.
         /// </summary>
+        /// <param name="value">The node.</param>
+        void Visit(DynamicMemoryLengthValue value);
+
+        /// <summary>
+        /// Visits the node.
+        /// </summary>
         /// <param name="barrier">The node.</param>
         void Visit(PredicateBarrier barrier);
 

--- a/Src/ILGPU/IR/Values/Memory.cs
+++ b/Src/ILGPU/IR/Values/Memory.cs
@@ -102,6 +102,12 @@ namespace ILGPU.IR.Values
         public bool IsSimpleAllocation =>
             ArrayLength.ResolveAs<UndefinedValue>() != null;
 
+        /// <summary>
+        /// Returns true if this allocation is a dynamic allocation.
+        /// </summary>
+        public bool IsDynamicAllocation =>
+            ArrayLength.ResolveAs<DynamicMemoryLengthValue>() != null;
+
         #endregion
 
         #region Methods

--- a/Src/ILGPU/IR/Values/ValueKind.cs
+++ b/Src/ILGPU/IR/Values/ValueKind.cs
@@ -142,6 +142,11 @@ namespace ILGPU.IR
         /// </summary>
         LaneIdx,
 
+        /// <summary>
+        /// A <see cref="Values.DynamicMemoryLengthValue"/> value.
+        /// </summary>
+        DynamicMemoryLength,
+
         // Memory
 
         /// <summary>

--- a/Src/ILGPU/Runtime/OpenCL/CLAPI.cs
+++ b/Src/ILGPU/Runtime/OpenCL/CLAPI.cs
@@ -71,12 +71,21 @@ namespace ILGPU.Runtime.OpenCL
             public readonly CLError PreLaunchKernel(
                 CLStream stream,
                 CLKernel kernel,
-                RuntimeKernelConfig config) =>
-                CurrentAPI.SetKernelArgumentUnsafeWithKernel(
-                    kernel,
-                    0,
-                    config.SharedMemoryConfig.DynamicArraySize,
-                    null);
+                RuntimeKernelConfig config)
+            {
+                // Allocate local buffer of desired size.
+                CLException.ThrowIfFailed(
+                    CurrentAPI.SetKernelArgumentUnsafeWithKernel(
+                        kernel,
+                        0,
+                        config.SharedMemoryConfig.DynamicArraySize,
+                        null));
+                // The length of the local buffer (in bytes).
+                return CurrentAPI.SetKernelArgument(
+                    kernel.KernelPtr,
+                    1,
+                    config.SharedMemoryConfig.DynamicArraySize);
+            }
         }
 
         #endregion


### PR DESCRIPTION
Fixes https://github.com/m4rs-mt/ILGPU/issues/356.

It appears that the `ArrayView` returned by `SharedMemory.GetDynamic<T>` currently returns -1 for its length on Cuda and OpenCL accelerators - the CPU accelerator is not affected.

On the Cuda accelerator, there is a [special register](https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-dynamic-smem-size) that contains the size of the dynamic memory (in bytes). This needs to be divided by the size of the data element type.

@m4rs-mt I'm not familiar with the OpenCL implementation of SharedMemory. How should this be handled?