### PR TITLE
Additional kernel information for compiled kernels

### DIFF
--- a/Src/ILGPU/Backends/CompiledKernel.cs
+++ b/Src/ILGPU/Backends/CompiledKernel.cs
@@ -220,6 +220,11 @@ namespace ILGPU.Backends
         public KernelSpecialization Specialization => EntryPoint.Specialization;
 
         /// <summary>
+        /// Returns the number of uniform parameters.
+        /// </summary>
+        public int NumParameters => EntryPoint.Parameters.Count;
+
+        /// <summary>
         /// Returns the internally used entry point.
         /// </summary>
         internal EntryPoint EntryPoint { get; }

--- a/Src/ILGPU/Backends/EntryPoints/ArgumentMapper.cs
+++ b/Src/ILGPU/Backends/EntryPoints/ArgumentMapper.cs
@@ -351,15 +351,20 @@ namespace ILGPU.Backends.EntryPoints
             /// <summary>
             /// Constructs a new view source.
             /// </summary>
+            /// <param name="typeInformationManager">
+            /// The parent type information manager.
+            /// </param>
             /// <param name="source">The underlying source.</param>
             /// <param name="viewParameter">The view parameter to map.</param>
             public ViewSource(
+                TypeInformationManager typeInformationManager,
                 in TSource source,
                 in SeparateViewEntryPoint.ViewParameter viewParameter)
             {
                 Source = source;
                 SourceType = viewParameter.ViewType;
-                ParameterType = viewParameter.ParameterType;
+                ParameterType = typeInformationManager.GetTypeInfo(
+                    viewParameter.ParameterType);
                 AccessChain = viewParameter.SourceChain;
             }
 
@@ -914,10 +919,14 @@ namespace ILGPU.Backends.EntryPoints
         /// <typeparam name="TMappingHandler">The handler type.</typeparam>
         /// <param name="emitter">The target emitter to write to.</param>
         /// <param name="mappingHandler">The target mapping handler to use.</param>
+        /// <param name="typeInformationManager">
+        /// The parent type information manager.
+        /// </param>
         /// <param name="entryPoint">The entry point to use.</param>
         protected static void MapViews<TILEmitter, TMappingHandler>(
             in TILEmitter emitter,
             in TMappingHandler mappingHandler,
+            TypeInformationManager typeInformationManager,
             SeparateViewEntryPoint entryPoint)
             where TILEmitter : struct, IILEmitter
             where TMappingHandler : struct, ISeparateViewMappingHandler
@@ -948,6 +957,7 @@ namespace ILGPU.Backends.EntryPoints
                 foreach (var view in views)
                 {
                     var viewSource = new ViewSource<ArgumentSource>(
+                        typeInformationManager,
                         argumentSource,
                         view);
                     mappingHandler.MapViewArgument(

--- a/Src/ILGPU/Backends/EntryPoints/SeparateViewEntryPoint.cs
+++ b/Src/ILGPU/Backends/EntryPoints/SeparateViewEntryPoint.cs
@@ -50,7 +50,7 @@ namespace ILGPU.Backends.EntryPoints
             /// <param name="viewType">The source view type.</param>
             internal ViewParameter(
                 int index,
-                in (TypeInformationManager.TypeInformation, int) parameter,
+                in (Type, int) parameter,
                 FieldAccessChain sourceChain,
                 FieldAccess targetAccess,
                 Type elementType,
@@ -77,7 +77,7 @@ namespace ILGPU.Backends.EntryPoints
             /// <summary>
             /// Returns the associated parameter type.
             /// </summary>
-            public TypeInformationManager.TypeInformation ParameterType { get; }
+            public Type ParameterType { get; }
 
             /// <summary>
             /// Returns the associated kernel-parameter index.
@@ -279,7 +279,7 @@ namespace ILGPU.Backends.EntryPoints
                 int sourceIndex = builder.Count;
                 ResolveVirtualViewParameters(
                     builder,
-                    (typeInfo, i),
+                    (typeInfo.ManagedType, i),
                     typeInfo,
                     FieldAccessChain.Empty,
                     new FieldAccess(0));
@@ -308,7 +308,7 @@ namespace ILGPU.Backends.EntryPoints
         /// <param name="targetAccess">The target field access.</param>
         private void ResolveVirtualViewParameters(
             ImmutableArray<ViewParameter>.Builder builder,
-            in (TypeInformationManager.TypeInformation, int) parameter,
+            in (Type, int) parameter,
             TypeInformationManager.TypeInformation type,
             FieldAccessChain sourceChain,
             FieldAccess targetAccess)

--- a/Src/ILGPU/Backends/OpenCL/CLArgumentMapper.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLArgumentMapper.cs
@@ -12,6 +12,7 @@
 using ILGPU.Backends.EntryPoints;
 using ILGPU.Backends.IL;
 using ILGPU.Backends.SeparateViews;
+using ILGPU.IR.Types;
 using ILGPU.Runtime;
 using ILGPU.Runtime.OpenCL;
 using System;
@@ -369,10 +370,14 @@ namespace ILGPU.Backends.OpenCL
         /// <typeparam name="TILEmitter">The emitter type.</typeparam>
         /// <param name="emitter">The target emitter to write to.</param>
         /// <param name="kernel">A local that holds the kernel driver reference.</param>
+        /// <param name="typeInformationManager">
+        /// The parent type information manager.
+        /// </param>
         /// <param name="entryPoint">The entry point.</param>
         public void Map<TILEmitter>(
             in TILEmitter emitter,
             ILLocal kernel,
+            TypeInformationManager typeInformationManager,
             SeparateViewEntryPoint entryPoint)
             where TILEmitter : struct, IILEmitter
         {
@@ -396,7 +401,11 @@ namespace ILGPU.Backends.OpenCL
                 kernel,
                 resultLocal,
                 baseOffset);
-            MapViews(emitter, viewMappingHandler, entryPoint);
+            MapViews(
+                emitter,
+                viewMappingHandler,
+                typeInformationManager,
+                entryPoint);
 
             // Map implicit kernel length (if required)
             int parameterOffset = entryPoint.NumViewParameters + baseOffset;

--- a/Src/ILGPU/Runtime/Kernel.cs
+++ b/Src/ILGPU/Runtime/Kernel.cs
@@ -277,9 +277,8 @@ namespace ILGPU.Runtime
             : base(accelerator)
         {
             Debug.Assert(compiledKernel != null, "Invalid compiled kernel");
-            Specialization = compiledKernel.Specialization;
+            CompiledKernel = compiledKernel;
             Launcher = launcher;
-            NumParameters = compiledKernel.EntryPoint.Parameters.Count;
         }
 
         #endregion
@@ -294,12 +293,26 @@ namespace ILGPU.Runtime
         /// <summary>
         /// Returns the associated specialization.
         /// </summary>
-        public KernelSpecialization Specialization { get; }
+        public KernelSpecialization Specialization => CompiledKernel.Specialization;
 
         /// <summary>
         /// Returns the number of uniform parameters.
         /// </summary>
-        public int NumParameters { get; }
+        public int NumParameters => CompiledKernel.NumParameters;
+
+        /// <summary>
+        /// Returns information about all functions in the compiled kernel.
+        /// </summary>
+        /// <remarks>
+        /// This instance will be available when the
+        /// <see cref="ContextFlags.EnableKernelStatistics"/> is set.
+        /// </remarks>
+        public CompiledKernel.KernelInfo Info => CompiledKernel.Info;
+
+        /// <summary>
+        /// Returns the associated compiled kernel object.
+        /// </summary>
+        public CompiledKernel CompiledKernel { get; }
 
         #endregion
 
@@ -411,5 +424,45 @@ namespace ILGPU.Runtime
             kernelDelegate.TryGetKernel(out var kernel)
             ? kernel
             : throw new InvalidOperationException();
+
+        /// <summary>
+        /// Returns the compiled kernel object that is associated with the given kernel
+        /// delegate handle.
+        /// </summary>
+        /// <typeparam name="TDelegate">The kernel-delegate type.</typeparam>
+        /// <param name="kernelDelegate">The kernel-delegate instance.</param>
+        /// <returns>The compiled kernel object.</returns>
+        public static CompiledKernel GetCompiledKernel<TDelegate>(
+            this TDelegate kernelDelegate)
+            where TDelegate : Delegate =>
+            kernelDelegate.GetKernel().CompiledKernel;
+
+        /// <summary>
+        /// Returns the kernel specialization that is associated with the given kernel
+        /// delegate handle.
+        /// </summary>
+        /// <typeparam name="TDelegate">The kernel-delegate type.</typeparam>
+        /// <param name="kernelDelegate">The kernel-delegate instance.</param>
+        /// <returns>The kernel specialization instance.</returns>
+        public static KernelSpecialization GetKernelSpecialization<TDelegate>(
+            this TDelegate kernelDelegate)
+            where TDelegate : Delegate =>
+            kernelDelegate.GetKernel().Specialization;
+
+        /// <summary>
+        /// Returns the kernel compilation information (if any) that is associated with
+        /// the given kernel delegate handle.
+        /// </summary>
+        /// <typeparam name="TDelegate">The kernel-delegate type.</typeparam>
+        /// <param name="kernelDelegate">The kernel-delegate instance.</param>
+        /// <returns>The kernel specialization instance.</returns>
+        /// <remarks>
+        /// This instance will be available when the
+        /// <see cref="ContextFlags.EnableKernelStatistics"/> is set.
+        /// </remarks>
+        public static CompiledKernel.KernelInfo GetKernelInfo<TDelegate>(
+            this TDelegate kernelDelegate)
+            where TDelegate : Delegate =>
+            kernelDelegate.GetKernel().Info;
     }
 }

--- a/Src/ILGPU/Runtime/OpenCL/CLAccelerator.cs
+++ b/Src/ILGPU/Runtime/OpenCL/CLAccelerator.cs
@@ -716,7 +716,11 @@ namespace ILGPU.Runtime.OpenCL
 
             // Map all kernel arguments
             var argumentMapper = Backend.ArgumentMapper;
-            argumentMapper.Map(emitter, kernelLocal, entryPoint);
+            argumentMapper.Map(
+                emitter,
+                kernelLocal,
+                Context.TypeContext,
+                entryPoint);
 
             // Load current driver API
             emitter.EmitCall(GetCLAPIMethod);


### PR DESCRIPTION
This PR adds additional utilities (and makes the necessary changes) to query additional information about kernels; also in the context of kernel launchers. This allows users to e.g. query the compiled assembly code and/or retrieve information about local/shared memory allocations.