### PR TITLE
Remove ArrayView's size limit of 2^31 - 1.

### DIFF
--- a/Src/ILGPU.Tests/ArrayViews.cs
+++ b/Src/ILGPU.Tests/ArrayViews.cs
@@ -588,44 +588,6 @@ namespace ILGPU.Tests
             data[index] = source[reconstructedIndex];
         }
 
-        [Theory]
-        [InlineData(127)]
-        [InlineData(1300)]  // Makes a 2.04GB MemoryBuffer on the GPU.
-        // Prefer not to go larger so this test will pass on more machines.
-        [KernelMethod(nameof(ArrayViewSparseMultidimensionalAccessKernel))]
-        public void ArrayViewSparseMultidimensionalAccess(long length)
-        {
-            // This test allocates over 2GB of memory (with length == 1300), then fills
-            // it with 0s and 255s.
-            // Rather than copying the whole array and checking the result, which would
-            // take a long time to check, we'll copy every outputReductionRatio'th
-            // element and check that result.
-            var extent = new LongIndex3(length);
-            long outputReductionRatio = 103;
-            using var buffer = Accelerator.Allocate<byte, LongIndex1>(
-                extent.Size / outputReductionRatio);
-            var expectedData = new byte[extent.Size / outputReductionRatio];
-            for (int i = 0; i < expectedData.Length; i++)
-            {
-                // Find what row of the source element i comes from.
-                // Odd rows contain 255, and even rows contain 0.
-                long sourceRow = (i * outputReductionRatio) / (length * length);
-                expectedData[i] = sourceRow % 2 == 0 ? byte.MinValue : byte.MaxValue;
-            }
-            using (var source = Accelerator.Allocate<byte, LongIndex3>(extent))
-            {
-                // Fill alternating rows with 0 and 255.
-                for (int i = 0; i < length; i++)
-                {
-                    source.MemSet(i % 2 == 0 ? byte.MinValue : byte.MaxValue,
-                        i * (length * length), length * length);
-                }
-                Execute((int)(extent.Size / outputReductionRatio),
-                    buffer.View, source.View);
-            }
-            Verify(buffer, expectedData);
-        }
-
         internal static void ArrayViewAlignmentKernel<T>(
             Index1 index,
             ArrayView<T> data,

--- a/Src/ILGPU.Tests/Configurations.txt
+++ b/Src/ILGPU.Tests/Configurations.txt
@@ -5,6 +5,7 @@ DisassemblerTests: Debug, Release, O2
 EnumValues: Debug, Release, O2
 ExchangeBufferOperations: Debug, Release, O2
 FixedBuffers: Debug, Release, O2
+Indices: Debug, Release, O2
 KernelEntryPoints: Debug, Release, O2
 MemoryBufferOperations : Debug, Release, O2
 MemoryCacheOperations : Debug, Release, O2

--- a/Src/ILGPU.Tests/Indices.cs
+++ b/Src/ILGPU.Tests/Indices.cs
@@ -22,8 +22,11 @@ namespace ILGPU.Tests
         [Theory]
         [InlineData(1, 1_000_000, 1_000_000, 1, 0)]
         [InlineData(17, 10, 10, 7, 1)]
-        [InlineData(6_000_000_005, 1_000_000, 1_000_000, 5, 6_000)]  // Make sure linearIndices > int.MaxValue work.
-        public void ReconstructIndex2(long linearIndex, int dimX, int dimY, int expectedX, int expectedY)
+        [InlineData(6_000_000_005, 1_000_000, 1_000_000,
+            5, 6_000)]  // Make sure linearIndices > int.MaxValue work.
+        public void ReconstructIndex2(
+            long linearIndex, int dimX, int dimY,
+            int expectedX, int expectedY)
         {
             var index = Index2.ReconstructIndex(linearIndex, new Index2(dimX, dimY));
             Assert.Equal(expectedX, index.X);
@@ -33,11 +36,19 @@ namespace ILGPU.Tests
         [Theory]
         [InlineData(1, 1_000_000, 1_000_000, 1_000_000, 1, 0, 0)]
         [InlineData(217, 10, 10, 10, 7, 1, 2)]
-        [InlineData(70_000_060_005, 10_000, 10_000, 10_000, 5, 6, 700)]  // Make sure linearIndices > int.MaxValue work.
-        [InlineData(700_000_000_006_000_005, 1_000_000, 1_000_000, 1_000_000, 5, 6, 700_000)]  // yz > int.MaxValue
-        public void ReconstructIndex3(long linearIndex, int dimX, int dimY, int dimZ, int expectedX, int expectedY, int expectedZ)
+        [InlineData(
+            70_000_060_005, 10_000, 10_000, 10_000,
+            5, 6, 700)]  // Make sure linearIndices > int.MaxValue work.
+        [InlineData(
+            700_000_000_006_000_005, 1_000_000, 1_000_000, 1_000_000,
+            5, 6, 700_000)]  // yz > int.MaxValue
+        public void ReconstructIndex3(
+            long linearIndex, int dimX, int dimY, int dimZ,
+            int expectedX, int expectedY, int expectedZ)
         {
-            var index = Index3.ReconstructIndex(linearIndex, new Index3(dimX, dimY, dimZ));
+            var index = Index3.ReconstructIndex(
+                linearIndex,
+                new Index3(dimX, dimY, dimZ));
             Assert.Equal(expectedX, index.X);
             Assert.Equal(expectedY, index.Y);
             Assert.Equal(expectedZ, index.Z);

--- a/Src/ILGPU.Tests/Indices.cs
+++ b/Src/ILGPU.Tests/Indices.cs
@@ -1,0 +1,46 @@
+﻿using Xunit;
+using Xunit.Abstractions;
+
+namespace ILGPU.Tests
+{
+    public abstract class Indices : TestBase
+    {
+        protected Indices(ITestOutputHelper output, TestContext testContext)
+            : base(output, testContext)
+        { }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(17)]
+        [InlineData(1025)]
+        public void ReconstructIndex1(long linearIndex)
+        {
+            var index = Index1.ReconstructIndex(linearIndex, int.MaxValue);
+            Assert.Equal(linearIndex, index.Size);
+        }
+
+        [Theory]
+        [InlineData(1, 1_000_000, 1_000_000, 1, 0)]
+        [InlineData(17, 10, 10, 7, 1)]
+        [InlineData(6_000_000_005, 1_000_000, 1_000_000, 5, 6_000)]  // Make sure linearIndices > int.MaxValue work.
+        public void ReconstructIndex2(long linearIndex, int dimX, int dimY, int expectedX, int expectedY)
+        {
+            var index = Index2.ReconstructIndex(linearIndex, new Index2(dimX, dimY));
+            Assert.Equal(expectedX, index.X);
+            Assert.Equal(expectedY, index.Y);
+        }
+
+        [Theory]
+        [InlineData(1, 1_000_000, 1_000_000, 1_000_000, 1, 0, 0)]
+        [InlineData(217, 10, 10, 10, 7, 1, 2)]
+        [InlineData(70_000_060_005, 10_000, 10_000, 10_000, 5, 6, 700)]  // Make sure linearIndices > int.MaxValue work.
+        [InlineData(700_000_000_006_000_005, 1_000_000, 1_000_000, 1_000_000, 5, 6, 700_000)]  // yz > int.MaxValue
+        public void ReconstructIndex3(long linearIndex, int dimX, int dimY, int dimZ, int expectedX, int expectedY, int expectedZ)
+        {
+            var index = Index3.ReconstructIndex(linearIndex, new Index3(dimX, dimY, dimZ));
+            Assert.Equal(expectedX, index.X);
+            Assert.Equal(expectedY, index.Y);
+            Assert.Equal(expectedZ, index.Z);
+        }
+    }
+}

--- a/Src/ILGPU/ArrayViews.tt
+++ b/Src/ILGPU/ArrayViews.tt
@@ -79,7 +79,6 @@ namespace ILGPU
         /// <param name="baseView">The source view.</param>
         public <#= typeName #>(ArrayView<T, <#= indexType #>> baseView)
         {
-            IndexTypeExtensions.AssertIntIndexRange(baseView.Length);
             BaseView = baseView;
         }
 

--- a/Src/ILGPU/IndexTypes.tt
+++ b/Src/ILGPU/IndexTypes.tt
@@ -261,26 +261,15 @@ namespace ILGPU
         /// <param name="linearIndex">The linear index.</param>
         /// <returns>The reconstructed index.</returns>
         public readonly <#= name #> ReconstructIndex(int linearIndex) =>
-<# if (def.IsIntIndex) { #>
             ReconstructIndex(linearIndex, this);
-<# } else { #>
-            ReconstructIndex((long)linearIndex);
-<# } #>
 
         /// <summary>
         /// Reconstructs an index from a linear index.
         /// </summary>
         /// <param name="linearIndex">The linear index.</param>
         /// <returns>The reconstructed index.</returns>
-        public readonly <#= name #> ReconstructIndex(long linearIndex)
-<# if (def.IsIntIndex) { #>
-        {
-            IndexTypeExtensions.AssertIntIndexRange(linearIndex);
-            return ReconstructIndex((int)linearIndex, this);
-        }
-<# } else { #>
-        => ReconstructIndex(linearIndex, this);
-<# } #>
+        public readonly <#= name #> ReconstructIndex(long linearIndex) =>
+            ReconstructIndex(linearIndex, this);
 
         #endregion
 
@@ -633,6 +622,22 @@ namespace ILGPU
             <#= name #> dimension) =>
             linearIndex;
 
+<# if (def.IsIntIndex) { #>
+        /// <summary>
+        /// Reconstructs a 1D index from a linear index.
+        /// </summary>
+        /// <param name="linearIndex">The linear index.</param>
+        /// <param name="dimension">The 1D dimension for reconstruction.</param>
+        /// <returns>The reconstructed 1D index.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static <#= name #> ReconstructIndex(
+            long linearIndex,
+            <#= name #> dimension) {
+            IndexTypeExtensions.AssertIntIndexRange(linearIndex);
+            return linearIndex;
+        }
+<# } #>
+
         /// <summary>
         /// Implicitly converts an index to an int.
         /// </summary>
@@ -688,6 +693,25 @@ namespace ILGPU
             <#= baseType #> y = linearIndex / dimension.X;
             return new <#= name #>(x, y);
         }
+
+<# if (def.IsIntIndex) { #>
+        /// <summary>
+        /// Reconstructs a 2D index from a linear index.
+        /// </summary>
+        /// <param name="linearIndex">The linear index.</param>
+        /// <param name="dimension">The 2D dimension for reconstruction.</param>
+        /// <returns>The reconstructed 2D index.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static <#= name #> ReconstructIndex(
+            long linearIndex,
+            <#= name #> dimension)
+        {
+            long x = linearIndex % dimension.X;
+            long y = linearIndex / dimension.X;
+            IndexTypeExtensions.AssertIntIndexRange(y);
+            return new <#= name #>((int)x, (int)y);
+        }
+<# } #>
     }
 
 <#  } #>
@@ -725,6 +749,27 @@ namespace ILGPU
             <#= baseType #> z = yz / dimension.Y;
             return new <#= name #>(x, y, z);
         }
+
+<# if (def.IsIntIndex) { #>
+        /// <summary>
+        /// Reconstructs a 3D index from a linear index.
+        /// </summary>
+        /// <param name="linearIndex">The linear index.</param>
+        /// <param name="dimension">The 3D dimension for reconstruction.</param>
+        /// <returns>The reconstructed 3D index.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static <#= name #> ReconstructIndex(
+            long linearIndex,
+            <#= name #> dimension)
+        {
+            long x = linearIndex % dimension.X;
+            long yz = linearIndex / dimension.X;
+            long y = yz % dimension.Y;
+            long z = yz / dimension.Y;
+            IndexTypeExtensions.AssertIntIndexRange(z);
+            return new <#= name #>((int)x, (int)y, (int)z);
+        }
+<# } #>
     }
 
 <#  } #>

--- a/Src/ILGPU/Runtime/KernelLauncherBuilder.cs
+++ b/Src/ILGPU/Runtime/KernelLauncherBuilder.cs
@@ -93,8 +93,10 @@ namespace ILGPU.Runtime
             emitter.EmitNewObject(mainConstructor);
         }
 
-        private static readonly Type[] ReconstructIndex2DArguments = new Type[] { typeof(int), typeof(Index2) };
-        private static readonly Type[] ReconstructIndex3DArguments = new Type[] { typeof(int), typeof(Index3) };
+        private static readonly Type[] ReconstructIndex2DArguments =
+            new Type[] { typeof(int), typeof(Index2) };
+        private static readonly Type[] ReconstructIndex3DArguments =
+            new Type[] { typeof(int), typeof(Index3) };
 
         /// <summary>
         /// Emits code to convert a linear index to a specific target type.

--- a/Src/ILGPU/Runtime/KernelLauncherBuilder.cs
+++ b/Src/ILGPU/Runtime/KernelLauncherBuilder.cs
@@ -93,6 +93,9 @@ namespace ILGPU.Runtime
             emitter.EmitNewObject(mainConstructor);
         }
 
+        private static readonly Type[] ReconstructIndex2DArguments = new Type[] { typeof(int), typeof(Index2) };
+        private static readonly Type[] ReconstructIndex3DArguments = new Type[] { typeof(int), typeof(Index3) };
+
         /// <summary>
         /// Emits code to convert a linear index to a specific target type.
         /// </summary>
@@ -123,14 +126,14 @@ namespace ILGPU.Runtime
                     emitter.EmitCall(
                         managedIndexType.GetMethod(
                             nameof(Index2.ReconstructIndex),
-                            BindingFlags.Public | BindingFlags.Static));
+                            ReconstructIndex2DArguments));
                     break;
                 case IndexType.Index3D:
                     loadDimension();
                     emitter.EmitCall(
                         managedIndexType.GetMethod(
                             nameof(Index3.ReconstructIndex),
-                            BindingFlags.Public | BindingFlags.Static));
+                            ReconstructIndex3DArguments));
                     break;
                 default:
                     throw new NotSupportedException(


### PR DESCRIPTION
Fixes #366, at least allowing such arrays to be created.