### PR TITLE
Updated Kernel Argument Mapping and Cuda Kernel Launchers

### DIFF
--- a/Src/ILGPU/Backends/IL/ILEmitter.cs
+++ b/Src/ILGPU/Backends/IL/ILEmitter.cs
@@ -120,6 +120,13 @@ namespace ILGPU.Backends.IL
         ILLocal DeclareLocal(Type type);
 
         /// <summary>
+        /// Declares a pinned local variable.
+        /// </summary>
+        /// <param name="type">The variable type.</param>
+        /// <returns>The variable reference.</returns>
+        ILLocal DeclarePinnedLocal(Type type);
+
+        /// <summary>
         /// Declares a new label.
         /// </summary>
         /// <returns>The label reference.</returns>
@@ -269,15 +276,28 @@ namespace ILGPU.Backends.IL
 
         #region Methods
 
-        /// <summary cref="IILEmitter.DeclareLocal(Type)"/>
+        /// <summary>
+        /// Declares a internal local.
+        /// </summary>
+        /// <param name="type">The local type.</param>
+        /// <param name="pinned">True, if the local is pinned.</param>
+        /// <returns>The declared local.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ILLocal DeclareLocal(Type type)
+        private ILLocal DeclareLocalInternal(Type type, bool pinned)
         {
             var local = Generator.DeclareLocal(type);
             var result = new ILLocal(declaredLocals.Count, type);
             declaredLocals.Add(local);
             return result;
         }
+
+        /// <summary cref="IILEmitter.DeclareLocal(Type)"/>
+        public ILLocal DeclareLocal(Type type) =>
+            DeclareLocalInternal(type, false);
+
+        /// <summary cref="IILEmitter.DeclarePinnedLocal(Type)"/>
+        public ILLocal DeclarePinnedLocal(Type type) =>
+            DeclareLocalInternal(type, true);
 
         /// <summary cref="IILEmitter.DeclareLabel"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -426,13 +446,25 @@ namespace ILGPU.Backends.IL
 
         #region Methods
 
-        /// <summary cref="IILEmitter.DeclareLocal(Type)"/>
-        public ILLocal DeclareLocal(Type type)
+        /// <summary>
+        /// Declares a locally internal type.
+        /// </summary>
+        /// <param name="type">The allocation type.</param>
+        /// <returns>The allocated local.</returns>
+        private ILLocal DeclareLocalInternal(Type type)
         {
             var result = new ILLocal(locals.Count, type);
             locals.Add(result);
             return result;
         }
+
+        /// <summary cref="IILEmitter.DeclareLocal(Type)"/>
+        public ILLocal DeclareLocal(Type type) =>
+            DeclareLocalInternal(type);
+
+        /// <summary cref="IILEmitter.DeclarePinnedLocal(Type)"/>
+        public ILLocal DeclarePinnedLocal(Type type) =>
+            DeclareLocalInternal(type);
 
         /// <summary cref="IILEmitter.DeclareLabel"/>
         public ILLabel DeclareLabel()

--- a/Src/ILGPU/Backends/PointerViews/ViewImplementation.cs
+++ b/Src/ILGPU/Backends/PointerViews/ViewImplementation.cs
@@ -35,11 +35,6 @@ namespace ILGPU.Backends.PointerViews
             "Microsoft.Design",
             "CA1051: DoNotDeclareVisibleInstanceFields",
             Justification = "Implementation type that simplifies code generation")]
-        [SuppressMessage(
-            "Microsoft.Security",
-            "CA2104: DoNotDeclareReadOnlyMutableReferenceTypes",
-            Justification = "This structure is used for marshaling purposes only. " +
-            "The reference will not be accessed using this structure.")]
         public readonly void* Ptr;
 
         /// <summary>


### PR DESCRIPTION
Kernel argument mapping is one of the essential tasks that have to be performed to pass parameter values from the C# world to the actual GPU kernel on the device. The current implementation of all kernel launchers uses several unsafe operations such as `Ldobj` and `Stobj` to load and store values into specially generated argument buffers on the stack. This PR changes the current implementation to use safe and verifiable MSIL instructions in most places instead. This allows the GC to process references on the stack more efficiently and improves the runtime performance of the generated kernel launchers.

Moreover, the `Cuda` accelerator passed all kernel arguments separately via an additional management data structure on the stack. This PR also changes this implementation by creating packed argument structures that contain fields for all kernel parameters. This structure is then immediately passed to the driver, reducing launch overhead and improving interoperability.