### PR TITLE
Added enhanced support for assertions on accelerator devices

### DIFF
--- a/Src/ILGPU.Tests/SharedMemory.cs
+++ b/Src/ILGPU.Tests/SharedMemory.cs
@@ -77,7 +77,7 @@ namespace ILGPU.Tests
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static int AllocateSharedMemoryNested()
         {
-            var sharedMemory = ILGPU.SharedMemory.Allocate<int>(2);
+            var sharedMemory = ILGPU.SharedMemory.Allocate<int>(1024);
             sharedMemory[Group.IdxX] = Group.IdxX;
             Group.Barrier();
 

--- a/Src/ILGPU/Backends/Backend.cs
+++ b/Src/ILGPU/Backends/Backend.cs
@@ -816,18 +816,14 @@ namespace ILGPU.Backends
         /// <summary>
         /// Initializes the associated kernel transformers.
         /// </summary>
-        /// <param name="flags">The specializer flags.</param>
         /// <param name="createTransformers">The target handler.</param>
-        protected void InitializeKernelTransformers(
-            IntrinsicSpecializerFlags flags,
+        protected new void InitializeKernelTransformers(
             Action<ImmutableArray<Transformer>.Builder> createTransformers) =>
-            InitializeKernelTransformers(builder =>
+            base.InitializeKernelTransformers(builder =>
             {
                 // Specialize intrinsic functions
                 var resolver = new IntrinsicResolver<TDelegate>(IntrinsicProvider);
-                var specializer = new IntrinsicSpecializer<TDelegate>(
-                    flags,
-                    IntrinsicProvider);
+                var specializer = new IntrinsicSpecializer<TDelegate>(IntrinsicProvider);
                 var lowerThreadIntrinsics = new LowerThreadIntrinsics();
 
                 // Perform two general passes to specialize ILGPU-specific intrinsic

--- a/Src/ILGPU/Backends/IBackendCodeGenerator.cs
+++ b/Src/ILGPU/Backends/IBackendCodeGenerator.cs
@@ -297,7 +297,7 @@ namespace ILGPU.Backends
         /// Generates code for the given value.
         /// </summary>
         /// <param name="debug">The node.</param>
-        void GenerateCode(DebugOperation debug);
+        void GenerateCode(DebugAssertOperation debug);
 
         // Terminators
 
@@ -540,8 +540,8 @@ namespace ILGPU.Backends
             public void Visit(HandleValue handle) =>
                 throw new InvalidCodeGenerationException();
 
-            /// <summary cref="IValueVisitor.Visit(DebugOperation)"/>
-            public void Visit(DebugOperation debug) =>
+            /// <summary cref="IValueVisitor.Visit(DebugAssertOperation)"/>
+            public void Visit(DebugAssertOperation debug) =>
                 CodeGenerator.GenerateCode(debug);
 
             /// <summary cref="IValueVisitor.Visit(WriteToOutput)"/>

--- a/Src/ILGPU/Backends/OpenCL/CLBackend.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLBackend.cs
@@ -67,7 +67,6 @@ namespace ILGPU.Backends.OpenCL
 
             InitIntrinsicProvider();
             InitializeKernelTransformers(
-                IntrinsicSpecializerFlags.None,
                 builder =>
                 {
                     var transformerBuilder = Transformer.CreateBuilder(

--- a/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Values.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Values.cs
@@ -656,8 +656,8 @@ namespace ILGPU.Backends.OpenCL
         public void GenerateCode(SubWarpShuffle shuffle) =>
             throw new InvalidCodeGenerationException();
 
-        /// <summary cref="IBackendCodeGenerator.GenerateCode(DebugOperation)"/>
-        public void GenerateCode(DebugOperation debug) =>
+        /// <summary cref="IBackendCodeGenerator.GenerateCode(DebugAssertOperation)"/>
+        public void GenerateCode(DebugAssertOperation debug) =>
             // Invalid debug node -> should have been removed
             debug.Assert(false);
     }

--- a/Src/ILGPU/Backends/OpenCL/Transformations/CLAcceleratorSpecializer.cs
+++ b/Src/ILGPU/Backends/OpenCL/Transformations/CLAcceleratorSpecializer.cs
@@ -56,7 +56,8 @@ namespace ILGPU.Backends.OpenCL.Transformations
             : base(
                   AcceleratorType.OpenCL,
                   null,
-                  pointerType)
+                  pointerType,
+                  false)
         { }
 
         #region Methods

--- a/Src/ILGPU/Backends/PTX/PTXBackend.cs
+++ b/Src/ILGPU/Backends/PTX/PTXBackend.cs
@@ -79,27 +79,26 @@ namespace ILGPU.Backends.PTX
 
             InitIntrinsicProvider();
             InitializeKernelTransformers(
-                Context.HasFlags(ContextFlags.EnableAssertions) ?
-                IntrinsicSpecializerFlags.EnableAssertions :
-                IntrinsicSpecializerFlags.None,
                 builder =>
-            {
-                var transformerBuilder = Transformer.CreateBuilder(
-                    TransformerConfiguration.Empty);
-                transformerBuilder.AddBackendOptimizations(
-                    new PTXAcceleratorSpecializer(PointerType),
-                    context.Flags,
-                    context.OptimizationLevel);
-
-                if (Context.HasFlags(ContextFlags.EnhancedPTXBackendFeatures))
                 {
-                    // Create an optimized PTX assembler block schedule
-                    transformerBuilder.Add(new PTXBlockScheduling());
-                    transformerBuilder.Add(new DeadCodeElimination());
-                }
+                    var transformerBuilder = Transformer.CreateBuilder(
+                        TransformerConfiguration.Empty);
+                    transformerBuilder.AddBackendOptimizations(
+                        new PTXAcceleratorSpecializer(
+                            PointerType,
+                            Context.HasFlags(ContextFlags.EnableAssertions)),
+                        context.Flags,
+                        context.OptimizationLevel);
 
-                builder.Add(transformerBuilder.ToTransformer());
-            });
+                    if (Context.HasFlags(ContextFlags.EnhancedPTXBackendFeatures))
+                    {
+                        // Create an optimized PTX assembler block schedule
+                        transformerBuilder.Add(new PTXBlockScheduling());
+                        transformerBuilder.Add(new DeadCodeElimination());
+                    }
+
+                    builder.Add(transformerBuilder.ToTransformer());
+                });
         }
 
         #endregion

--- a/Src/ILGPU/Backends/PTX/PTXCodeGenerator.Values.cs
+++ b/Src/ILGPU/Backends/PTX/PTXCodeGenerator.Values.cs
@@ -1049,8 +1049,8 @@ namespace ILGPU.Backends.PTX
             FreeRegister(maskRegister);
         }
 
-        /// <summary cref="IBackendCodeGenerator.GenerateCode(DebugOperation)"/>
-        public void GenerateCode(DebugOperation debug) =>
+        /// <summary cref="IBackendCodeGenerator.GenerateCode(DebugAssertOperation)"/>
+        public void GenerateCode(DebugAssertOperation debug) =>
             Debug.Assert(false, "Invalid debug node -> should have been removed");
     }
 }

--- a/Src/ILGPU/Backends/PTX/PTXIntrinsics.cs
+++ b/Src/ILGPU/Backends/PTX/PTXIntrinsics.cs
@@ -10,7 +10,6 @@
 // ---------------------------------------------------------------------------------------
 
 using ILGPU.AtomicOperations;
-using ILGPU.Frontend;
 using ILGPU.IR.Intrinsics;
 using ILGPU.IR.Values;
 using System;
@@ -23,26 +22,6 @@ namespace ILGPU.Backends.PTX
     /// </summary>
     static partial class PTXIntrinsics
     {
-        #region Debugging
-
-        /// <remarks>
-        /// All strings must be in the generic address space.
-        /// </remarks>
-        [External("__assertfail")]
-        private static void AssertFail(
-            string message,
-            string file,
-            int line,
-            string function,
-            int charSize)
-        { }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void AssertFailed(string message) =>
-            AssertFail(message, "Kernel.cs", 0, "Kernel", 1);
-
-        #endregion
-
         #region Specializers
 
         /// <summary>
@@ -115,13 +94,6 @@ namespace ILGPU.Backends.PTX
             RegisterWarpShuffles(manager);
             RegisterFP16(manager);
             RegisterBitFunctions(manager);
-
-            // Register assert support
-            manager.RegisterDebug(
-                DebugKind.AssertFailed,
-                CreateIntrinsic(
-                    nameof(AssertFailed),
-                    IntrinsicImplementationMode.Redirect));
         }
 
         #endregion

--- a/Src/ILGPU/Backends/PTX/Transformations/PTXAcceleratorSpecializer.cs
+++ b/Src/ILGPU/Backends/PTX/Transformations/PTXAcceleratorSpecializer.cs
@@ -40,11 +40,71 @@ namespace ILGPU.Backends.PTX.Transformations
         private static unsafe int PrintF(string str, void* args) => 0;
 
         /// <summary>
+        /// Represents the intrinsic Cuda assertion failed function.
+        /// </summary>
+        /// <remarks>
+        /// All strings must be in the generic address space.
+        /// </remarks>
+        [External("__assertfail")]
+        private static void AssertFailed(
+            string message,
+            string file,
+            int line,
+            string function,
+            int charSize)
+        { }
+
+        /// <summary>
+        /// Represents the intrinsic Cuda assertion failed function.
+        /// </summary>
+        /// <remarks>
+        /// All strings must be in the generic address space.
+        /// </remarks>
+        private static void DebugAssertImplementation(
+            bool condition,
+            string message,
+            string file,
+            int line,
+            string function,
+            int charSize)
+        {
+            /* Implementation
+            if (!condition)
+            {
+                AssertFailed(
+                    message,
+                    file,
+                    line,
+                    function,
+                    charSize);
+            }
+            */
+        }
+
+        /// <summary>
         /// A handle to the <see cref="PrintF(string, void*)"/> method.
         /// </summary>
         private static readonly MethodInfo PrintFMethod =
             typeof(PTXAcceleratorSpecializer).GetMethod(
                 nameof(PrintF),
+                BindingFlags.Static | BindingFlags.NonPublic);
+
+        /// <summary>
+        /// A handle to the <see cref="AssertFailed(string, string, int, string, int)"/>
+        /// method.
+        /// </summary>
+        private static readonly MethodInfo AssertFailedMethod =
+            typeof(PTXAcceleratorSpecializer).GetMethod(
+                nameof(AssertFailed),
+                BindingFlags.Static | BindingFlags.NonPublic);
+
+        /// <summary>
+        /// A handle to the <see cref="DebugAssertImplementation(bool, string, string,
+        /// int, string, int)"/> method.
+        /// </summary>
+        private static readonly MethodInfo DebugAssertMethod =
+            typeof(PTXAcceleratorSpecializer).GetMethod(
+                nameof(DebugAssertImplementation),
                 BindingFlags.Static | BindingFlags.NonPublic);
 
         #endregion
@@ -55,16 +115,61 @@ namespace ILGPU.Backends.PTX.Transformations
         /// Constructs a new PTX accelerator specializer.
         /// </summary>
         /// <param name="pointerType">The actual pointer type to use.</param>
-        public PTXAcceleratorSpecializer(PrimitiveType pointerType)
+        /// <param name="enableAssertions">True, if the assertions are enabled.</param>
+        public PTXAcceleratorSpecializer(
+            PrimitiveType pointerType,
+            bool enableAssertions)
             : base(
                   AcceleratorType.Cuda,
                   PTXBackend.WarpSize,
-                  pointerType)
+                  pointerType,
+                  enableAssertions)
         { }
 
         #endregion
 
         #region Methods
+
+        /// <summary>
+        /// Maps internal debug assertions to <see cref="AssertFailed(string, string,
+        /// int, string, int)"/> method calls.
+        /// </summary>
+        protected override void Specialize(
+            in RewriterContext context,
+            IRContext irContext,
+            DebugAssertOperation debugAssert)
+        {
+            var builder = context.Builder;
+            var location = debugAssert.Location;
+
+            // Create a call to the debug-implementation wrapper while taking the
+            // current source location into account
+            var debugAssertMethod = BuildDebugAssertImplementation(
+                irContext,
+                DebugAssertMethod,
+                AssertFailedMethod);
+
+            // Create a call to the assert implementation
+            var callBuilder = builder.CreateCall(location, debugAssertMethod);
+            callBuilder.Add(debugAssert.Condition);
+            callBuilder.Add(debugAssert.Message);
+
+            // Append source location information
+            var debugLocation = debugAssert.GetLocationInfo();
+            callBuilder.Add(
+                builder.CreatePrimitiveValue(location, debugLocation.FileName));
+            callBuilder.Add(
+                builder.CreatePrimitiveValue(location, debugLocation.Line));
+            callBuilder.Add(
+                builder.CreatePrimitiveValue(location, debugLocation.Method));
+            callBuilder.Add(
+                builder.CreatePrimitiveValue(location, 1));
+
+            callBuilder.Seal();
+
+            // Remove the debug assertion value
+            context.Remove(debugAssert);
+        }
 
         /// <summary>
         /// Maps internal <see cref="WriteToOutput"/> values to

--- a/Src/ILGPU/Frontend/Intrinsic/Intrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/Intrinsics.cs
@@ -221,10 +221,18 @@ namespace ILGPU.Frontend.Intrinsic
 
             return context.Method.Name switch
             {
+                nameof(Debug.Assert) when context.NumArguments == 1 =>
+                    builder.CreateDebugAssert(
+                        location,
+                        context[0],
+                        builder.CreatePrimitiveValue(location, "Assert failed")),
                 nameof(Debug.Assert) when context.NumArguments == 2 =>
-                    builder.CreateDebug(location, DebugKind.Trace, context[0]),
+                    builder.CreateDebugAssert(location, context[0], context[1]),
                 nameof(Debug.Fail) when context.NumArguments == 1 =>
-                    builder.CreateDebug(location, DebugKind.AssertFailed, context[0]),
+                    builder.CreateDebugAssert(
+                        location,
+                        builder.CreatePrimitiveValue(location, false),
+                        context[0]),
                 _ => throw location.GetNotSupportedException(
                     ErrorMessages.NotSupportedIntrinsic,
                     context.Method.Name),

--- a/Src/ILGPU/IIndex.cs
+++ b/Src/ILGPU/IIndex.cs
@@ -104,7 +104,7 @@ namespace ILGPU
         };
 
         /// <summary>
-        /// A reference to the 32-bit index linerization method.
+        /// A reference to the 32-bit index linearization method.
         /// </summary>
         private static readonly MethodInfo ViewLinearIndex32Method =
             typeof(IndexTypeExtensions).GetMethod(
@@ -112,7 +112,7 @@ namespace ILGPU
                 BindingFlags.NonPublic | BindingFlags.Static);
 
         /// <summary>
-        /// A reference to the 64-bit index linerization method.
+        /// A reference to the 64-bit index linearization method.
         /// </summary>
         private static readonly MethodInfo ViewLinearIndex64Method =
             typeof(IndexTypeExtensions).GetMethod(
@@ -209,14 +209,14 @@ namespace ILGPU
             typeof(TIndex).IsLongIndex();
 
         /// <summary>
-        /// Gets the index linerization method that works either on 32-bit or on 64-bit
+        /// Gets the index linearization method that works either on 32-bit or on 64-bit
         /// values depending on the index type.
         /// </summary>
         /// <param name="indexType">The managed index type.</param>
         /// <param name="elementType">
         /// The managed element type of a particular view.
         /// </param>
-        /// <returns>The managed 32-bit or 64-bit linerization method.</returns>
+        /// <returns>The managed 32-bit or 64-bit linearization method.</returns>
         public static MethodBase GetViewLinearIndexMethod(
             this Type indexType,
             Type elementType)
@@ -244,6 +244,9 @@ namespace ILGPU
             where T : unmanaged
             where TIndex : struct, IGenericIndex<TIndex>
         {
+            Trace.Assert(
+                index.InBounds(dimension),
+                "Multidimensional index out of range");
             int linearIndex = index.ComputeLinearIndex(dimension);
             return ref view[linearIndex];
         }
@@ -265,6 +268,9 @@ namespace ILGPU
             where T : unmanaged
             where TIndex : struct, IGenericIndex<TIndex>
         {
+            Trace.Assert(
+                index.InBounds(dimension),
+                "Multidimensional index out of range");
             long linearIndex = index.ComputeLongLinearIndex(dimension);
             return ref view[linearIndex];
         }

--- a/Src/ILGPU/IR/Construction/Debug.cs
+++ b/Src/ILGPU/IR/Construction/Debug.cs
@@ -19,16 +19,16 @@ namespace ILGPU.IR.Construction
         /// Creates a new failed debug assertion.
         /// </summary>
         /// <param name="location">The current location.</param>
-        /// <param name="kind">The operation kind.</param>
+        /// <param name="condition">The debug assert condition.</param>
         /// <param name="message">The assertion message.</param>
         /// <returns>A node that represents the debug assertion.</returns>
-        public ValueReference CreateDebug(
+        public ValueReference CreateDebugAssert(
             Location location,
-            DebugKind kind,
+            Value condition,
             Value message) =>
-            Append(new DebugOperation(
+            Append(new DebugAssertOperation(
                 GetInitializer(location),
-                kind,
+                condition,
                 message));
     }
 }

--- a/Src/ILGPU/IR/Intrinsics/IntrinsicMatcher.cs
+++ b/Src/ILGPU/IR/Intrinsics/IntrinsicMatcher.cs
@@ -31,10 +31,6 @@ namespace ILGPU.IR.Intrinsics
     /// <summary>
     /// Defines an abstract intrinsic implementation.
     /// </summary>
-    [SuppressMessage(
-        "Microsoft.Design",
-        "CA1040:AvoidEmptyInterfaces",
-        Justification = "It is used as a type constraint")]
     public interface IIntrinsicImplementation
     {
         // Left blank for future extension possibilities

--- a/Src/ILGPU/IR/Intrinsics/IntrinsicMatchers.tt
+++ b/Src/ILGPU/IR/Intrinsics/IntrinsicMatchers.tt
@@ -15,10 +15,7 @@
 <#@ import namespace="System.Text" #>
 <#@ import namespace="System.Collections.Generic" #>
 <#
-var matchers = new (string, string, string)[]
-    {
-        ("Debug", "DebugOperation", "DebugKind"),
-    };
+var matchers = new (string, string, string)[] { };
 var typedMatchers = new (string, string, string)[]
     {
         ("Broadcast", "Broadcast", "BroadcastKind"),

--- a/Src/ILGPU/IR/Transformations/IntrinsicSpecializer.cs
+++ b/Src/ILGPU/IR/Transformations/IntrinsicSpecializer.cs
@@ -10,29 +10,11 @@
 // ---------------------------------------------------------------------------------------
 
 using ILGPU.IR.Intrinsics;
-using ILGPU.IR.Values;
 using System;
 using System.Collections.Generic;
 
 namespace ILGPU.IR.Transformations
 {
-    /// <summary>
-    /// Flags for the <see cref="IntrinsicSpecializer{TDelegate}"/> transformation.
-    /// </summary>
-    [Flags]
-    public enum IntrinsicSpecializerFlags : int
-    {
-        /// <summary>
-        /// Default lowering flags.
-        /// </summary>
-        None,
-
-        /// <summary>
-        /// Enables assertions.
-        /// </summary>
-        EnableAssertions = 1 << 0,
-    }
-
     /// <summary>
     /// Represents an intrinsic implementation specializer.
     /// </summary>
@@ -76,24 +58,10 @@ namespace ILGPU.IR.Transformations
         /// Constructs a new intrinsic specializer.
         /// </summary>
         public IntrinsicSpecializer(
-            IntrinsicSpecializerFlags flags,
             IntrinsicImplementationProvider<TDelegate> implementationProvider)
         {
-            Flags = flags;
             provider = implementationProvider;
         }
-
-        /// <summary>
-        /// Returns the current flags.
-        /// </summary>
-        public IntrinsicSpecializerFlags Flags { get; }
-
-        /// <summary>
-        /// Returns true if assertions should be enabled.
-        /// </summary>
-        public bool EnableAssertions =>
-            (Flags & IntrinsicSpecializerFlags.EnableAssertions) !=
-            IntrinsicSpecializerFlags.None;
 
         /// <summary>
         /// Applies an intrinsic specialization.
@@ -142,24 +110,8 @@ namespace ILGPU.IR.Transformations
             {
                 var blockBuilder = builder[value.BasicBlock];
 
-                if (value is DebugOperation debug)
-                {
-                    if (EnableAssertions &&
-                        provider.TryGetImplementation(
-                            debug,
-                            out var debugImplementation))
-                    {
-                        intrinsicFunctions.Add((debug, debugImplementation));
-                    }
-                    else
-                    {
-                        blockBuilder.Remove(debug);
-                    }
-
-                    applied = true;
-                }
-                // Check intrinsic value
-                else if (provider.TryGetImplementation(value, out var implementation))
+                // Check intrinsic implementations
+                if (provider.TryGetImplementation(value, out var implementation))
                 {
                     intrinsicFunctions.Add((value, implementation));
                     applied = true;

--- a/Src/ILGPU/IR/Values/IOValues.cs
+++ b/Src/ILGPU/IR/Values/IOValues.cs
@@ -15,7 +15,6 @@ using ILGPU.Util;
 using System;
 using System.Collections;
 using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text;
 using FormatArray = System.Collections.Immutable.ImmutableArray<
@@ -369,10 +368,6 @@ namespace ILGPU.IR.Values
         /// Converts the internal format expressions into a printf string.
         /// </summary>
         /// <returns>The converted printf string.</returns>
-        [SuppressMessage(
-            "Globalization",
-            "CA1307:Specify StringComparison",
-            Justification = "There are no affected characters")]
         public string ToPrintFExpression()
         {
             var result = new StringBuilder();
@@ -404,10 +399,6 @@ namespace ILGPU.IR.Values
         /// <summary>
         /// Converts the internal format expressions into an escaped sequence.
         /// </summary>
-        [SuppressMessage(
-            "Globalization",
-            "CA1307:Specify StringComparison",
-            Justification = "There are no affected characters")]
         public string ToEscapedPrintFExpression() =>
             ToPrintFExpression()
             .Replace("\t", @"\t")
@@ -425,10 +416,6 @@ namespace ILGPU.IR.Values
 
 
         /// <summary cref="Value.ToArgString"/>
-        [SuppressMessage(
-            "Globalization",
-            "CA1307:Specify StringComparison",
-            Justification = "There are no affected characters")]
         protected override string ToArgString() =>
             ToPrintFExpression().Replace(
                 Environment.NewLine,

--- a/Src/ILGPU/IR/Values/IValueVisitor.cs
+++ b/Src/ILGPU/IR/Values/IValueVisitor.cs
@@ -312,7 +312,7 @@ namespace ILGPU.IR.Values
         /// Visits the debug operation.
         /// </summary>
         /// <param name="debug">The node.</param>
-        void Visit(DebugOperation debug);
+        void Visit(DebugAssertOperation debug);
 
         // IO operations
 

--- a/Src/ILGPU/IR/Values/ValueKind.cs
+++ b/Src/ILGPU/IR/Values/ValueKind.cs
@@ -294,9 +294,9 @@ namespace ILGPU.IR
         // Debugging
 
         /// <summary>
-        /// A <see cref="Values.DebugOperation"/> value.
+        /// A <see cref="Values.DebugAssertOperation"/> value.
         /// </summary>
-        Debug,
+        DebugAssert,
 
         // IO
 


### PR DESCRIPTION
This PR adds additional support for assertions on accelerator devices (fixes #371). Also, it refines the internal assertion implementation in ILGPU to represent high-level assertions within the IR. This allows us to obtain accurate location information for all assertions.

~Note that this PR requires #374 to run. Once #374 has been merged, we have to rebase this PR.~