### PR TITLE
Fixed invalid PTX on-device calling convention

### DIFF
--- a/Src/ILGPU/Backends/PTX/PTXCodeGenerator.Emitter.cs
+++ b/Src/ILGPU/Backends/PTX/PTXCodeGenerator.Emitter.cs
@@ -440,9 +440,8 @@ namespace ILGPU.Backends.PTX
 
                 RegisterAllocator = registerAllocator;
                 PredicateRegister = registerAllocator.AllocateRegister(
-                    new RegisterDescription(
-                        BasicValueType.Int1,
-                        PTXRegisterKind.Predicate));
+                    BasicValueType.Int1,
+                    PTXRegisterKind.Predicate);
             }
 
             /// <summary>
@@ -791,9 +790,8 @@ namespace ILGPU.Backends.PTX
                 "Invalid register kind");
 
             var targetRegister = AllocateRegister(
-                new RegisterDescription(
-                    BasicValueType.Int1,
-                    PTXRegisterKind.Predicate));
+                BasicValueType.Int1,
+                PTXRegisterKind.Predicate);
             ConvertValueToPredicate(register, targetRegister);
             return targetRegister;
         }
@@ -991,11 +989,13 @@ namespace ILGPU.Backends.PTX
         /// <summary>
         /// Resolves the desired hardware register.
         /// </summary>
-        public static HardwareRegister GetIntrinsicRegister(
+        public HardwareRegister GetIntrinsicRegister(
             PTXRegisterKind registerKind,
             int dimension = 0)
         {
-            var desc = new RegisterDescription(BasicValueType.Int32, registerKind);
+            var desc = RegisterDescription.Create(
+                TypeContext.GetPrimitiveType(BasicValueType.Int32),
+                registerKind);
             return new HardwareRegister(desc, dimension);
         }
 

--- a/Src/ILGPU/Backends/PTX/PTXCodeGenerator.Values.cs
+++ b/Src/ILGPU/Backends/PTX/PTXCodeGenerator.Values.cs
@@ -32,8 +32,6 @@ namespace ILGPU.Backends.PTX
             Builder.AppendLine();
             Builder.AppendLine("\t{");
 
-            Builder.AppendLine("\t.reg .b32 temp_param_reg;");
-
             for (int i = 0, e = methodCall.Count; i < e; ++i)
             {
                 var argument = methodCall.Nodes[i];
@@ -611,9 +609,7 @@ namespace ILGPU.Backends.PTX
 
             if (fieldOffset != 0)
             {
-                var targetRegister = AllocatePlatformRegister(
-                    value,
-                    out RegisterDescription _);
+                var targetRegister = AllocateHardware(value);
                 using var command = BeginCommand(
                     PTXInstructions.GetArithmeticOperation(
                         BinaryArithmeticKind.Add,
@@ -667,7 +663,7 @@ namespace ILGPU.Backends.PTX
 
             // Convert the string value into the generic address space
             // string (global) -> string (generic)
-            var register = AllocatePlatformRegister(value, out var _);
+            var register = AllocateHardware(value);
             CreateAddressSpaceCast(
                 tempValueRegister,
                 register,

--- a/Src/ILGPU/Backends/PTX/PTXCodeGenerator.Views.cs
+++ b/Src/ILGPU/Backends/PTX/PTXCodeGenerator.Views.cs
@@ -22,9 +22,7 @@ namespace ILGPU.Backends.PTX
         public void GenerateCode(LoadElementAddress value)
         {
             var elementIndex = LoadPrimitive(value.Offset);
-            var targetAddressRegister = AllocatePlatformRegister(
-                value,
-                out RegisterDescription _);
+            var targetAddressRegister = AllocateHardware(value);
             Debug.Assert(value.IsPointerAccess, "Invalid pointer access");
 
             var address = LoadPrimitive(value.Source);
@@ -100,11 +98,9 @@ namespace ILGPU.Backends.PTX
         /// <summary cref="IBackendCodeGenerator.GenerateCode(AddressSpaceCast)"/>
         public void GenerateCode(AddressSpaceCast value)
         {
-            var sourceType = value.SourceType as AddressSpaceType;
-            var targetAdressRegister = AllocatePlatformRegister(
-                value,
-                out RegisterDescription _);
-            Debug.Assert(value.IsPointerCast, "Invalid pointer access");
+            var sourceType = value.SourceType.As<AddressSpaceType>(value);
+            var targetAdressRegister = AllocateHardware(value);
+            value.Assert(value.IsPointerCast);
 
             var address = LoadPrimitive(value.Value);
             CreateAddressSpaceCast(


### PR DESCRIPTION
The current implementation of the calling convention of functions (including kernel functions) in the PTX device code has not taken into account the poorly documented address spaces of pointers. The use of the `O2` pipeline leads to programs that use efficient IO operations and expect pointers to live in a specific address space. 

This can lead to issues with the PTX assembler or the GPU drivers since they implicitly expect the input PTX program to pay attention to the calling convention. Even worse, we have experienced several "random" crashes in the past of the currently implemented Cuda tests on different devices. After some investigation, it turned out that all pointers should be passed in the `generic` address space and should be converted into an appropriate (more specific) address space at the beginning of each function. If we call an on-device function, we have to convert all "specialized" address-space pointers to be valid in the generic address space instead.

This PR implements these barely documented calling-convention rules for all emitted PTX programs. Note that this PR does not include any test cases since they are already existing in the code base.