### PR TITLE
Updated analysis framework and fixed alignment issues of shared and local-memory allocations.

### DIFF
--- a/Src/ILGPU/Backends/PTX/PTXBackend.cs
+++ b/Src/ILGPU/Backends/PTX/PTXBackend.cs
@@ -178,10 +178,10 @@ namespace ILGPU.Backends.PTX
 
             // Creates pointer alignment information in the context of O1 or higher
             var alignments = Context.OptimizationLevel >= OptimizationLevel.O1
-                ? PointerAlignments.Create(
+                ? PointerAlignments.Apply(
                     backendContext.KernelMethod,
                     DefaultGlobalMemoryAlignment)
-                : null;
+                : PointerAlignments.AlignmentInfo.Empty;
 
             data = new PTXCodeGenerator.GeneratorArgs(
                 this,

--- a/Src/ILGPU/Backends/PTX/PTXCodeGenerator.Emitter.cs
+++ b/Src/ILGPU/Backends/PTX/PTXCodeGenerator.Emitter.cs
@@ -687,7 +687,7 @@ namespace ILGPU.Backends.PTX
             Register register)
             where TEmitter : IVectorizedCommandEmitter
         {
-            if (PointerAlignments != null &&
+            if (!PointerAlignments.IsEmpty &&
                 register is CompoundRegister compoundRegister)
             {
                 // Check the provided alignment value to create vectorized instructions

--- a/Src/ILGPU/Backends/PTX/PTXCodeGenerator.cs
+++ b/Src/ILGPU/Backends/PTX/PTXCodeGenerator.cs
@@ -72,7 +72,7 @@ namespace ILGPU.Backends.PTX
                 EntryPoint entryPoint,
                 ContextFlags contextFlags,
                 PTXDebugInfoGenerator debugInfoGenerator,
-                PointerAlignments pointerAlignments)
+                PointerAlignments.AlignmentInfo pointerAlignments)
             {
                 Backend = backend;
                 EntryPoint = entryPoint;
@@ -104,7 +104,7 @@ namespace ILGPU.Backends.PTX
             /// <summary>
             /// Returns detailed information about all pointer alignments.
             /// </summary>
-            public PointerAlignments PointerAlignments { get; }
+            public PointerAlignments.AlignmentInfo PointerAlignments { get; }
         }
 
         /// <summary>
@@ -415,7 +415,7 @@ namespace ILGPU.Backends.PTX
         /// <summary>
         /// Returns detailed information about all pointer alignments.
         /// </summary>
-        public PointerAlignments PointerAlignments { get; }
+        public PointerAlignments.AlignmentInfo PointerAlignments { get; }
 
         /// <summary>
         /// Returns all blocks in an appropriate schedule.
@@ -450,15 +450,6 @@ namespace ILGPU.Backends.PTX
         #endregion
 
         #region General Code Generation
-
-        /// <summary>
-        /// Returns the alignment in bytes for the given alloca.
-        /// </summary>
-        /// <param name="alloca">The alloca to get the alignment information for.</param>
-        /// <returns>The determined and used alignment in bytes.</returns>
-        protected int GetAllocaAlignment(Alloca alloca) =>
-            PointerAlignments?.GetAllocaAlignment(alloca) ??
-            AllocaAlignments.GetInitialAlignment(alloca);
 
         /// <summary>
         /// Declares a new label.
@@ -615,7 +606,7 @@ namespace ILGPU.Backends.PTX
                 Builder.Append(addressSpacePrefix);
 
                 Builder.Append(".align ");
-                Builder.Append(GetAllocaAlignment(allocaInfo.Alloca));
+                Builder.Append(PointerAlignments.GetAllocaAlignment(allocaInfo.Alloca));
                 Builder.Append(" .b8 ");
 
                 var name = namePrefix + offset++;

--- a/Src/ILGPU/Backends/PTX/PTXKernelFunctionGenerator.cs
+++ b/Src/ILGPU/Backends/PTX/PTXKernelFunctionGenerator.cs
@@ -126,7 +126,7 @@ namespace ILGPU.Backends.PTX
             {
                 sharedAlignmentInBytes = Math.Max(
                     sharedAlignmentInBytes,
-                    GetAllocaAlignment(alloca.Alloca));
+                    PointerAlignments.GetAllocaAlignment(alloca.Alloca));
             }
             sharedAlignmentInBytes = Math.Min(
                 sharedAlignmentInBytes,

--- a/Src/ILGPU/IR/Analyses/FixPointAnalysis.cs
+++ b/Src/ILGPU/IR/Analyses/FixPointAnalysis.cs
@@ -488,36 +488,27 @@ namespace ILGPU.IR.Analyses
         /// <param name="type">The type node.</param>
         /// <returns>The created analysis value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected static AnalysisValue<T> Create(T data, TypeNode type)
-        {
-            if (type is StructureType structureType)
-            {
-                var childData = new T[structureType.NumFields];
-                for (int i = 0, e = childData.Length; i < e; ++i)
-                    childData[i] = data;
-                return new AnalysisValue<T>(data, childData);
-            }
-            return new AnalysisValue<T>(data);
-        }
+        protected static AnalysisValue<T> CreateValue(T data, TypeNode type) =>
+            AnalysisValue.Create(data, type);
 
         /// <summary>
         /// Creates an initial analysis value.
         /// </summary>
         /// <param name="type">The type node.</param>
         /// <returns>The created analysis value.</returns>
-        protected AnalysisValue<T> Create(TypeNode type)
+        protected AnalysisValue<T> CreateValue(TypeNode type)
         {
             if (type is StructureType structureType)
             {
                 var childData = new T[structureType.NumFields];
                 for (int i = 0, e = childData.Length; i < e; ++i)
-                    childData[i] = Create(structureType[i]).Data;
+                    childData[i] = CreateValue(structureType[i]).Data;
                 T data = childData[0];
                 for (int i = 1, e = childData.Length; i < e; ++i)
                     data = Merge(data, childData[i]);
                 return new AnalysisValue<T>(data, childData);
             }
-            return TryProvide(type) ?? Create(DefaultValue, type);
+            return TryProvide(type) ?? CreateValue(DefaultValue, type);
         }
 
         /// <summary>
@@ -562,7 +553,7 @@ namespace ILGPU.IR.Analyses
             var fieldSpan = getField.FieldSpan;
             if (!fieldSpan.HasSpan)
             {
-                return Create(
+                return CreateValue(
                     Merge(
                         source.Data,
                         sourceValue[fieldSpan.Index]),
@@ -679,7 +670,7 @@ namespace ILGPU.IR.Analyses
             var newData = source.Data;
             foreach (Value node in value.Nodes)
                 newData = Merge(newData, context[node].Data);
-            return Create(newData, value.Type);
+            return CreateValue(newData, value.Type);
         }
 
         #endregion

--- a/Src/ILGPU/IR/Analyses/PointerAlignments.cs
+++ b/Src/ILGPU/IR/Analyses/PointerAlignments.cs
@@ -85,9 +85,9 @@ namespace ILGPU.IR.Analyses
             /// </param>
             /// <returns>The determined and used alignment in bytes.</returns>
             public readonly int GetAllocaAlignment(Alloca alloca) =>
-                AnalysisResult.TryGetData(alloca, out var data)
-                ? data.Data
-                : AllocaAlignments.GetInitialAlignment(alloca);
+                GetAlignment(
+                    alloca,
+                    AllocaAlignments.GetInitialAlignment(alloca));
 
             /// <summary>
             /// Returns safe alignment information.
@@ -206,6 +206,7 @@ namespace ILGPU.IR.Analyses
                 case PhiValue _:
                 case PrimitiveValue _:
                 case NullValue _:
+                case UndefinedValue _:
                     return int.MaxValue;
                 default:
                     return 1;

--- a/Src/ILGPU/IR/Analyses/PointerAlignments.cs
+++ b/Src/ILGPU/IR/Analyses/PointerAlignments.cs
@@ -13,39 +13,49 @@ using ILGPU.IR.Analyses.ControlFlowDirection;
 using ILGPU.IR.Types;
 using ILGPU.IR.Values;
 using System;
-using System.Collections.Generic;
 
 namespace ILGPU.IR.Analyses
 {
     /// <summary>
     /// An analysis to determine safe alignment information for all pointer values.
     /// </summary>
-    public sealed class PointerAlignments
+    public class PointerAlignments : GlobalFixPointAnalysis<int, Forwards>
     {
         #region Nested Types
 
         /// <summary>
-        /// Stores alignment information of a specific method.
+        /// Stores alignment information of an alignment analysis run.
         /// </summary>
         public readonly struct AlignmentInfo
         {
-            internal AlignmentInfo(
-                Method method,
-                AnalysisValueMapping<int> alignments)
+            #region Static
+
+            /// <summary>
+            /// Empty allocation information.
+            /// </summary>
+            public static readonly AlignmentInfo Empty =
+                new AlignmentInfo(GlobalAnalysisValueResult<int>.Empty);
+
+            #endregion
+
+            #region Instance
+
+            /// <summary>
+            /// Constructs a new alignment analysis.
+            /// </summary>
+            internal AlignmentInfo(GlobalAnalysisValueResult<int> analysisResult)
             {
-                Method = method;
-                Alignments = alignments;
+                AnalysisResult = analysisResult;
             }
 
-            /// <summary>
-            /// Returns the underlying alignments object.
-            /// </summary>
-            private AnalysisValueMapping<int> Alignments { get; }
+            #endregion
+
+            #region Properties
 
             /// <summary>
-            /// Returns the associated method.
+            /// Stores a method value-alignment mapping.
             /// </summary>
-            public Method Method { get; }
+            public GlobalAnalysisValueResult<int> AnalysisResult { get; }
 
             /// <summary>
             /// Returns pointer alignment information for the given value.
@@ -53,82 +63,120 @@ namespace ILGPU.IR.Analyses
             /// <param name="value">The value to get alignment information for.</param>
             /// <returns>Pointer alignment in bytes (can be 1 byte).</returns>
             public readonly int this[Value value] =>
-                Alignments.TryGetValue(value, out var alignment)
-                ? alignment.Data
+                AnalysisResult.TryGetData(value, out var data)
+                ? data.Data
                 : 1;
-        }
-
-        /// <summary>
-        /// Models the internal pointer alignment analysis.
-        /// </summary>
-        private sealed class AnalysisImplementation :
-            GlobalFixPointAnalysis<int, Forwards>
-        {
-            private readonly AllocaAlignments allocaAlignments =
-                AllocaAlignments.Create();
 
             /// <summary>
-            /// Constructs a new analysis implementation.
+            /// Returns true if this alignment information object is empty.
             /// </summary>
-            /// <param name="globalAlignment">The global alignment information.</param>
-            public AnalysisImplementation(int globalAlignment)
-                : base(
-                      defaultValue: 1,
-                      initialValue: globalAlignment)
-            { }
+            public readonly bool IsEmpty => AnalysisResult.IsEmpty;
+
+            #endregion
+
+            #region Methods
 
             /// <summary>
-            /// Creates initial analysis data.
+            /// Returns the alignment information determined and used for the given
+            /// alloca.
             /// </summary>
-            protected override AnalysisValue<int> CreateData(Value node) =>
-                Create(
-                    node is Alloca alloca
-                        ? allocaAlignments.ComputeAllocaAlignment(alloca)
-                        : GetInitialAlignment(node),
-                    node.Type);
+            /// <param name="alloca">
+            /// The alloca to get the alignment information for.
+            /// </param>
+            /// <returns>The determined and used alignment in bytes.</returns>
+            public readonly int GetAllocaAlignment(Alloca alloca) =>
+                AnalysisResult.TryGetData(alloca, out var data)
+                ? data.Data
+                : AllocaAlignments.GetInitialAlignment(alloca);
 
             /// <summary>
-            /// Returns the minimum of the first and the second value.
+            /// Returns safe alignment information.
             /// </summary>
-            protected override int Merge(int first, int second) =>
-                Math.Min(first, second);
+            /// <param name="value">
+            /// The value for which to compute the alignment for.
+            /// </param>
+            /// <param name="safeMinAlignment">
+            /// The safe minimum alignment in bytes.
+            /// </param>
+            /// <returns>The computed alignment.</returns>
+            public readonly int GetAlignment(Value value, int safeMinAlignment) =>
+                Math.Max(this[value], safeMinAlignment);
 
             /// <summary>
-            /// Returns merged information about <see cref="LoadFieldAddress"/> and
-            /// <see cref="LoadElementAddress"/> IR nodes.
+            /// Returns safe alignment information.
             /// </summary>
-            protected override AnalysisValue<int>? TryMerge<TContext>(
+            /// <param name="value">
+            /// The value for which to compute the alignment for.
+            /// </param>
+            /// <param name="safeMinTypeAlignment">
+            /// The safe minimum type alignment.
+            /// </param>
+            /// <returns>The computed alignment.</returns>
+            public readonly int GetAlignment(
                 Value value,
-                TContext context) =>
-                value switch
-                {
-                    LoadFieldAddress lfa =>
-                        Create(
-                            Math.Min(
-                                context[lfa.Source].Data,
-                                lfa.StructureType[lfa.FieldSpan.Access].Alignment),
-                                lfa.Type),
-                    LoadElementAddress lea =>
-                        Create(
-                            Math.Max(
-                                context[lea.Source].Data,
-                                (lea.Type as IAddressSpaceType).ElementType.Alignment),
-                            lea.Type),
-                    _ => null,
-                };
+                TypeNode safeMinTypeAlignment) =>
+                GetAlignment(value, safeMinTypeAlignment.Alignment);
 
-            /// <summary>
-            /// Creates alignment information for global pointer and view types.
-            /// </summary>
-            protected override AnalysisValue<int>? TryProvide(TypeNode typeNode) =>
-                typeNode is IAddressSpaceType
-                ? Create(InitialValue, typeNode)
-                : (AnalysisValue<int>?)null;
+            #endregion
         }
 
         #endregion
 
         #region Static
+
+        /// <summary>
+        /// Creates a new alignment analysis.
+        /// </summary>
+        /// <param name="globalAlignment">
+        /// The initial alignment information of all pointers and views of the root
+        /// method.
+        /// </param>
+        public static PointerAlignments Create(int globalAlignment) =>
+            new PointerAlignments(globalAlignment);
+
+        /// <summary>
+        /// Applies a new alignment analysis to the given root method.
+        /// </summary>
+        /// <param name="rootMethod">The root (entry) method.</param>
+        /// <param name="globalAlignment">
+        /// The initial alignment information of all pointers and views of the root
+        /// method.
+        /// </param>
+        public static AlignmentInfo Apply(Method rootMethod, int globalAlignment)
+        {
+            var analysis = Create(globalAlignment);
+            var result = analysis.AnalyzeGlobalMethod(rootMethod, globalAlignment);
+            return new AlignmentInfo(result);
+        }
+
+        #endregion
+
+        #region Instance
+
+        private readonly AllocaAlignments allocaAlignments = AllocaAlignments.Create();
+
+        /// <summary>
+        /// Constructs a new analysis implementation.
+        /// </summary>
+        /// <param name="globalAlignment">The global alignment information.</param>
+        protected PointerAlignments(int globalAlignment)
+            : base(defaultValue: 1)
+        {
+            GlobalAlignment = globalAlignment;
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Returns the global alignment in bytes.
+        /// </summary>
+        public int GlobalAlignment { get; }
+
+        #endregion
+
+        #region Methods
 
         /// <summary>
         /// Returns initial and unconstrained alignment information.
@@ -165,103 +213,53 @@ namespace ILGPU.IR.Analyses
         }
 
         /// <summary>
-        /// An empty value mapping.
+        /// Creates initial analysis data.
         /// </summary>
-        private readonly static AnalysisValueMapping<int> EmptyMapping =
-            AnalysisValueMapping.Create<int>();
+        protected override AnalysisValue<int> CreateData(Value node) =>
+            CreateValue(
+                node is Alloca alloca
+                    ? allocaAlignments.ComputeAllocaAlignment(alloca)
+                    : GetInitialAlignment(node),
+                node.Type);
 
         /// <summary>
-        /// Represents no pointer alignment information.
+        /// Returns the minimum of the first and the second value.
         /// </summary>
-        public static readonly PointerAlignments Empty = new PointerAlignments();
+        protected override int Merge(int first, int second) =>
+            Math.Min(first, second);
 
         /// <summary>
-        /// Creates a new alignment analysis.
+        /// Returns merged information about <see cref="LoadFieldAddress"/> and
+        /// <see cref="LoadElementAddress"/> IR nodes.
         /// </summary>
-        /// <param name="rootMethod">The root (entry) method.</param>
-        /// <param name="globalAlignment">
-        /// The initial alignment information of all pointers and views of the root
-        /// method.
-        /// </param>
-        public static PointerAlignments Create(Method rootMethod, int globalAlignment) =>
-            new PointerAlignments(rootMethod, globalAlignment);
-
-        #endregion
-
-        #region Instance
+        protected override AnalysisValue<int>? TryMerge<TContext>(
+            Value value,
+            TContext context) =>
+            value switch
+            {
+                LoadFieldAddress lfa =>
+                    CreateValue(
+                        Math.Min(
+                            context[lfa.Source].Data,
+                            lfa.StructureType[lfa.FieldSpan.Access].Alignment),
+                            lfa.Type),
+                LoadElementAddress lea =>
+                    CreateValue(
+                        Math.Max(
+                            context[lea.Source].Data,
+                            (lea.Type as IAddressSpaceType).ElementType.Alignment),
+                        lea.Type),
+                _ => null,
+            };
 
         /// <summary>
-        /// Stores a method value-alignment mapping.
+        /// Creates alignment information for global pointer and view types.
         /// </summary>
-        private readonly Dictionary<Method, AnalysisValueMapping<int>> alignments;
-
-        /// <summary>
-        /// Constructs an empty pointer alignment analysis.
-        /// </summary>
-        private PointerAlignments()
-        {
-            alignments = new Dictionary<Method, AnalysisValueMapping<int>>();
-        }
-
-        /// <summary>
-        /// Constructs a new alignment analysis.
-        /// </summary>
-        private PointerAlignments(Method rootMethod, int globalAlignment)
-        {
-            var impl = new AnalysisImplementation(globalAlignment);
-            alignments = impl.AnalyzeGlobal(rootMethod);
-        }
-
-        #endregion
-
-        #region Properties
-
-        /// <summary>
-        /// Returns pointer alignment information for the given method.
-        /// </summary>
-        /// <param name="method">The method to get alignment information for.</param>
-        /// <returns>Resolved pointer alignment information.</returns>
-        public AlignmentInfo this[Method method] =>
-            alignments.TryGetValue(method, out var result)
-            ? new AlignmentInfo(method, result)
-            : new AlignmentInfo(method, EmptyMapping);
-
-        /// <summary>
-        /// Returns pointer alignment information for the given value.
-        /// </summary>
-        /// <param name="value">The value to get alignment information for.</param>
-        /// <returns>Pointer alignment in bytes (can be 1 byte).</returns>
-        public int this[Value value] => this[value.Method][value];
-
-        #endregion
-
-        #region Methods
-
-        /// <summary>
-        /// Returns the alignment information determined and used for the given alloca.
-        /// </summary>
-        /// <param name="alloca">The alloca to get the alignment information for.</param>
-        /// <returns>The determined and used alignment in bytes.</returns>
-        public int GetAllocaAlignment(Alloca alloca) => this[alloca];
-
-        /// <summary>
-        /// Returns safe alignment information.
-        /// </summary>
-        /// <param name="value">The value for which to compute the alignment for.</param>
-        /// <param name="safeMinAlignment">The safe minimum alignment in bytes.</param>
-        /// <returns>The computed alignment.</returns>
-        public int GetAlignment(Value value, int safeMinAlignment) =>
-            Math.Max(this[value], safeMinAlignment);
-
-        /// <summary>
-        /// Returns safe alignment information.
-        /// </summary>
-        /// <param name="value">The value for which to compute the alignment for.</param>
-        /// <param name="safeMinTypeAlignment">The safe minimum type alignment.</param>
-        /// <returns>The computed alignment.</returns>
-        public int GetAlignment(Value value, TypeNode safeMinTypeAlignment) =>
-            GetAlignment(value, safeMinTypeAlignment.Alignment);
-
-        #endregion
+        protected override AnalysisValue<int>? TryProvide(TypeNode typeNode) =>
+            typeNode is IAddressSpaceType
+            ? CreateValue(GlobalAlignment, typeNode)
+            : default(AnalysisValue<int>?);
     }
+
+    #endregion
 }

--- a/Src/ILGPU/IR/Types/PointerTypes.cs
+++ b/Src/ILGPU/IR/Types/PointerTypes.cs
@@ -47,7 +47,7 @@ namespace ILGPU.IR.Types
             /// Constructs a new address space converter.
             /// </summary>
             /// <param name="addressSpace">The target address space.</param>
-            public AddressSpaceConverter(MemoryAddressSpace addressSpace)
+            internal AddressSpaceConverter(MemoryAddressSpace addressSpace)
             {
                 AddressSpace = addressSpace;
             }
@@ -72,6 +72,36 @@ namespace ILGPU.IR.Types
                 typeContext.SpecializeAddressSpaceType(
                     type,
                     AddressSpace);
+        }
+
+        #endregion
+
+        #region Static
+
+        /// <summary>
+        /// Caches all known address space type converters.
+        /// </summary>
+        private static readonly AddressSpaceConverter[] TypeConverters =
+        {
+            new AddressSpaceConverter(MemoryAddressSpace.Generic),
+            new AddressSpaceConverter(MemoryAddressSpace.Global),
+            new AddressSpaceConverter(MemoryAddressSpace.Shared),
+            new AddressSpaceConverter(MemoryAddressSpace.Local),
+        };
+
+        /// <summary>
+        /// Returns a cached version of an <see cref="AddressSpaceConverter"/> for known
+        /// address spaces.
+        /// </summary>
+        /// <param name="addressSpace">The address space to convert into.</param>
+        /// <returns>A cached or a new converter instance.</returns>
+        public static AddressSpaceConverter GetAddressSpaceConverter(
+            MemoryAddressSpace addressSpace)
+        {
+            int index = (int)addressSpace;
+            return index < 0 || index >= TypeConverters.Length
+                ? new AddressSpaceConverter(addressSpace)
+                : TypeConverters[index];
         }
 
         #endregion

--- a/Src/ILGPU/IR/Values/Cast.cs
+++ b/Src/ILGPU/IR/Values/Cast.cs
@@ -250,6 +250,11 @@ namespace ILGPU.IR.Values
         /// </summary>
         public new AddressSpaceType Type => base.Type as AddressSpaceType;
 
+        /// <summary>
+        /// Returns the source type.
+        /// </summary>
+        public new AddressSpaceType SourceType => base.SourceType as AddressSpaceType;
+
         #endregion
     }
 

--- a/Src/ILGPU/IR/Values/Predicate.cs
+++ b/Src/ILGPU/IR/Values/Predicate.cs
@@ -11,6 +11,7 @@
 
 using ILGPU.IR.Construction;
 using ILGPU.IR.Types;
+using System;
 
 namespace ILGPU.IR.Values
 {
@@ -63,6 +64,11 @@ namespace ILGPU.IR.Values
         /// Returns the false value.
         /// </summary>
         public ValueReference FalseValue => this[2];
+
+        /// <summary>
+        /// Returns a span excluding the condition value reference.
+        /// </summary>
+        public ReadOnlySpan<ValueReference> Values => Nodes.Slice(1);
 
         #endregion
 


### PR DESCRIPTION
This PR updates the existing analysis framework to simplify the implementation of new program analyses. Furthermore, it makes it easier to use the existing analysis. The intent is to capture implementation issues faster and reduce the amount of code required to develop internal analysis. It also includes new features that allows us to reason about the return values of functions and to support the previously introduced `Predicate`-selection IR values.

Finally, this PR also fixes invalidly aligned local and shared memory allocations in the device code, which could already occur in the existing test cases. However, this did not cause any problems since the `PointerAlignmentsAnalysis` was aware of the badly aligned allocations.