### PR TITLE
Changed to official T4 text transformation tool.

### DIFF
--- a/Src/.config/dotnet-tools.json
+++ b/Src/.config/dotnet-tools.json
@@ -2,8 +2,8 @@
   "version": 1,
   "isRoot": true,
   "tools": {
-    "dotnet-t4-fix": {
-      "version": "2.3.0-preview-0000-gb1ee03d9bc",
+    "dotnet-t4": {
+      "version": "2.2.0",
       "commands": [
         "t4"
       ]


### PR DESCRIPTION
The [official T4 text transformation tool](https://github.com/mono/t4) used to have [an issue compiling our T4 templates](https://github.com/m4rs-mt/ILGPU/pull/117#discussion_r428334222). They recently released a new version which appears to work as expected.