### PR TITLE
Fixed critical concurrent resource deallocation issues

### DIFF
--- a/Src/ILGPU.Tests/ExchangeBufferOperations.cs
+++ b/Src/ILGPU.Tests/ExchangeBufferOperations.cs
@@ -446,7 +446,7 @@ namespace ILGPU.Tests
             using var stream = Accelerator.CreateStream();
             using var exchangeBuffer = Accelerator.AllocateExchangeBuffer<long>(
                 bufferSize);
-            exchangeBuffer.Buffer.MemSetToZero(stream);
+            exchangeBuffer.MemSetToZero(stream);
             stream.Synchronize();
 
             // Fill data on the CPU side
@@ -491,7 +491,7 @@ namespace ILGPU.Tests
             using var stream = Accelerator.CreateStream();
             using var exchangeBuffer = Accelerator.AllocateExchangeBuffer<long>(
                 bufferSize);
-            exchangeBuffer.Buffer.MemSetToZero(stream);
+            exchangeBuffer.MemSetToZero(stream);
             stream.Synchronize();
 
             // Fill data on the CPU side

--- a/Src/ILGPU.Tests/Generic/TestBase.cs
+++ b/Src/ILGPU.Tests/Generic/TestBase.cs
@@ -199,26 +199,6 @@ namespace ILGPU.Tests
         /// <param name="expected">The expected values.</param>
         /// <param name="offset">The custom data offset to use (if any).</param>
         /// <param name="length">The custom data length to use (if any).</param>
-        public void Verify<T>(
-            MemoryBuffer<T> buffer,
-            T[] expected,
-            int? offset = null,
-            int? length = null)
-            where T : unmanaged =>
-            Verify(
-                buffer.Buffer,
-                expected,
-                offset,
-                length);
-
-        /// <summary>
-        /// Verifies the contents of the given memory buffer.
-        /// </summary>
-        /// <typeparam name="T">The element type.</typeparam>
-        /// <param name="buffer">The target buffer.</param>
-        /// <param name="expected">The expected values.</param>
-        /// <param name="offset">The custom data offset to use (if any).</param>
-        /// <param name="length">The custom data length to use (if any).</param>
         public void Verify<T, TIndex>(
             MemoryBuffer<T, TIndex> buffer,
             T[] expected,

--- a/Src/ILGPU/Context.cs
+++ b/Src/ILGPU/Context.cs
@@ -145,6 +145,7 @@ namespace ILGPU
             if (Debugger.IsAttached)
                 flags |= DefaultDebug;
 
+            InstanceId = InstanceId.CreateNew();
             OptimizationLevel = optimizationLevel;
             Flags = flags.Prepare();
             TargetPlatform = Backend.RuntimePlatform;
@@ -172,8 +173,8 @@ namespace ILGPU
                 : null;
 
             ILFrontend = HasFlags(ContextFlags.EnableParallelCodeGenerationInFrontend)
-                ? new ILFrontend(frontendDebugInformationManager)
-                : new ILFrontend(frontendDebugInformationManager, 1);
+                ? new ILFrontend(this, frontendDebugInformationManager)
+                : new ILFrontend(this, frontendDebugInformationManager, 1);
 
             // Create default IL backend
             DefautltILBackend = flags.HasFlags(ContextFlags.SkipCPUCodeGeneration)
@@ -195,6 +196,11 @@ namespace ILGPU
         #endregion
 
         #region Properties
+
+        /// <summary>
+        /// Returns the current instance id.
+        /// </summary>
+        internal InstanceId InstanceId { get; }
 
         /// <summary>
         /// Returns the current target platform.

--- a/Src/ILGPU/ContextFlags.cs
+++ b/Src/ILGPU/ContextFlags.cs
@@ -173,6 +173,7 @@ namespace ILGPU
         /// disposal, you have to ensure that all accelerator child objects have been
         /// freed manually before disposing the associated accelerator object.
         /// </remarks>
+        [Obsolete]
         DisableAutomaticBufferDisposal = 1 << 25,
 
         /// <summary>
@@ -189,12 +190,14 @@ namespace ILGPU
         /// disposal, you have to ensure that all accelerator child objects have been
         /// freed manually before disposing the associated accelerator object.
         /// </remarks>
+        [Obsolete]
         DisableAutomaticKernelDisposal = 1 << 26,
 
         /// <summary>
         /// Disables kernel caching and automatic disposal of memory buffers and kernels.
         /// It should only be used by experienced users.
         /// </summary>
+        [Obsolete]
         DisableAcceleratorGC =
             DisableKernelCaching |
             DisableAutomaticBufferDisposal |

--- a/Src/ILGPU/Frontend/ILFrontend.cs
+++ b/Src/ILGPU/Frontend/ILFrontend.cs
@@ -86,22 +86,27 @@ namespace ILGPU.Frontend
         /// <summary>
         /// Constructs a new frontend with two threads.
         /// </summary>
+        /// <param name="context">The context instance.</param>
         /// <param name="debugInformationManager">
         /// The associated debug information manager.
         /// </param>
-        public ILFrontend(DebugInformationManager debugInformationManager)
-            : this(debugInformationManager, 2)
+        public ILFrontend(
+            Context context,
+            DebugInformationManager debugInformationManager)
+            : this(context, debugInformationManager, 2)
         { }
 
         /// <summary>
         /// Constructs a new frontend that uses the given number of
         /// threads for code generation.
         /// </summary>
+        /// <param name="context">The context instance.</param>
         /// <param name="debugInformationManager">
         /// The associated debug information manager.
         /// </param>
         /// <param name="numThreads">The number of threads.</param>
         public ILFrontend(
+            Context context,
             DebugInformationManager debugInformationManager,
             int numThreads)
         {
@@ -114,7 +119,7 @@ namespace ILGPU.Frontend
             {
                 var thread = new Thread(DoWork)
                 {
-                    Name = "ILFrontendWorker" + i,
+                    Name = $"ILGPU_{context.InstanceId}_Frontend_{i}",
                     IsBackground = true,
                 };
                 threads[i] = thread;

--- a/Src/ILGPU/IR/NodeId.cs
+++ b/Src/ILGPU/IR/NodeId.cs
@@ -20,29 +20,14 @@ namespace ILGPU.IR
     /// </summary>
     public readonly struct NodeId : IEquatable<NodeId>, IComparable<NodeId>
     {
-        #region Constants
-
-        /// <summary>
-        /// Represents the empty node id.
-        /// </summary>
-        public static readonly NodeId Empty = new NodeId(-1);
-
-        #endregion
-
         #region Static
-
-        /// <summary>
-        /// A shared static id counter.
-        /// </summary>
-        private static long idCounter = 0;
 
         /// <summary>
         /// Creates a new unique node id.
         /// </summary>
         /// <returns>A new unique node id.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static NodeId CreateNew() =>
-            new NodeId(Interlocked.Add(ref idCounter, 1L));
+        public static NodeId CreateNew() => new NodeId(InstanceId.CreateNew());
 
         #endregion
 
@@ -52,9 +37,9 @@ namespace ILGPU.IR
         /// Constructs a new node id.
         /// </summary>
         /// <param name="id">The raw id.</param>
-        internal NodeId(long id)
+        private NodeId(InstanceId id)
         {
-            Value = id;
+            Id = id;
         }
 
         #endregion
@@ -62,9 +47,9 @@ namespace ILGPU.IR
         #region Properties
 
         /// <summary>
-        /// Returns the encapsulated value.
+        /// Returns the encapsulated id.
         /// </summary>
-        public long Value { get; }
+        private InstanceId Id { get; }
 
         #endregion
 
@@ -86,7 +71,7 @@ namespace ILGPU.IR
         /// </summary>
         /// <param name="other">The object to compare to.</param>
         /// <returns>The comparison result.</returns>
-        public int CompareTo(NodeId other) => Value.CompareTo(other.Value);
+        public int CompareTo(NodeId other) => Id.Value.CompareTo(other.Id.Value);
 
         #endregion
 
@@ -104,13 +89,13 @@ namespace ILGPU.IR
         /// Returns the hash code of this id.
         /// </summary>
         /// <returns>The hash code of this id.</returns>
-        public override int GetHashCode() => Value.GetHashCode();
+        public override int GetHashCode() => Id.GetHashCode();
 
         /// <summary>
         /// Returns the string representation of this id.
         /// </summary>
         /// <returns>The string representation of this id.</returns>
-        public override string ToString() => Value.ToString();
+        public override string ToString() => Id.ToString();
 
         #endregion
 
@@ -120,7 +105,7 @@ namespace ILGPU.IR
         /// Converts the given node id into its underlying long value.
         /// </summary>
         /// <param name="nodeId">The node id.</param>
-        public static implicit operator long(NodeId nodeId) => nodeId.Value;
+        public static implicit operator long(NodeId nodeId) => nodeId.Id;
 
         /// <summary>
         /// Returns true if the first and the second id are the same.
@@ -129,7 +114,7 @@ namespace ILGPU.IR
         /// <param name="second">The second id.</param>
         /// <returns>True, if the first and the second id are the same.</returns>
         public static bool operator ==(NodeId first, NodeId second) =>
-            first.Value == second.Value;
+            first.Id == second.Id;
 
         /// <summary>
         /// Returns true if the first and the second id are not the same.
@@ -138,7 +123,7 @@ namespace ILGPU.IR
         /// <param name="second">The second id.</param>
         /// <returns>True, if the first and the second id are not the same.</returns>
         public static bool operator !=(NodeId first, NodeId second) =>
-            first.Value != second.Value;
+            first.Id != second.Id;
 
         /// <summary>
         /// Returns true if the first id is smaller than the second one.
@@ -147,7 +132,7 @@ namespace ILGPU.IR
         /// <param name="second">The second id.</param>
         /// <returns>True, if the first id is smaller than the second one.</returns>
         public static bool operator <(NodeId first, NodeId second) =>
-            first.Value < second.Value;
+            first.Id < second.Id;
 
         /// <summary>
         /// Returns true if the first id is smaller than or equal to the second one.
@@ -158,7 +143,7 @@ namespace ILGPU.IR
         /// True, if the first id is smaller than or equal to the second one.
         /// </returns>
         public static bool operator <=(NodeId first, NodeId second) =>
-            first.Value <= second.Value;
+            first.Id <= second.Id;
 
         /// <summary>
         /// Returns true if the first id is greater than the second one.
@@ -167,7 +152,7 @@ namespace ILGPU.IR
         /// <param name="second">The second id.</param>
         /// <returns>True, if the first id is greater than the second one.</returns>
         public static bool operator >(NodeId first, NodeId second) =>
-            first.Value > second.Value;
+            first.Id > second.Id;
 
         /// <summary>
         /// Returns true if the first id is greater than or equal to the second one.
@@ -178,7 +163,7 @@ namespace ILGPU.IR
         /// True, if the first id is greater than or equal to the second one.
         /// </returns>
         public static bool operator >=(NodeId first, NodeId second) =>
-            first.Value >= second.Value;
+            first.Id >= second.Id;
 
         #endregion
     }

--- a/Src/ILGPU/InstanceId.cs
+++ b/Src/ILGPU/InstanceId.cs
@@ -1,0 +1,129 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                        Copyright (c) 2016-2020 Marcel Koester
+//                                    www.ilgpu.net
+//
+// File: InstanceId.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace ILGPU
+{
+    internal readonly struct InstanceId : IEquatable<InstanceId>
+    {
+        #region Static
+
+        /// <summary>
+        /// Represents the empty instance id.
+        /// </summary>
+        public static readonly InstanceId Empty = new InstanceId(-1);
+
+        /// <summary>
+        /// A shared static instance id counter.
+        /// </summary>
+        private static long instanceIdCounter = 0;
+
+        /// <summary>
+        /// Creates a new unique instance id.
+        /// </summary>
+        /// <returns>The unique instance id.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static InstanceId CreateNew() =>
+            new InstanceId(Interlocked.Add(ref instanceIdCounter, 1L));
+
+        #endregion
+
+        #region Instance
+
+        /// <summary>
+        /// Constructs a new instance id.
+        /// </summary>
+        /// <param name="id">The raw id.</param>
+        internal InstanceId(long id)
+        {
+            Value = id;
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Returns the underlying raw id.
+        /// </summary>
+        public long Value { get; }
+
+        #endregion
+
+        #region IEquatable
+
+        /// <summary>
+        /// Returns true if the given id is equal to this id.
+        /// </summary>
+        /// <param name="other">The other id.</param>
+        /// <returns>True, if the given id is equal to this id.</returns>
+        public bool Equals(InstanceId other) => this == other;
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Returns true if the given object is equal to this id.
+        /// </summary>
+        /// <param name="obj">The other object.</param>
+        /// <returns>True, if the given object is equal to this id.</returns>
+        public override bool Equals(object obj) =>
+            obj is InstanceId id && id == this;
+
+        /// <summary>
+        /// Returns the hash code of this id.
+        /// </summary>
+        /// <returns>The hash code of this id.</returns>
+        public override int GetHashCode() => Value.GetHashCode();
+
+        /// <summary>
+        /// Returns the string representation of the <see cref="Value"/> property.
+        /// </summary>
+        /// <returns>
+        /// The string representation of the <see cref="Value"/> property.
+        /// </returns>
+        public override string ToString() => Value.ToString();
+
+        #endregion
+
+        #region Operators
+
+        /// <summary>
+        /// Converts the given instance id into its underlying long value.
+        /// </summary>
+        /// <param name="id">The instance id.</param>
+        public static implicit operator long(InstanceId id) => id.Value;
+
+        /// <summary>
+        /// Returns true if the first and the second id are the same.
+        /// </summary>
+        /// <param name="first">The first id.</param>
+        /// <param name="second">The second id.</param>
+        /// <returns>True, if the first and the second id are the same.</returns>
+        public static bool operator ==(InstanceId first, InstanceId second) =>
+            first.Value == second.Value;
+
+        /// <summary>
+        /// Returns true if the first and the second id are not the same.
+        /// </summary>
+        /// <param name="first">The first id.</param>
+        /// <param name="second">The second id.</param>
+        /// <returns>True, if the first and the second id are not the same.</returns>
+        public static bool operator !=(InstanceId first, InstanceId second) =>
+            first.Value != second.Value;
+
+        #endregion
+    }
+}

--- a/Src/ILGPU/Runtime/Accelerator.GC.cs
+++ b/Src/ILGPU/Runtime/Accelerator.GC.cs
@@ -39,7 +39,7 @@ namespace ILGPU.Runtime
             gcActivated = true;
             gcThread = new Thread(GCThread)
             {
-                Name = "ILGPUAcceleratorGCThread",
+                Name = $"ILGPU_{InstanceId}_GCThread",
             };
             gcThread.Start();
         }

--- a/Src/ILGPU/Runtime/Accelerator.GC.cs
+++ b/Src/ILGPU/Runtime/Accelerator.GC.cs
@@ -47,14 +47,10 @@ namespace ILGPU.Runtime
         /// <summary>
         /// Disposes the GC functionality.
         /// </summary>
-        private void DisposeGC()
+        private void DisposeGC_SyncRoot()
         {
-            lock (syncRoot)
-            {
-                gcActivated = false;
-                Monitor.Pulse(syncRoot);
-            }
-            gcThread.Join();
+            gcActivated = false;
+            Monitor.PulseAll(syncRoot);
         }
 
         #endregion
@@ -70,7 +66,7 @@ namespace ILGPU.Runtime
         private void RequestGC_SyncRoot()
         {
             if (RequestChildObjectsGC_SyncRoot || RequestKernelCacheGC_SyncRoot)
-                Monitor.Pulse(syncRoot);
+                Monitor.PulseAll(syncRoot);
         }
 
         /// <summary>
@@ -83,6 +79,9 @@ namespace ILGPU.Runtime
                 while (gcActivated)
                 {
                     Monitor.Wait(syncRoot);
+
+                    if (!gcActivated)
+                        break;
 
                     ChildObjectsGC_SyncRoot();
                     KernelCacheGC_SyncRoot();

--- a/Src/ILGPU/Runtime/Accelerator.GC.cs
+++ b/Src/ILGPU/Runtime/Accelerator.GC.cs
@@ -36,9 +36,6 @@ namespace ILGPU.Runtime
         /// </summary>
         private void InitGC()
         {
-            if (Context.HasFlags(ContextFlags.DisableAcceleratorGC))
-                return;
-
             gcActivated = true;
             gcThread = new Thread(GCThread)
             {
@@ -52,9 +49,6 @@ namespace ILGPU.Runtime
         /// </summary>
         private void DisposeGC()
         {
-            if (!gcActivated)
-                return;
-
             lock (syncRoot)
             {
                 gcActivated = false;
@@ -62,15 +56,6 @@ namespace ILGPU.Runtime
             }
             gcThread.Join();
         }
-
-        #endregion
-
-        #region Properties
-
-        /// <summary>
-        /// Returns true if the GC thread is enabled.
-        /// </summary>
-        private bool GCEnabled => gcThread != null;
 
         #endregion
 

--- a/Src/ILGPU/Runtime/Accelerator.cs
+++ b/Src/ILGPU/Runtime/Accelerator.cs
@@ -148,10 +148,6 @@ namespace ILGPU.Runtime
             Context = context ?? throw new ArgumentNullException(nameof(context));
             AcceleratorType = type;
 
-            AutomaticBufferDisposalEnabled = !context.HasFlags(
-                ContextFlags.DisableAutomaticBufferDisposal);
-            AutomaticKernelDisposalEnabled = !context.HasFlags(
-                ContextFlags.DisableAutomaticKernelDisposal);
             InitKernelCache();
             InitLaunchCache();
             InitGC();
@@ -259,20 +255,6 @@ namespace ILGPU.Runtime
         /// operations.
         /// </summary>
         public MemoryBufferCache MemoryCache => memoryCache;
-
-        /// <summary>
-        /// See <see cref="ContextFlags.DisableAutomaticBufferDisposal"/> for more
-        /// information.
-        /// </summary>
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private bool AutomaticBufferDisposalEnabled { get; }
-
-        /// <summary>
-        /// See <see cref="ContextFlags.DisableAutomaticKernelDisposal"/> for more
-        /// information.
-        /// </summary>
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private bool AutomaticKernelDisposalEnabled { get; }
 
         #endregion
 

--- a/Src/ILGPU/Runtime/Accelerator.cs
+++ b/Src/ILGPU/Runtime/Accelerator.cs
@@ -16,7 +16,6 @@ using ILGPU.Util;
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 
 namespace ILGPU.Runtime
 {
@@ -58,10 +57,6 @@ namespace ILGPU.Runtime
         /// <summary>
         /// Detects all accelerators.
         /// </summary>
-        [SuppressMessage(
-            "Microsoft.Performance",
-            "CA1810:InitializeReferenceTypeStaticFieldsInline",
-            Justification = "Complex initialization logic is required in this case")]
         static Accelerator()
         {
             var accelerators = ImmutableArray.CreateBuilder<AcceleratorId>(4);
@@ -147,6 +142,7 @@ namespace ILGPU.Runtime
         {
             Context = context ?? throw new ArgumentNullException(nameof(context));
             AcceleratorType = type;
+            InstanceId = InstanceId.CreateNew();
 
             InitKernelCache();
             InitLaunchCache();
@@ -158,6 +154,11 @@ namespace ILGPU.Runtime
         #endregion
 
         #region Properties
+
+        /// <summary>
+        /// Returns the internal unique accelerator instance id.
+        /// </summary>
+        internal InstanceId InstanceId { get; }
 
         /// <summary>
         /// Returns the associated ILGPU context.

--- a/Src/ILGPU/Runtime/Accelerator.cs
+++ b/Src/ILGPU/Runtime/Accelerator.cs
@@ -135,6 +135,12 @@ namespace ILGPU.Runtime
         private readonly MemoryBufferCache memoryCache;
 
         /// <summary>
+        /// The current volatile native pointer of this instance.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private volatile IntPtr nativePtr;
+
+        /// <summary>
         /// Constructs a new accelerator.
         /// </summary>
         /// <param name="context">The target context.</param>
@@ -175,6 +181,15 @@ namespace ILGPU.Runtime
         /// Returns the type of the accelerator.
         /// </summary>
         public AcceleratorType AcceleratorType { get; }
+
+        /// <summary>
+        /// Returns the current native accelerator pointer.
+        /// </summary>
+        public IntPtr NativePtr
+        {
+            get => nativePtr;
+            protected set => nativePtr = value;
+        }
 
         /// <summary>
         /// Returns the memory size in bytes.

--- a/Src/ILGPU/Runtime/AcceleratorException.cs
+++ b/Src/ILGPU/Runtime/AcceleratorException.cs
@@ -1,0 +1,77 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                        Copyright (c) 2016-2020 Marcel Koester
+//                                    www.ilgpu.net
+//
+// File: AcceleratorException.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+
+using System;
+using System.Runtime.Serialization;
+
+namespace ILGPU.Runtime
+{
+    /// <summary>
+    /// The exception that is thrown when a specific operation did not succeed.
+    /// </summary>
+    [Serializable]
+    public abstract class AcceleratorException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the AcceleratorException class.
+        /// </summary>
+        public AcceleratorException()
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the AcceleratorException class
+        /// with a specified error message.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public AcceleratorException(string message)
+            : base(message)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the AcceleratorException class with a specified
+        /// error message and a reference to the inner exception that is the cause of
+        /// this exception.
+        /// </summary>
+        /// <param name="message">
+        /// The error message that explains the reason for the exception.
+        /// </param>
+        /// <param name="innerException">
+        /// The exception that is the cause of the current exception, or a null reference
+        /// if no inner exception is specified.
+        /// </param>
+        public AcceleratorException(string message, Exception innerException)
+            : base(message, innerException)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the AcceleratorException class with serialized
+        /// data.
+        /// </summary>
+        /// <param name="serializationInfo">
+        /// The System.Runtime.Serialization.SerializationInfo that holds the serialized
+        /// object data about the exception being thrown.
+        /// </param>
+        /// <param name="streamingContext">
+        /// The System.Runtime.Serialization.StreamingContext that contains contextual
+        /// information about the source or destination.
+        /// </param>
+        protected AcceleratorException(
+            SerializationInfo serializationInfo,
+            StreamingContext streamingContext)
+            : base(serializationInfo, streamingContext)
+        { }
+
+        /// <summary>
+        /// Returns the associated accelerator type.
+        /// </summary>
+        public abstract AcceleratorType AcceleratorType { get; }
+    }
+}

--- a/Src/ILGPU/Runtime/AcceleratorObject.cs
+++ b/Src/ILGPU/Runtime/AcceleratorObject.cs
@@ -47,10 +47,7 @@ namespace ILGPU.Runtime
         /// <summary>
         /// Constructs an accelerator object that lives on the CPU.
         /// </summary>
-        protected AcceleratorObject()
-        {
-            AcceleratorType = AcceleratorType.CPU;
-        }
+        protected AcceleratorObject() { }
 
         /// <summary>
         /// Constructs an accelerator object.
@@ -59,7 +56,6 @@ namespace ILGPU.Runtime
         protected AcceleratorObject(Accelerator accelerator)
         {
             Accelerator = accelerator;
-            AcceleratorType = accelerator.AcceleratorType;
             accelerator.RegisterChildObject(this);
         }
 
@@ -75,7 +71,56 @@ namespace ILGPU.Runtime
         /// <summary>
         /// Returns the accelerator type of this object.
         /// </summary>
-        public AcceleratorType AcceleratorType { get; }
+        public AcceleratorType AcceleratorType =>
+            Accelerator?.AcceleratorType ?? AcceleratorType.CPU;
+
+        #endregion
+
+        #region IDisposable
+
+        /// <summary cref="DisposeBase.Dispose(bool)"/>
+        protected sealed override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            // Leave the dispose functionality to the associated accelerator object
+            Accelerator?.DisposeChildObject_AcceleratorObject(this, disposing);
+        }
+
+        /// <summary>
+        /// Disposes this accelerator object. Implementations of this function can
+        /// assume that the associated accelerator is currently bound and active.
+        /// </summary>
+        /// <param name="disposing">
+        /// True, if the method is not called by the finalizer.
+        /// </param>
+        /// <remarks>
+        /// This function is called by the owning accelerator instance. This can either
+        /// be <see cref="Accelerator.DisposeChildObject_AcceleratorObject(
+        /// AcceleratorObject, bool)"/> or
+        /// <see cref="Accelerator.DisposeChildObjects_SyncRoot(bool)"/>.
+        /// </remarks>
+        internal void DisposeAcceleratorObject_Accelerator(bool disposing)
+        {
+            if (IsDisposed)
+                return;
+            DisposeAcceleratorObject(disposing);
+        }
+
+        /// <summary>
+        /// Disposes this accelerator object. Implementations of this function can
+        /// assume that the associated accelerator is currently bound and active.
+        /// </summary>
+        /// <param name="disposing">
+        /// True, if the method is not called by the finalizer.
+        /// </param>
+        /// <remarks>
+        /// This function is called by the owning accelerator instance. This can either
+        /// be <see cref="Accelerator.DisposeChildObject_AcceleratorObject(
+        /// AcceleratorObject, bool)"/> or
+        /// <see cref="Accelerator.DisposeChildObjects_SyncRoot(bool)"/>.
+        /// </remarks>
+        protected abstract void DisposeAcceleratorObject(bool disposing);
 
         #endregion
     }
@@ -184,20 +229,59 @@ namespace ILGPU.Runtime
         #region Dispose Functionality
 
         /// <summary>
+        /// Disposes the given child object associated with this accelerator instance.
+        /// CAUTION: this function is invoked by the
+        /// <see cref="AcceleratorObject.Dispose(bool)"/> function only. It should
+        /// never be called in a different context.
+        /// </summary>
+        /// <param name="acceleratorObject">The object to dispose.</param>
+        /// <param name="disposing">
+        /// True, if the method is not called by the finalizer.
+        /// </param>
+        internal void DisposeChildObject_AcceleratorObject(
+            AcceleratorObject acceleratorObject,
+            bool disposing)
+        {
+            // Assert that this object belongs to us.
+            Debug.Assert(
+                acceleratorObject.Accelerator == this,
+                "Invalid accelerator association");
+
+            // Lock the current accelerator syncLock to avoid ongoing disposes
+            lock (syncRoot)
+            {
+                // Check the native pointer of the current accelerator
+                if (IsDisposed)
+                    return;
+
+                // Ensure that we have a valid accelerator binding
+                var binding = BindScoped();
+
+                // Dispose the actual accelerator object
+                acceleratorObject.DisposeAcceleratorObject_Accelerator(disposing);
+
+                // Recover the current binding
+                binding.Recover();
+            }
+        }
+
+        /// <summary>
         /// Disposes all child objects that are still alive since they are not allowed
         /// to live longer than the parent accelerator object.
         /// </summary>
-        private void DisposeChildObjects()
+        private void DisposeChildObjects_SyncRoot(bool disposing)
         {
-            lock (syncRoot)
+            foreach (var childObject in childObjects)
             {
-                foreach (var childObject in childObjects)
+                // Try to get the actual child object and dispose it
+                if (childObject.TryGetTarget(out AcceleratorObject obj))
                 {
-                    if (childObject.TryGetTarget(out AcceleratorObject obj))
-                        obj.Dispose();
+                    // We can safely dispose the object at this point since the current
+                    // accelerator is bound and the syncRoot lock is acquired
+                    obj.DisposeAcceleratorObject_Accelerator(disposing);
                 }
-                childObjects.Clear();
             }
+            childObjects.Clear();
         }
 
         /// <summary>

--- a/Src/ILGPU/Runtime/AcceleratorObject.cs
+++ b/Src/ILGPU/Runtime/AcceleratorObject.cs
@@ -106,7 +106,7 @@ namespace ILGPU.Runtime
         /// </summary>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private List<WeakReference<AcceleratorObject>> childObjects =
-            new List<WeakReference<AcceleratorObject>>();
+            new List<WeakReference<AcceleratorObject>>(MinNumberOfChildObjectsInGC);
 
         #endregion
 
@@ -150,13 +150,6 @@ namespace ILGPU.Runtime
         internal void RegisterChildObject<T>(T child)
             where T : AcceleratorObject
         {
-            if (!GCEnabled ||
-                !AutomaticBufferDisposalEnabled && child is MemoryBuffer ||
-                !AutomaticKernelDisposalEnabled && child is Kernel)
-            {
-                return;
-            }
-
             var objRef = new WeakReference<AcceleratorObject>(child);
             lock (syncRoot)
             {

--- a/Src/ILGPU/Runtime/AcceleratorObject.cs
+++ b/Src/ILGPU/Runtime/AcceleratorObject.cs
@@ -136,7 +136,7 @@ namespace ILGPU.Runtime
         /// <remarks>This method is invoked in the scope of the locked
         /// <see cref="syncRoot"/> object.</remarks>
         private bool RequestChildObjectsGC_SyncRoot =>
-            childObjects.Count % NumberNewChildObjectsUntilGC == 0;
+            (childObjects.Count + 1) % NumberNewChildObjectsUntilGC == 0;
 
         #endregion
 

--- a/Src/ILGPU/Runtime/ArrayViewSource.cs
+++ b/Src/ILGPU/Runtime/ArrayViewSource.cs
@@ -9,7 +9,6 @@
 // Source License. See LICENSE.txt for details
 // ---------------------------------------------------------------------------------------
 
-using ILGPU.Util;
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -95,6 +94,8 @@ namespace ILGPU.Runtime
     /// </summary>
     public class ViewPointerWrapper : ArrayViewSource
     {
+        #region Static
+
         /// <summary>
         /// Creates a new pointer wrapper.
         /// </summary>
@@ -126,6 +127,10 @@ namespace ILGPU.Runtime
         public static unsafe ViewPointerWrapper Create(IntPtr value) =>
             new ViewPointerWrapper(value);
 
+        #endregion
+
+        #region Instance
+
         /// <summary>
         /// Creates a new pointer wrapper.
         /// </summary>
@@ -135,12 +140,27 @@ namespace ILGPU.Runtime
             NativePtr = ptr;
         }
 
+        #endregion
+
+        #region Methods
+
         /// <summary cref="ArrayViewSource.GetAsRawArray(
         /// AcceleratorStream, long, long)"/>
         protected internal override ArraySegment<byte> GetAsRawArray(
             AcceleratorStream stream,
             long byteOffset,
             long byteExtent) => throw new InvalidOperationException();
+
+        #endregion
+
+        #region IDisposable
+
+        /// <summary>
+        /// Does not perform any operation.
+        /// </summary>
+        protected override void DisposeAcceleratorObject(bool disposing) { }
+
+        #endregion
     }
 
     /// <summary>
@@ -148,6 +168,8 @@ namespace ILGPU.Runtime
     /// </summary>
     internal sealed class UnmanagedMemoryViewSource : ViewPointerWrapper
     {
+        #region Static
+
         /// <summary>
         /// Creates a new unmanaged memory view source.
         /// </summary>
@@ -157,9 +179,17 @@ namespace ILGPU.Runtime
         public static unsafe UnmanagedMemoryViewSource Create(long sizeInBytes) =>
             new UnmanagedMemoryViewSource(sizeInBytes);
 
+        #endregion
+
+        #region Instance
+
         private UnmanagedMemoryViewSource(long sizeInBytes)
             : base(Marshal.AllocHGlobal(new IntPtr(sizeInBytes)))
         { }
+
+        #endregion
+
+        #region Methods
 
         /// <summary cref="ArrayViewSource.GetAsRawArray(
         /// AcceleratorStream, long, long)"/>
@@ -168,17 +198,17 @@ namespace ILGPU.Runtime
             long byteOffset,
             long byteExtent) => throw new InvalidOperationException();
 
-        #region IDispoable
+        #endregion
 
-        /// <summary cref="DisposeBase.Dispose(bool)"/>
-        protected override void Dispose(bool disposing)
+        #region IDisposable
+
+        /// <summary>
+        /// Frees the allocated unsafe memory.
+        /// </summary>
+        protected override void DisposeAcceleratorObject(bool disposing)
         {
-            if (NativePtr != IntPtr.Zero)
-            {
-                Marshal.FreeHGlobal(NativePtr);
-                NativePtr = IntPtr.Zero;
-            }
-            base.Dispose(disposing);
+            Marshal.FreeHGlobal(NativePtr);
+            NativePtr = IntPtr.Zero;
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/CPU/CPUAccelerator.cs
+++ b/Src/ILGPU/Runtime/CPU/CPUAccelerator.cs
@@ -108,7 +108,7 @@ namespace ILGPU.Runtime.CPU
                     IsBackground = true,
                     Priority = threadPriority,
                 };
-                thread.Name = "ILGPUExecutionThread" + i;
+                thread.Name = $"ILGPU_{InstanceId}_CPU_{i}";
                 thread.Start(i);
             }
 

--- a/Src/ILGPU/Runtime/CPU/CPUKernel.cs
+++ b/Src/ILGPU/Runtime/CPU/CPUKernel.cs
@@ -68,5 +68,14 @@ namespace ILGPU.Runtime.CPU
         internal CPUKernelExecutionHandler KernelExecutionDelegate { get; }
 
         #endregion
+
+        #region IDisposable
+
+        /// <summary>
+        /// Does not perform any operation.
+        /// </summary>
+        protected override void DisposeAcceleratorObject(bool disposing) { }
+
+        #endregion
     }
 }

--- a/Src/ILGPU/Runtime/CPU/CPUStream.cs
+++ b/Src/ILGPU/Runtime/CPU/CPUStream.cs
@@ -34,5 +34,14 @@ namespace ILGPU.Runtime.CPU
         public override void Synchronize() { }
 
         #endregion
+
+        #region IDisposable
+
+        /// <summary>
+        /// Does not perform any operation.
+        /// </summary>
+        protected override void DisposeAcceleratorObject(bool disposing) { }
+
+        #endregion
     }
 }

--- a/Src/ILGPU/Runtime/Cuda/CudaDriverVersion.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaDriverVersion.cs
@@ -3,7 +3,7 @@
 //                        Copyright (c) 2016-2020 Marcel Koester
 //                                    www.ilgpu.net
 //
-// File: PTXArchitecture.cs
+// File: CudaDriverVersion.cs
 //
 // This file is part of ILGPU and is distributed under the University of Illinois Open
 // Source License. See LICENSE.txt for details

--- a/Src/ILGPU/Runtime/Cuda/CudaException.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaException.cs
@@ -10,7 +10,6 @@
 // ---------------------------------------------------------------------------------------
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Security.Permissions;
@@ -21,11 +20,8 @@ namespace ILGPU.Runtime.Cuda
     /// <summary>
     /// Represents a Cuda exception that can be thrown by the Cuda runtime.
     /// </summary>
-    [SuppressMessage(
-        "Microsoft.Design",
-        "CA1032:ImplementStandardExceptionConstructors")]
     [Serializable]
-    public sealed class CudaException : Exception
+    public sealed class CudaException : AcceleratorException
     {
         #region Instance
 
@@ -63,6 +59,11 @@ namespace ILGPU.Runtime.Cuda
         /// </summary>
         public string Error { get; }
 
+        /// <summary>
+        /// Returns <see cref="AcceleratorType.Cuda"/>.
+        /// </summary>
+        public override AcceleratorType AcceleratorType => AcceleratorType.Cuda;
+
         #endregion
 
         #region Methods
@@ -79,6 +80,22 @@ namespace ILGPU.Runtime.Cuda
             base.GetObjectData(info, context);
 
             info.AddValue("Error", Error);
+        }
+
+        /// <summary>
+        /// Checks the given status and throws an exception in case of an error if
+        /// <paramref name="disposing"/> is set to true. If it is set to false, the
+        /// exception will be suppressed in all cases.
+        /// </summary>
+        /// <param name="disposing">
+        /// True, if this function has been called by the dispose method, false otherwise.
+        /// </param>
+        /// <param name="cudaStatus">The Cuda status to check.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void VerifyDisposed(bool disposing, CudaError cudaStatus)
+        {
+            if (disposing)
+                ThrowIfFailed(cudaStatus);
         }
 
         /// <summary>

--- a/Src/ILGPU/Runtime/Cuda/CudaKernel.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaKernel.cs
@@ -10,10 +10,8 @@
 // ---------------------------------------------------------------------------------------
 
 using ILGPU.Backends.PTX;
-using ILGPU.Util;
 using System;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using static ILGPU.Runtime.Cuda.CudaAPI;
 
@@ -44,11 +42,6 @@ namespace ILGPU.Runtime.Cuda
         /// <param name="accelerator">The associated accelerator.</param>
         /// <param name="kernel">The source kernel.</param>
         /// <param name="launcher">The launcher method for the given kernel.</param>
-        [SuppressMessage(
-            "Microsoft.Design",
-            "CA1062:Validate arguments of public methods",
-            MessageId = "0",
-            Justification = "Will be verified in the constructor of the base class")]
         internal CudaKernel(
             CudaAccelerator accelerator,
             PTXCompiledKernel kernel,
@@ -87,12 +80,12 @@ namespace ILGPU.Runtime.Cuda
         #region Properties
 
         /// <summary>
-        /// Returns the Cuda module ptr.
+        /// Returns the Cuda module pointer.
         /// </summary>
         public IntPtr ModulePtr => modulePtr;
 
         /// <summary>
-        /// Returns the Cuda function ptr.
+        /// Returns the Cuda function pointer.
         /// </summary>
         public IntPtr FunctionPtr => functionPtr;
 
@@ -100,17 +93,16 @@ namespace ILGPU.Runtime.Cuda
 
         #region IDisposable
 
-        /// <summary cref="DisposeBase.Dispose(bool)"/>
-        protected override void Dispose(bool disposing)
+        /// <summary>
+        /// Disposes this Cuda kernel.
+        /// </summary>
+        protected override void DisposeAcceleratorObject(bool disposing)
         {
-            if (modulePtr != IntPtr.Zero)
-            {
-                CudaException.ThrowIfFailed(
-                    CurrentAPI.DestroyModule(modulePtr));
-                functionPtr = IntPtr.Zero;
-                modulePtr = IntPtr.Zero;
-            }
-            base.Dispose(disposing);
+            CudaException.VerifyDisposed(
+                disposing,
+                CurrentAPI.DestroyModule(modulePtr));
+            functionPtr = IntPtr.Zero;
+            modulePtr = IntPtr.Zero;
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/Cuda/CudaMemoryBuffer.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaMemoryBuffer.cs
@@ -10,9 +10,7 @@
 // ---------------------------------------------------------------------------------------
 
 using ILGPU.Resources;
-using ILGPU.Util;
 using System;
-using System.Runtime.CompilerServices;
 using static ILGPU.Runtime.Cuda.CudaAPI;
 
 namespace ILGPU.Runtime.Cuda
@@ -147,16 +145,15 @@ namespace ILGPU.Runtime.Cuda
 
         #region IDisposable
 
-        /// <summary cref="DisposeBase.Dispose(bool)"/>
-        protected override void Dispose(bool disposing)
+        /// <summary>
+        /// Disposes this Cuda buffer.
+        /// </summary>
+        protected override void DisposeAcceleratorObject(bool disposing)
         {
-            if (NativePtr != IntPtr.Zero)
-            {
-                CudaException.ThrowIfFailed(
-                    CurrentAPI.FreeMemory(NativePtr));
-                NativePtr = IntPtr.Zero;
-            }
-            base.Dispose(disposing);
+            CudaException.VerifyDisposed(
+                disposing,
+                CurrentAPI.FreeMemory(NativePtr));
+            NativePtr = IntPtr.Zero;
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/Cuda/CudaStream.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaStream.cs
@@ -9,7 +9,6 @@
 // Source License. See LICENSE.txt for details
 // ---------------------------------------------------------------------------------------
 
-using ILGPU.Util;
 using System;
 using System.Diagnostics.CodeAnalysis;
 using static ILGPU.Runtime.Cuda.CudaAPI;
@@ -30,7 +29,7 @@ namespace ILGPU.Runtime.Cuda
         private readonly bool responsibleForHandle;
 
         /// <summary>
-        /// Constructs a new cuda stream from the given native pointer.
+        /// Constructs a new Cuda stream from the given native pointer.
         /// </summary>
         /// <param name="accelerator">The associated accelerator.</param>
         /// <param name="ptr">The native stream pointer.</param>
@@ -45,7 +44,7 @@ namespace ILGPU.Runtime.Cuda
         }
 
         /// <summary>
-        /// Constructs a new cuda stream with given <see cref="StreamFlags"/>.
+        /// Constructs a new Cuda stream with given <see cref="StreamFlags"/>.
         /// </summary>
         /// <param name="accelerator">The associated accelerator.</param>
         /// <param name="flag">
@@ -89,16 +88,18 @@ namespace ILGPU.Runtime.Cuda
 
         #region IDisposable
 
-        /// <summary cref="DisposeBase.Dispose(bool)"/>
-        protected override void Dispose(bool disposing)
+        /// <summary>
+        /// Disposes this Cuda stream.
+        /// </summary>
+        protected override void DisposeAcceleratorObject(bool disposing)
         {
-            if (responsibleForHandle && streamPtr != IntPtr.Zero)
-            {
-                CudaException.ThrowIfFailed(
-                    CurrentAPI.DestroyStream(streamPtr));
-                streamPtr = IntPtr.Zero;
-            }
-            base.Dispose(disposing);
+            if (!responsibleForHandle || streamPtr == IntPtr.Zero)
+                return;
+
+            CudaException.VerifyDisposed(
+                disposing,
+                CurrentAPI.DestroyStream(streamPtr));
+            streamPtr = IntPtr.Zero;
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/ExchangeBufferExtensions.tt
+++ b/Src/ILGPU/Runtime/ExchangeBufferExtensions.tt
@@ -15,7 +15,8 @@
 <#@ import namespace="System.Text" #>
 <#@ import namespace="System.Collections.Generic" #>
 <#@ output extension=".cs" #>
-using System.Diagnostics.CodeAnalysis;
+<# int numDimensions = 3; #>
+using ILGPU.Runtime.CPU;
 
 namespace ILGPU.Runtime
 {
@@ -23,17 +24,11 @@ namespace ILGPU.Runtime
     /// A static helper class for all exchange buffer implementations.
     /// </summary>
     public static class ExchangeBuffer
-    {<#int top = 3;
-    for(int i = 1; i <= top; i++)
-    {#>
-    <# var indexName = $"LongIndex{i}"; #>
-    <# var dimensionName = $"{i}D"; #>
-    <# var typeName = i == 1 ? "ExchangeBuffer" : $"ExchangeBuffer{dimensionName}"; #>
-    <# var arrayViewType = $"ArrayView<T, {indexName}>"; #>
-    <# var highLevelView =  i == 1 ? "ArrayView" : $"ArrayView{dimensionName}"; #>
-    <# var memoryBufferType = $"MemoryBuffer<T, {indexName}>"; #>
-    <# var highLevelMemBuf = i == 1 ? "MemoryBuffer" : $"MemoryBuffer{dimensionName}";#>
-
+    {
+<# for(int i = 1; i <= numDimensions; i++) { #>
+<#      var indexName = $"LongIndex{i}"; #>
+<#      var dimensionName = $"{i}D"; #>
+<#      var typeName = i == 1 ? "ExchangeBuffer" : $"ExchangeBuffer{dimensionName}"; #>
         /// <summary>
         /// Allocates a new <#= dimensionName #> exchange buffer
         /// that allocates the specified amount of elements on the current
@@ -53,7 +48,7 @@ namespace ILGPU.Runtime
             <#= indexName #> extent)
             where T : unmanaged => accelerator.AllocateExchangeBuffer<T>(
                 extent,
-                ExchangeBufferMode.PreferPagedLockedMemory);
+                ExchangeBufferMode.PreferPageLockedMemory);
 
         /// <summary>
         /// Allocates a new <#= dimensionName #> exchange buffer
@@ -75,18 +70,16 @@ namespace ILGPU.Runtime
             var gpuBuffer = accelerator.Allocate<T>(extent);
             return new <#= typeName #><T>(gpuBuffer, mode);
         }
-    <#}
-    #>}
-    <#for(int i = 1; i <= top; i++)
-    {#>
-    <# var indexName = $"LongIndex{i}"; #>
-    <# var dimensionName = $"{i}D"; #>
-    <# var typeName = i == 1 ? "ExchangeBuffer" : $"ExchangeBuffer{dimensionName}"; #>
-    <# var arrayViewType = $"ArrayView<T, {indexName}>"; #>
-    <# var highLevelView =  i == 1 ? "ArrayView" : $"ArrayView{dimensionName}"; #>
-    <# var memoryBufferType = $"MemoryBuffer<T, {indexName}>"; #>
-    <# var highLevelMemBuf =  i == 1 ? "MemoryBuffer" :
-        $"MemoryBuffer{dimensionName}"; #>
+<# } #>
+   }
+<# for(int i = 1; i <= numDimensions; i++) { #>
+<#      var indexName = $"LongIndex{i}"; #>
+<#      var dimensionName = $"{i}D"; #>
+<#      var typeName = i == 1 ? "ExchangeBuffer" : $"ExchangeBuffer{dimensionName}"; #>
+<#      var arrayViewType = $"ArrayView<T, {indexName}>"; #>
+<#      var highLevelView =  i == 1 ? "ArrayView" : $"ArrayView{dimensionName}"; #>
+<#      var memoryBufferType = i == 1 ? "MemoryBuffer<T>" :
+            $"MemoryBuffer{dimensionName}<T>"; #>
 
     /// <summary>
     /// <#= dimensionName #> implementation of
@@ -94,10 +87,13 @@ namespace ILGPU.Runtime
     /// </summary>
     /// <typeparam name="T">The element type.</typeparam>
     /// <remarks>Members of this class are not thread safe.</remarks>
-    public sealed unsafe class <#=typeName#><T> : ExchangeBufferBase<T, <#=indexName#>>
+    public sealed unsafe class <#= typeName #><T> :
+        ExchangeBufferBase<T, <#= indexName #>>
         where T : unmanaged
     {
         #region Instance
+
+        private readonly <#= memoryBufferType #> gpuBuffer;
 
         /// <summary>
         /// Initializes this memory buffer.
@@ -107,38 +103,66 @@ namespace ILGPU.Runtime
         internal <#= typeName #>(
             <#= memoryBufferType #> buffer,
             ExchangeBufferMode mode)
-            : base(buffer, mode)
+            : base(buffer.Accelerator, buffer.Extent, mode)
         {
-            <#if(i > 1)
-            {#>var baseView = new ArrayView<T>(CPUMemory, 0, buffer.Length);
-            CPUArrayView = new <#= arrayViewType #>(baseView, buffer.Extent);
-            <#}
-            else
-            {#>CPUArrayView = new ArrayView<T>(CPUMemory, 0, buffer.Length);
-            <#}#>
-
-            // Cache local data
-            Buffer = buffer;
+            gpuBuffer = buffer;
             NativePtr = buffer.NativePtr;
-            View = buffer.View;
-            Extent = buffer.Extent;
         }
 
         #endregion
 
         #region Methods
 
-        /// <summary>
-        /// Gets this buffer as a higher level memory buffer.
-        /// </summary>
-        /// <returns> A <see cref="<#= highLevelMemBuf #>{T}"/> containing
-        /// the data in this exchanage buffer.
-        /// </returns>
-        public <#= highLevelMemBuf #><T> As<#= highLevelMemBuf #>() =>
-            new <#= highLevelMemBuf #><T>(Buffer);
+        /// <summary cref="MemoryBuffer{T, TIndex}.CopyToView(
+        /// AcceleratorStream, ArrayView{T}, LongIndex1)"/>
+        protected internal override void CopyToView(
+            AcceleratorStream stream,
+            ArrayView<T> target,
+            LongIndex1 sourceOffset) =>
+            gpuBuffer.CopyToView(stream, target, sourceOffset);
 
-<#if(i > 1)
-        {#>
+        /// <summary cref="MemoryBuffer{T, TIndex}.CopyFromView(
+        /// AcceleratorStream, ArrayView{T}, LongIndex1)"/>
+        protected internal override void CopyFromView(
+            AcceleratorStream stream,
+            ArrayView<T> source,
+            LongIndex1 targetOffset) =>
+            gpuBuffer.CopyFromView(stream, source, targetOffset);
+
+        /// <summary>
+        /// Sets the contents of the current buffer to the given byte value.
+        /// </summary>
+        /// <param name="stream">The used accelerator stream.</param>
+        /// <param name="value">The value to write into the memory buffer.</param>
+        /// <param name="offsetInBytes">The raw offset in bytes.</param>
+        /// <param name="lengthInBytes">The raw length in bytes.</param>
+        protected internal override void MemSetInternal(
+            AcceleratorStream stream,
+            byte value,
+            long offsetInBytes,
+            long lengthInBytes)
+        {
+            gpuBuffer.MemSetInternal(
+                stream,
+                value,
+                offsetInBytes,
+                lengthInBytes);
+            CPUMemoryBuffer<T, <#= indexName #>>.MemSet(
+                CPUMemory.NativePtr,
+                value,
+                offsetInBytes,
+                lengthInBytes);
+        }
+
+        /// <summary>
+        /// Copies the current contents into a new byte array.
+        /// </summary>
+        /// <param name="stream">The used accelerator stream.</param>
+        /// <returns>A new array holding the requested contents.</returns>
+        public override byte[] GetAsRawArray(AcceleratorStream stream) =>
+            gpuBuffer.GetAsRawArray(stream);
+<#      if(i > 1) { #>
+
         /// <summary>
         /// Gets the part of this buffer on CPU memory as a <#= dimensionName #> View
         /// using the current extent.
@@ -152,10 +176,6 @@ namespace ILGPU.Runtime
         /// the accelerator using the default stream.
         /// </summary>
         /// <returns>The array containing all the elements in the buffer.</returns>
-        [SuppressMessage(
-            "Microsoft.Performance",
-            "CA1814: PreferJaggedArraysOverMultidimensional",
-            Target = "target")]
         public T[,<#if(i == 3){#>,<#}#>] GetAs<#= dimensionName #>Array() =>
             GetAs<#= dimensionName #>Array(Accelerator.DefaultStream);
 
@@ -163,20 +183,12 @@ namespace ILGPU.Runtime
         /// Gets this buffer as a <#= dimensionName #> array from the accelerator.
         /// </summary>
         /// <returns>The array containing all the elements in the buffer.</returns>
-        [SuppressMessage(
-            "Microsoft.Performance",
-            "CA1814: PreferJaggedArraysOverMultidimensional",
-            Target = "target")]
         public T[,<#if(i == 3){#>,<#}#>] GetAs<#= dimensionName #>Array(
-            AcceleratorStream stream)
-        {
-            var buffer = new <#= highLevelMemBuf #><T>(Buffer);
-            var array = buffer.GetAs<#= dimensionName #>Array(stream);
-            buffer.Dispose();
-            return array;
-        }
+            AcceleratorStream stream) =>
+            gpuBuffer.GetAs<#= dimensionName #>Array(stream);
+<#      } #>
 
-<#}#>        #endregion
+        #endregion
 
         #region Operators
 
@@ -188,15 +200,21 @@ namespace ILGPU.Runtime
             <#= typeName #><T> buffer) =>
             buffer.View;
 
+        #endregion
+
+        #region IDisposable
+
         /// <summary>
-        /// Implicitly converts this buffer into a memory buffer.
+        /// Frees the underlying GPU memory buffer.
         /// </summary>
-        /// <param name="buffer">The source buffer.</param>
-        public static implicit operator MemoryBuffer<T, <#= indexName #>>(
-            <#= typeName #><T> buffer) =>
-            buffer.Buffer;
+        protected override void DisposeAcceleratorObject(bool disposing)
+        {
+            if (disposing)
+                gpuBuffer.Dispose();
+            base.DisposeAcceleratorObject(disposing);
+        }
 
         #endregion
     }
-<#}
-#>}
+<# } #>
+}

--- a/Src/ILGPU/Runtime/KernelCache.cs
+++ b/Src/ILGPU/Runtime/KernelCache.cs
@@ -356,8 +356,8 @@ namespace ILGPU.Runtime
         /// </remarks>
         private bool RequestKernelCacheGC_SyncRoot =>
             KernelCacheEnabled &&
-            (compiledKernelCache.Count % NumberNewKernelsUntilGC == 0 ||
-            kernelCache.Count % NumberNewKernelsUntilGC == 0);
+            ((compiledKernelCache.Count + 1) % NumberNewKernelsUntilGC == 0 ||
+            (kernelCache.Count + 1) % NumberNewKernelsUntilGC == 0);
 
         #endregion
 

--- a/Src/ILGPU/Runtime/MemoryBuffer.cs
+++ b/Src/ILGPU/Runtime/MemoryBuffer.cs
@@ -170,7 +170,8 @@ namespace ILGPU.Runtime
     /// <typeparam name="TIndex">The index type.</typeparam>
     /// <remarks>Members of this class are not thread safe.</remarks>
     public abstract class MemoryBuffer<T, TIndex> :
-        MemoryBuffer, IMemoryBuffer<T, TIndex>
+        MemoryBuffer,
+        IMemoryBuffer<T, TIndex>
         where T : unmanaged
         where TIndex : unmanaged, IGenericIndex<TIndex>
     {
@@ -190,9 +191,7 @@ namespace ILGPU.Runtime
         /// </summary>
         /// <param name="accelerator">The associated accelerator.</param>
         /// <param name="extent">The extent (number of elements).</param>
-        protected unsafe MemoryBuffer(
-            Accelerator accelerator,
-            TIndex extent)
+        protected unsafe MemoryBuffer(Accelerator accelerator, TIndex extent)
             : base(accelerator, extent.Size, ElementSize)
         {
             Extent = extent;

--- a/Src/ILGPU/Runtime/MemoryBufferCache.cs
+++ b/Src/ILGPU/Runtime/MemoryBufferCache.cs
@@ -80,11 +80,6 @@ namespace ILGPU.Runtime
         /// </summary>
         /// <typeparam name="T">The desired element type.</typeparam>
         /// <returns>The available number of elements of type T.</returns>
-        [SuppressMessage(
-            "Microsoft.Design",
-            "CA1004:GenericMethodsShouldProvideTypeParameter",
-            Justification = "The generic parameter is required to compute the number " +
-            "of elements of the given type that can be stored")]
         public long GetCacheSize<T>()
             where T : unmanaged =>
             (cache?.Length ?? 0L) / Interop.SizeOf<T>();
@@ -166,12 +161,14 @@ namespace ILGPU.Runtime
 
         #region IDisposable
 
-        /// <summary cref="DisposeBase.Dispose(bool)"/>
-        protected override void Dispose(bool disposing)
+        /// <summary>
+        /// Disposes this cache by disposing the associated cache buffer.
+        /// </summary>
+        protected override void DisposeAcceleratorObject(bool disposing)
         {
-            if (disposing)
-                cache?.Dispose();
-            base.Dispose(disposing);
+            if (disposing && cache != null)
+                cache.Dispose();
+            cache = null;
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/MemoryBuffers.tt
+++ b/Src/ILGPU/Runtime/MemoryBuffers.tt
@@ -16,10 +16,8 @@
 <#@ import namespace="System.Text" #>
 <#@ import namespace="System.Collections.Generic" #>
 <#@ output extension=".cs" #>
-using ILGPU.Util;
 using System;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 // disable: max_line_length
@@ -40,19 +38,9 @@ namespace ILGPU.Runtime
     /// </summary>
     /// <typeparam name="T">The element type.</typeparam>
     /// <remarks>Members of this class are not thread safe.</remarks>
-    public sealed partial class <#= typeName #><T> :
-        MemoryBuffer, IMemoryBuffer<T, <#= indexType #>>
+    public sealed partial class <#= typeName #><T> : MemoryBuffer<T, <#= indexType #>>
         where T : unmanaged
     {
-        #region Constants
-
-        /// <summary>
-        /// Represents the size of an element in bytes.
-        /// </summary>
-        public static int ElementSize => MemoryBuffer<T, <#= indexType #>>.ElementSize;
-
-        #endregion
-
         #region Instance
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -61,16 +49,14 @@ namespace ILGPU.Runtime
         /// <summary>
         /// Initializes this memory buffer.
         /// </summary>
-        /// <param name="buffer">The wrapped buffer.</param>
-        internal <#= typeName #>(MemoryBuffer<T, <#= indexType #>> buffer)
-            : base(buffer.Accelerator, buffer.Extent.Size, ElementSize)
+        /// <param name="wrappedBuffer">The wrapped buffer.</param>
+        internal <#= typeName #>(MemoryBuffer<T, <#= indexType #>> wrappedBuffer)
+            : base(wrappedBuffer.Accelerator, wrappedBuffer.Extent)
         {
-            this.buffer = buffer;
+            buffer = wrappedBuffer;
 
             // Cache local data
-            NativePtr = buffer.NativePtr;
-            View = buffer.View;
-            Extent = buffer.Extent;
+            NativePtr = wrappedBuffer.NativePtr;
         }
 
         #endregion
@@ -78,28 +64,29 @@ namespace ILGPU.Runtime
         #region Properties
 
         /// <summary>
-        /// Returns the underlying generic memory buffer.
-        /// </summary>
-        public MemoryBuffer<T, <#= indexType #>> Buffer => buffer;
-
-        /// <summary>
         /// Returns an array view that can access this array.
         /// </summary>
-        public <#= viewTypeName #> View { get; }
-
-        /// <summary>
-        /// Returns an array view that can access this array.
-        /// </summary>
-        ArrayView<T, <#= indexType #>> IMemoryBuffer<T, <#= indexType #>>.View => View;
-
-        /// <summary>
-        /// Returns the extent of this buffer.
-        /// </summary>
-        public <#= indexType #> Extent { get; }
+        public new <#= viewTypeName #> View => base.View;
 
         #endregion
 
         #region MemoryBuffer Methods
+
+        /// <summary cref="MemoryBuffer{T, TIndex}.CopyToView(
+        /// AcceleratorStream, ArrayView{T}, LongIndex1)"/>
+        protected internal override void CopyToView(
+            AcceleratorStream stream,
+            ArrayView<T> target,
+            LongIndex1 sourceOffset) =>
+            buffer.CopyToView(stream, target, sourceOffset);
+
+        /// <summary cref="MemoryBuffer{T, TIndex}.CopyFromView(
+        /// AcceleratorStream, ArrayView{T}, LongIndex1)"/>
+        protected internal override void CopyFromView(
+            AcceleratorStream stream,
+            ArrayView<T> source,
+            LongIndex1 targetOffset) =>
+            buffer.CopyFromView(stream, source, targetOffset);
 
         /// <summary>
         /// Sets the contents of the current buffer to the given byte value.
@@ -126,73 +113,6 @@ namespace ILGPU.Runtime
         /// <returns>A new array holding the requested contents.</returns>
         public override byte[] GetAsRawArray(AcceleratorStream stream) =>
             buffer.GetAsRawArray(stream);
-
-        /// <summary>
-        /// Copies the current contents into a new byte array.
-        /// </summary>
-        /// <param name="stream">The used accelerator stream.</param>
-        /// <param name="byteOffset">The offset in bytes.</param>
-        /// <param name="byteExtent">The extent in bytes (number of elements).</param>
-        /// <returns>A new array holding the requested contents.</returns>
-        protected internal override ArraySegment<byte> GetAsRawArray(
-            AcceleratorStream stream,
-            long byteOffset,
-            long byteExtent) =>
-            buffer.GetAsRawArray(stream, byteOffset, byteExtent);
-
-        /// <summary>
-        /// Copies the current contents into a new array using
-        /// the default accelerator stream.
-        /// </summary>
-        /// <returns>A new array holding the requested contents.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public T[] GetAsArray() => buffer.GetAsArray();
-
-        /// <summary>
-        /// Copies the current contents into a new array.
-        /// </summary>
-        /// <param name="stream">The used accelerator stream.</param>
-        /// <returns>A new array holding the requested contents.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public T[] GetAsArray(AcceleratorStream stream) =>
-            buffer.GetAsArray(stream);
-
-        /// <summary>
-        /// Copies the current contents into a new array using
-        /// the default accelerator stream.
-        /// </summary>
-        /// <param name="offset">The offset.</param>
-        /// <param name="extent">The extent (number of elements).</param>
-        /// <returns>A new array holding the requested contents.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public T[] GetAsArray(<#= indexType #> offset, <#= indexType #> extent) =>
-            buffer.GetAsArray(Accelerator.DefaultStream, offset, extent);
-
-        /// <summary>
-        /// Copies the current contents into a new array.
-        /// </summary>
-        /// <param name="stream">The used accelerator stream.</param>
-        /// <param name="offset">The offset.</param>
-        /// <param name="extent">The extent (number of elements).</param>
-        /// <returns>A new array holding the requested contents.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public T[] GetAsArray(
-            AcceleratorStream stream,
-            <#= indexType #> offset,
-            <#= indexType #> extent) =>
-            buffer.GetAsArray(stream, offset, extent);
-
-        /// <summary>
-        /// Returns the underlying generic memory buffer.
-        /// </summary>
-        /// <returns>The underlying generic memory buffer.</returns>
-        public MemoryBuffer<T, <#= indexType #>> ToMemoryBuffer() => buffer;
-
-        /// <summary>
-        /// Returns an array view that can access this array.
-        /// </summary>
-        /// <returns>An array view that can access this array.</returns>
-        public ArrayView<T, <#= indexType #>> ToArrayView() => View;
 
         #endregion
 
@@ -222,31 +142,6 @@ namespace ILGPU.Runtime
             buffer.CopyTo(target, sourceOffset);
 
         /// <summary>
-        /// Copies elements from the current buffer to the target view using
-        /// the default accelerator stream.
-        /// </summary>
-        /// <param name="target">The target view.</param>
-        /// <param name="sourceOffset">The source offset.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void CopyTo(
-            ArrayView<T, <#= indexType #>> target,
-            <#= indexType #> sourceOffset) =>
-            buffer.CopyTo(target, sourceOffset);
-
-        /// <summary>
-        /// Copies elements from the current buffer to the target view.
-        /// </summary>
-        /// <param name="stream">The used accelerator stream.</param>
-        /// <param name="target">The target view.</param>
-        /// <param name="sourceOffset">The source offset.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void CopyTo(
-            AcceleratorStream stream,
-            ArrayView<T, <#= indexType #>> target,
-            <#= indexType #> sourceOffset) =>
-            buffer.CopyTo(stream, target, sourceOffset);
-
-        /// <summary>
         /// Copies elements to the current buffer from the source view.
         /// </summary>
         /// <param name="source">The source view.</param>
@@ -265,31 +160,6 @@ namespace ILGPU.Runtime
         public void CopyFrom(
             AcceleratorStream stream,
             <#= viewTypeName #> source,
-            <#= indexType #> targetOffset) =>
-            buffer.CopyFrom(stream, source, targetOffset);
-
-        /// <summary>
-        /// Copies elements to the current buffer from the source view using
-        /// the default accelerator stream.
-        /// </summary>
-        /// <param name="source">The source view.</param>
-        /// <param name="targetOffset">The target offset.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void CopyFrom(
-            ArrayView<T, <#= indexType #>> source,
-            <#= indexType #> targetOffset) =>
-            buffer.CopyFrom(source, targetOffset);
-
-        /// <summary>
-        /// Copies elements to the current buffer from the source view.
-        /// </summary>
-        /// <param name="stream">The used accelerator stream.</param>
-        /// <param name="source">The source view.</param>
-        /// <param name="targetOffset">The target offset.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void CopyFrom(
-            AcceleratorStream stream,
-            ArrayView<T, <#= indexType #>> source,
             <#= indexType #> targetOffset) =>
             buffer.CopyFrom(stream, source, targetOffset);
 
@@ -421,30 +291,6 @@ namespace ILGPU.Runtime
 <#      } #>
 
         /// <summary>
-        /// Copies a single element of this buffer to the given target variable
-        /// in CPU memory using the default accelerator stream.
-        /// </summary>
-        /// <param name="target">The target location.</param>
-        /// <param name="targetIndex">The target index.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void CopyTo(out T target, <#= indexType #> targetIndex) =>
-            buffer.CopyTo(out target, targetIndex);
-
-        /// <summary>
-        /// Copies a single element of this buffer to the given target variable
-        /// in CPU memory.
-        /// </summary>
-        /// <param name="stream">The used accelerator stream.</param>
-        /// <param name="target">The target location.</param>
-        /// <param name="targetIndex">The target index.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void CopyTo(
-            AcceleratorStream stream,
-            out T target,
-            <#= indexType #> targetIndex) =>
-            buffer.CopyTo(stream, out target, targetIndex);
-
-        /// <summary>
         /// Copies the contents of this buffer into the given array using
         /// the default accelerator stream.
         /// </summary>
@@ -476,48 +322,6 @@ namespace ILGPU.Runtime
         public void CopyTo(
             AcceleratorStream stream,
             T[] target,
-            <#= indexType #> sourceOffset,
-            long targetOffset,
-            <#= indexType #> extent) =>
-            buffer.CopyTo(
-                stream,
-                target,
-                sourceOffset,
-                targetOffset,
-                extent);
-
-        /// <summary>
-        /// Copies the contents of this buffer into the given array using
-        /// the default accelerator stream.
-        /// </summary>
-        /// <param name="target">The target array.</param>
-        /// <param name="sourceOffset">The source offset.</param>
-        /// <param name="targetOffset">The target offset.</param>
-        /// <param name="extent">The extent (number of elements).</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void CopyTo(
-            Span<T> target,
-            <#= indexType #> sourceOffset,
-            long targetOffset,
-            <#= indexType #> extent) =>
-            buffer.CopyTo(
-                target,
-                sourceOffset,
-                targetOffset,
-                extent);
-
-        /// <summary>
-        /// Copies the contents of this buffer into the given array.
-        /// </summary>
-        /// <param name="stream">The used accelerator stream.</param>
-        /// <param name="target">The target array.</param>
-        /// <param name="sourceOffset">The source offset.</param>
-        /// <param name="targetOffset">The target offset.</param>
-        /// <param name="extent">The extent (number of elements).</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void CopyTo(
-            AcceleratorStream stream,
-            Span<T> target,
             <#= indexType #> sourceOffset,
             long targetOffset,
             <#= indexType #> extent) =>
@@ -649,31 +453,6 @@ namespace ILGPU.Runtime
                 targetOffset);
 
         /// <summary>
-        /// Copies a single element from CPU memory to this buffer using
-        /// the default accelerator stream.
-        /// </summary>
-        /// <param name="source">The source value.</param>
-        /// <param name="sourceIndex">The source index.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void CopyFrom(T source, <#= indexType #> sourceIndex) =>
-            buffer.CopyFrom(source, sourceIndex);
-
-        /// <summary>
-        /// Copies a single element from CPU memory to this buffer.
-        /// </summary>
-        /// <param name="stream">The used accelerator stream.</param>
-        /// <param name="source">The source value.</param>
-        /// <param name="sourceIndex">The source index.</param>
-        public void CopyFrom(
-            AcceleratorStream stream,
-            T source,
-            <#= indexType #> sourceIndex) =>
-            buffer.CopyFrom(
-                stream,
-                source,
-                sourceIndex);
-
-        /// <summary>
         /// Copies the contents to this buffer from the given array using
         /// the default accelerator stream.
         /// </summary>
@@ -705,48 +484,6 @@ namespace ILGPU.Runtime
         public void CopyFrom(
             AcceleratorStream stream,
             T[] source,
-            long sourceOffset,
-            <#= indexType #> targetOffset,
-            long extent) =>
-            buffer.CopyFrom(
-                stream,
-                source,
-                sourceOffset,
-                targetOffset,
-                extent);
-
-        /// <summary>
-        /// Copies the contents to this buffer from the given array using
-        /// the default accelerator stream.
-        /// </summary>
-        /// <param name="source">The source array.</param>
-        /// <param name="sourceOffset">The source offset.</param>
-        /// <param name="targetOffset">The target offset.</param>
-        /// <param name="extent">The extent (number of elements).</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void CopyFrom(
-            ReadOnlySpan<T> source,
-            long sourceOffset,
-            <#= indexType #> targetOffset,
-            long extent) =>
-            buffer.CopyFrom(
-                source,
-                sourceOffset,
-                targetOffset,
-                extent);
-
-        /// <summary>
-        /// Copies the contents to this buffer from the given array.
-        /// </summary>
-        /// <param name="stream">The used accelerator stream.</param>
-        /// <param name="source">The source array.</param>
-        /// <param name="sourceOffset">The source offset.</param>
-        /// <param name="targetOffset">The target offset.</param>
-        /// <param name="extent">The extent (number of elements).</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void CopyFrom(
-            AcceleratorStream stream,
-            ReadOnlySpan<T> source,
             long sourceOffset,
             <#= indexType #> targetOffset,
             long extent) =>
@@ -768,23 +505,17 @@ namespace ILGPU.Runtime
         public static implicit operator <#= viewTypeName #>(<#= typeName #><T> buffer) =>
             buffer.View;
 
-        /// <summary>
-        /// Implicitly converts this buffer into an array view.
-        /// </summary>
-        /// <param name="buffer">The source buffer.</param>
-        public static implicit operator MemoryBuffer<T, <#= indexType #>>(<#= typeName #><T> buffer) =>
-            buffer.buffer;
-
         #endregion
 
         #region IDisposable
 
-        /// <summary cref="DisposeBase.Dispose(bool)"/>
-        protected override void Dispose(bool disposing)
+        /// <summary>
+        /// Disposes the associated memory buffer.
+        /// </summary>
+        protected override void DisposeAcceleratorObject(bool disposing)
         {
             if (disposing)
                 buffer.Dispose();
-            base.Dispose(disposing);
         }
 
         #endregion
@@ -800,12 +531,6 @@ namespace ILGPU.Runtime
         /// <param name="accelerator">The current accelerator.</param>
         /// <param name="data">The initial data array.</param>
         /// <returns>The allocated memory buffer.</returns>
-<#      if (dimension > 1) { #>
-        [SuppressMessage(
-            "Microsoft.Performance",
-            "CA1814: PreferJaggedArraysOverMultidimensional",
-            Target = "data")]
-<#      } #>
 <#      var allocExpression = Enumerable.Range(0, dimension).
             Select(t => $"data.GetLongLength({t})"); #>
         public static <#= typeName #><T> Allocate<T>(

--- a/Src/ILGPU/Runtime/OpenCL/CLKernel.cs
+++ b/Src/ILGPU/Runtime/OpenCL/CLKernel.cs
@@ -10,7 +10,6 @@
 // ---------------------------------------------------------------------------------------
 
 using ILGPU.Backends.OpenCL;
-using ILGPU.Util;
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -49,7 +48,7 @@ namespace ILGPU.Runtime.OpenCL
             errorLog = null;
             kernelPtr = IntPtr.Zero;
             var programError = CurrentAPI.CreateProgram(
-                accelerator.ContextPtr,
+                accelerator.NativePtr,
                 source,
                 out programPtr);
             if (programError != CLError.CL_SUCCESS)
@@ -202,22 +201,28 @@ namespace ILGPU.Runtime.OpenCL
 
         #region IDisposable
 
-        /// <summary cref="DisposeBase.Dispose(bool)"/>
-        protected override void Dispose(bool disposing)
+        /// <summary>
+        /// Disposes this OpenCL kernel.
+        /// </summary>
+        protected override void DisposeAcceleratorObject(bool disposing)
         {
+            // Free the kernel
             if (kernelPtr != IntPtr.Zero)
             {
-                CLException.ThrowIfFailed(
+                CLException.VerifyDisposed(
+                    disposing,
                     CurrentAPI.ReleaseKernel(kernelPtr));
                 kernelPtr = IntPtr.Zero;
             }
+
+            // Free the surrounding program
             if (programPtr != IntPtr.Zero)
             {
-                CLException.ThrowIfFailed(
+                CLException.VerifyDisposed(
+                    disposing,
                     CurrentAPI.ReleaseProgram(programPtr));
                 programPtr = IntPtr.Zero;
             }
-            base.Dispose(disposing);
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/OpenCL/CLMemoryBuffer.cs
+++ b/Src/ILGPU/Runtime/OpenCL/CLMemoryBuffer.cs
@@ -10,7 +10,6 @@
 // ---------------------------------------------------------------------------------------
 
 using ILGPU.Resources;
-using ILGPU.Util;
 using System;
 using static ILGPU.Runtime.OpenCL.CLAPI;
 
@@ -37,7 +36,7 @@ namespace ILGPU.Runtime.OpenCL
         {
             CLException.ThrowIfFailed(
                 CurrentAPI.CreateBuffer(
-                    accelerator.ContextPtr,
+                    accelerator.NativePtr,
                     CLBufferFlags.CL_MEM_READ_WRITE,
                     new IntPtr(extent.Size * ElementSize),
                     IntPtr.Zero,
@@ -153,16 +152,15 @@ namespace ILGPU.Runtime.OpenCL
 
         #region IDisposable
 
-        /// <summary cref="DisposeBase.Dispose(bool)"/>
-        protected override void Dispose(bool disposing)
+        /// <summary>
+        /// Disposes this OpenCL buffer.
+        /// </summary>
+        protected override void DisposeAcceleratorObject(bool disposing)
         {
-            if (NativePtr != IntPtr.Zero)
-            {
-                CLException.ThrowIfFailed(
-                    CurrentAPI.ReleaseBuffer(NativePtr));
-                NativePtr = IntPtr.Zero;
-            }
-            base.Dispose(disposing);
+            CLException.VerifyDisposed(
+                disposing,
+                CurrentAPI.ReleaseBuffer(NativePtr));
+            NativePtr = IntPtr.Zero;
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/OpenCL/CLStream.cs
+++ b/Src/ILGPU/Runtime/OpenCL/CLStream.cs
@@ -9,7 +9,6 @@
 // Source License. See LICENSE.txt for details
 // ---------------------------------------------------------------------------------------
 
-using ILGPU.Util;
 using System;
 using System.Diagnostics.CodeAnalysis;
 using static ILGPU.Runtime.OpenCL.CLAPI;
@@ -43,7 +42,7 @@ namespace ILGPU.Runtime.OpenCL
                 CurrentAPI.CreateCommandQueue(
                     accelerator.PlatformVersion,
                     accelerator.DeviceId,
-                    accelerator.ContextPtr,
+                    accelerator.NativePtr,
                     out queuePtr));
             responsibleForHandle = true;
         }
@@ -70,16 +69,18 @@ namespace ILGPU.Runtime.OpenCL
 
         #region IDisposable
 
-        /// <summary cref="DisposeBase.Dispose(bool)"/>
-        protected override void Dispose(bool disposing)
+        /// <summary>
+        /// Disposes this OpenCL stream.
+        /// </summary>
+        protected override void DisposeAcceleratorObject(bool disposing)
         {
-            if (responsibleForHandle && queuePtr != IntPtr.Zero)
-            {
-                CLException.ThrowIfFailed(
-                    CurrentAPI.ReleaseCommandQueue(queuePtr));
-                queuePtr = IntPtr.Zero;
-            }
-            base.Dispose(disposing);
+            if (!responsibleForHandle || queuePtr == IntPtr.Zero)
+                return;
+
+            CLException.VerifyDisposed(
+                disposing,
+                CurrentAPI.ReleaseCommandQueue(queuePtr));
+            queuePtr = IntPtr.Zero;
         }
 
         #endregion


### PR DESCRIPTION
This PR fixes several critical concurrent resource deallocation issues (closes #367). The problems were related to the fact that the .Net GC and manual disposes could interfere with each other. Once a GC thread was already disposing an accelerator-related object, the user could *simultaneously* dispose the accelerator. While there were several synchronization mechanisms that prevented multiple threads from releasing the same object, it was possible that the user had already destroyed the accelerator instance while the GC thread was just activated at *the same time* and was just disposing an associated kernel/buffer object *in parallel* (already entered the internal object-defined `Dispose` function). Also, there was no guarantee that the current accelerator binding was well defined in the case of concurrent GC threads.

Note that this PR introduces *breaking* changes. This is necessary to avoid broken programs that can crash due to improperly managed object live times. In our case the `ExchangeBuffer` classes stored reference to an internally created memory buffer instance instead of referencing its parent container instance. This can easily lead to invalid free operations in the background.