### PR TITLE
Fixed edge cases in LoopUnrolling

### DIFF
--- a/Src/ILGPU.Tests/BasicLoops.cs
+++ b/Src/ILGPU.Tests/BasicLoops.cs
@@ -424,6 +424,35 @@ namespace ILGPU.Tests
             var expected = Enumerable.Repeat(7, Length).ToArray();
             Verify(buffer, expected);
         }
+
+        internal static void LoopUnrollingChainedIfKernel(
+            Index1 index,
+            ArrayView<int> source,
+            ArrayView<int> data)
+        {
+            for (int i = 0; i < 4; ++i)
+            {
+                var j = source[i];
+                if (i > 2 && i < 5 && i == j)
+                    data[index] = j;
+            }
+        }
+
+        [Fact]
+        [KernelMethod(nameof(LoopUnrollingChainedIfKernel))]
+        public void LoopUnrollingChainedIf()
+        {
+            using var source = Accelerator.Allocate<int>(Length);
+            using var buffer = Accelerator.Allocate<int>(Length);
+
+            source.MemSetToZero();
+            buffer.MemSetToZero();
+
+            Execute(buffer.Length, source.View, buffer.View);
+
+            var expected = Enumerable.Repeat(0, Length).ToArray();
+            Verify(buffer, expected);
+        }
     }
 }
 

--- a/Src/ILGPU/IR/Analyses/Loops.cs
+++ b/Src/ILGPU/IR/Analyses/Loops.cs
@@ -32,10 +32,6 @@ namespace ILGPU.IR.Analyses
     /// </summary>
     /// <typeparam name="TOrder">The current order.</typeparam>
     /// <typeparam name="TDirection">The control-flow direction.</typeparam>
-    [SuppressMessage(
-        "Microsoft.Naming",
-        "CA1710: IdentifiersShouldHaveCorrectSuffix",
-        Justification = "This is the correct name of this program analysis")]
     public sealed class Loops<TOrder, TDirection>
         where TOrder : struct, ITraversalOrder
         where TDirection : struct, IControlFlowDirection
@@ -285,6 +281,40 @@ namespace ILGPU.IR.Analyses
                         builder.Add(block);
                 }
                 return builder.Seal();
+            }
+
+            /// <summary>
+            /// Returns true if the given blocks contain at least one backedge block.
+            /// </summary>
+            /// <param name="blocks">The blocks to test.</param>
+            /// <returns>
+            /// True, if the given block contain at least one backedge block.
+            /// </returns>
+            public bool ContainsBackedgeBlock(ReadOnlySpan<BasicBlock> blocks)
+            {
+                foreach (var block in blocks)
+                {
+                    if (BackEdges.Contains(block, new BasicBlock.Comparer()))
+                        return true;
+                }
+                return false;
+            }
+
+            /// <summary>
+            /// Returns true if the given blocks consists of exclusive body blocks only.
+            /// </summary>
+            /// <param name="blocks">The blocks to test.</param>
+            /// <returns>
+            /// True, if the given blocks consists of exclusive body blocks only.
+            /// </returns>
+            public bool ConsistsOfBodyBlocks(ReadOnlySpan<BasicBlock> blocks)
+            {
+                foreach (var block in blocks)
+                {
+                    if (!ContainsExclusively(block))
+                        return false;
+                }
+                return true;
             }
 
             /// <summary>


### PR DESCRIPTION
The current `LoopUnrolling` implementation has a critical bug related to nested conditionals with side effects. Without this PR, ILGPU can crash using `O1` and `O2`.