### PR TITLE
Updated default optimization mode for Debug builds

### DIFF
--- a/Src/ILGPU/Context.cs
+++ b/Src/ILGPU/Context.cs
@@ -119,11 +119,7 @@ namespace ILGPU
         /// </summary>
         /// <param name="flags">The context flags.</param>
         public Context(ContextFlags flags)
-#if DEBUG
-            : this(flags, OptimizationLevel.Debug)
-#else
             : this(flags, OptimizationLevel.Release)
-#endif
         { }
 
         /// <summary>


### PR DESCRIPTION
This PR changes the default optimization mode for `Debug` builds to match the `Release`-build settings used in the `nuget` package.