### PR TITLE
Fixed support for SizeOf instruction.

### DIFF
--- a/Src/ILGPU/Frontend/CodeGenerator/Driver.cs
+++ b/Src/ILGPU/Frontend/CodeGenerator/Driver.cs
@@ -287,6 +287,10 @@ namespace ILGPU.Frontend
                     MakeLoadArrayLength();
                     return true;
 
+                case ILInstructionType.SizeOf:
+                    LoadSizeOf(instruction.GetArgumentAs<Type>());
+                    return true;
+
                 default:
                     return false;
             }

--- a/Src/ILGPU/IR/Types/TypeNode.cs
+++ b/Src/ILGPU/IR/Types/TypeNode.cs
@@ -191,10 +191,27 @@ namespace ILGPU.IR.Types
         /// <summary>
         /// Returns the basic value type.
         /// </summary>
-        public BasicValueType BasicValueType =>
-            this is PrimitiveType primitiveType
-            ? primitiveType.BasicValueType
-            : BasicValueType.None;
+        public BasicValueType BasicValueType
+        {
+            get
+            {
+                if (this is PrimitiveType primitiveType)
+                {
+                    return primitiveType.BasicValueType;
+                }
+                else if (this is PointerType pointerType)
+                {
+                    return pointerType.Size switch
+                    {
+                        4 => BasicValueType.Int32,
+                        8 => BasicValueType.Int64,
+                        _ => throw new NotImplementedException(),
+                    };
+                }
+
+                return BasicValueType.None;
+            }
+        }
 
         /// <summary>
         /// Returns all type flags.


### PR DESCRIPTION
As reported in https://github.com/m4rs-mt/ILGPU.Algorithms/issues/73, ILGPU is able to load the [Sizeof](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.sizeof?view=net-5.0) opcode, but does not translate the instruction.

This PR attempts to get the `Matrix4x4.Decompose` function to compile in an ILGPU kernel.

