### PR TITLE
Fixed alignment information in the presence of reinterpret casts.

### DIFF
--- a/Src/ILGPU.Tests/ArrayViews.cs
+++ b/Src/ILGPU.Tests/ArrayViews.cs
@@ -1,5 +1,7 @@
-﻿using System;
+﻿using ILGPU.Util;
+using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
@@ -574,6 +576,90 @@ namespace ILGPU.Tests
                 Execute((int)extent.Size, buffer.View, source.View);
             }
             Verify(buffer, expectedData);
+        }
+
+        internal static void ArrayViewVectorizedIOKernel<T, T2>(
+            Index1 index,
+            ArrayView<T> source,
+            ArrayView<T> target)
+            where T : unmanaged
+            where T2 : unmanaged
+        {
+            // Use compile-time known offsets to test the internal alignment rules
+
+            var nonVectorAlignedSource = source.GetSubView(1, 2);
+            var nonVectorAlignedCastedSource = nonVectorAlignedSource.Cast<T2>();
+
+            var nonVectorAlignedTarget = target.GetSubView(1, 2);
+            var nonVectorAlignedTargetCasted = nonVectorAlignedTarget.Cast<T2>();
+
+            // Load from source and write to target
+            T2 data = nonVectorAlignedCastedSource[index];
+            nonVectorAlignedTargetCasted[index] = data;
+
+            // Perform the same operations with compile-time known offsets
+
+            var vectorAlignedSource = source.GetSubView(2, 2);
+            var vectorAlignedCastedSource = vectorAlignedSource.Cast<T2>();
+
+            var vectorAlignedTarget = target.GetSubView(2, 2);
+            var vectorAlignedTargetCasted = vectorAlignedTarget.Cast<T2>();
+
+            // Load from source and write to target
+            T2 data2 = vectorAlignedCastedSource[index];
+            vectorAlignedTargetCasted[index] = data2;
+        }
+
+        public static TheoryData<object, object> VectorizedIOData =>
+            new TheoryData<object, object>
+            {
+                { default(int), default(PairStruct<int, int>) },
+                { default(long), default(PairStruct<long, long>) },
+                {
+                    default(PairStruct<int, int>),
+                    default(PairStruct<PairStruct<int, int>, PairStruct<int, int>>)
+                },
+                {
+                    default(PairStruct<long, long>),
+                    default(PairStruct<PairStruct<long, long>, PairStruct<long, long>>)
+                },
+
+                { default(float), default(PairStruct<float, float>) },
+                { default(double), default(PairStruct<double, double>) },
+                {
+                    default(PairStruct<float, float>),
+                    default(
+                        PairStruct<
+                            PairStruct<float, float>,
+                            PairStruct<float, float>>)
+                },
+                {
+                    default(PairStruct<double, double>),
+                    default(
+                        PairStruct<
+                            PairStruct<double, double>,
+                            PairStruct<double, double>>)
+                },
+            };
+
+        [Theory]
+        [MemberData(nameof(VectorizedIOData))]
+        [KernelMethod(nameof(ArrayViewVectorizedIOKernel))]
+        [SuppressMessage(
+            "Usage",
+            "xUnit1026:Theory methods should use all of their parameters")]
+        public void ArrayViewVectorizedIO<T, T2>(T sourceType, T2 targetType)
+            where T : unmanaged
+            where T2 : unmanaged
+        {
+            const int Length = 4;
+            using var source = Accelerator.Allocate<T>(Length);
+            using var target = Accelerator.Allocate<T2>(Length);
+
+            Execute<Index1, T, T2>(1, source.View, target.View.Cast<T>());
+
+            // Note that we don't have to check the result in this case. If the execution
+            // succeeds, we already know that the vectorized IO access worked as intended
         }
 
         internal static void ArrayViewAlignmentKernel<T>(

--- a/Src/ILGPU/ArrayView.cs
+++ b/Src/ILGPU/ArrayView.cs
@@ -346,7 +346,9 @@ namespace ILGPU
         [ViewIntrinsic(ViewIntrinsicKind.GetSubViewImplicitLength)]
         public ArrayView<T> GetSubView(long index)
         {
-            Trace.Assert(index >= 0 && index < Length, "Offset out of bounds");
+            Trace.Assert(
+                index >= 0 && index < Length || index == 0 && Length < 1,
+                "Offset out of bounds");
             return GetSubView(index, Length - index);
         }
 
@@ -374,8 +376,9 @@ namespace ILGPU
         [ViewIntrinsic(ViewIntrinsicKind.GetSubView)]
         public ArrayView<T> GetSubView(long index, long subViewLength)
         {
-            Trace.Assert(index >= 0 && index < Length, "Index out of bounds");
-            Trace.Assert(index < Length, "Index out of bounds");
+            Trace.Assert(
+                index >= 0 && index < Length || index == 0 && Length < 1,
+                "Index out of bounds");
             Trace.Assert(index + subViewLength <= Length, "Sub view out of range");
             index += Index;
             return new ArrayView<T>(Source, index, subViewLength);

--- a/Src/ILGPU/Backends/PTX/PTXCodeGenerator.Emitter.cs
+++ b/Src/ILGPU/Backends/PTX/PTXCodeGenerator.Emitter.cs
@@ -693,7 +693,8 @@ namespace ILGPU.Backends.PTX
                 int alignment = PointerAlignments.GetAlignment(
                     pointerValue,
                     safeAlignment);
-                var ranges = compoundRegister.Type.VectorizableFields;
+                var ranges = compoundRegister.Type.GetVectorizableFields(
+                    MaxVectorSizeInBytes);
                 for (int i = 0, e = ranges.Count; i < e; ++i)
                 {
                     var rangeEntry = ranges[i];

--- a/Src/ILGPU/Backends/PTX/PTXCodeGenerator.cs
+++ b/Src/ILGPU/Backends/PTX/PTXCodeGenerator.cs
@@ -18,7 +18,6 @@ using ILGPU.IR.Types;
 using ILGPU.IR.Values;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
 using System.Text;
 
 namespace ILGPU.Backends.PTX
@@ -53,6 +52,11 @@ namespace ILGPU.Backends.PTX
         /// The name for the globally registered dynamic shared memory alloca (if any).
         /// </summary>
         protected const string DynamicSharedMemoryAllocationName = "__dyn_shared_alloca";
+
+        /// <summary>
+        /// The maximum vector size in bytes (128 bits in PTX).
+        /// </summary>
+        private const int MaxVectorSizeInBytes = 128 / 8;
 
         #endregion
 

--- a/Src/ILGPU/IR/Analyses/Allocas.cs
+++ b/Src/ILGPU/IR/Analyses/Allocas.cs
@@ -363,7 +363,7 @@ namespace ILGPU.IR.Analyses
                 PhiValue phiValue => phiValue.Type,
                 PointerCast cast => cast.TargetElementType,
                 AddressSpaceCast cast =>
-                    (cast.TargetType as IAddressSpaceType).ElementType,
+                    (cast.TargetType as AddressSpaceType).ElementType,
                 NewView newView => newView.ViewElementType,
                 ViewCast cast => cast.TargetElementType,
                 SubViewValue subView => subView.ElementType,

--- a/Src/ILGPU/IR/Analyses/Allocas.cs
+++ b/Src/ILGPU/IR/Analyses/Allocas.cs
@@ -342,7 +342,7 @@ namespace ILGPU.IR.Analyses
         /// <param name="type">The type.</param>
         /// <returns>The compatible allocation alignment in bytes.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static int GetAllocaTypeAlignment(TypeNode type) =>
+        public static int GetAllocaTypeAlignment(TypeNode type) =>
             // Assume that we can align the type to an appropriate power of
             // 2 if the type size is compatible
             Utilities.IsPowerOf2(type.Size)

--- a/Src/ILGPU/IR/Analyses/PointerAddressSpaces.cs
+++ b/Src/ILGPU/IR/Analyses/PointerAddressSpaces.cs
@@ -484,7 +484,7 @@ namespace ILGPU.IR.Analyses
         /// <returns>The initial address space information.</returns>
         protected AddressSpaceInfo GetInitialInfo(Value node)
         {
-            if (!(node.Type is IAddressSpaceType type))
+            if (!(node.Type is AddressSpaceType type))
                 return default;
             return
                 type.AddressSpace != MemoryAddressSpace.Generic ||
@@ -515,12 +515,12 @@ namespace ILGPU.IR.Analyses
             TContext context) => null;
 
         /// <summary>
-        /// Tries to convert the given type into an <see cref="IAddressSpaceType"/>
+        /// Tries to convert the given type into an <see cref="AddressSpaceType"/>
         /// and returns the determined address space.
         /// </summary>
         protected override AnalysisValue<AddressSpaceInfo>?
             TryProvide(TypeNode typeNode) =>
-            typeNode is IAddressSpaceType spaceType
+            typeNode is AddressSpaceType spaceType
             ? AnalysisValue.Create<AddressSpaceInfo>(spaceType.AddressSpace, typeNode)
             : default(AnalysisValue<AddressSpaceInfo>?);
 

--- a/Src/ILGPU/IR/Construction/Memory.cs
+++ b/Src/ILGPU/IR/Construction/Memory.cs
@@ -222,7 +222,7 @@ namespace ILGPU.IR.Construction
             // Assert a valid indexing type from here on
             location.Assert(
                 IRTypeContext.IsViewIndexType(elementIndex.BasicValueType));
-            var addressSpaceType = source.Type as IAddressSpaceType;
+            var addressSpaceType = source.Type as AddressSpaceType;
             location.AssertNotNull(addressSpaceType);
 
             // Fold primitive pointer arithmetic that does not change anything

--- a/Src/ILGPU/IR/Transformations/InferAddressSpaces.cs
+++ b/Src/ILGPU/IR/Transformations/InferAddressSpaces.cs
@@ -58,7 +58,7 @@ namespace ILGPU.IR.Transformations
             /// Returns the target address space of the underling type.
             /// </summary>
             public readonly MemoryAddressSpace this[Value value] =>
-                value.Type is IAddressSpaceType type
+                value.Type is AddressSpaceType type
                 ? type.AddressSpace
                 : MemoryAddressSpace.Generic;
         }
@@ -204,7 +204,7 @@ namespace ILGPU.IR.Transformations
                     if (!call.Target.HasImplementation)
                         break;
                     var targetParam = call.Target.Parameters[use.Index];
-                    if (targetParam.Type is IAddressSpaceType &&
+                    if (targetParam.Type is AddressSpaceType &&
                         data[targetParam] == targetSpace)
                     {
                         return false;
@@ -215,7 +215,7 @@ namespace ILGPU.IR.Transformations
                 case ReturnTerminator _:
                     // We are not allowed to remove casts in the case of phi values,
                     // predicates and returns
-                    if (value.Type is IAddressSpaceType && data[value] == targetSpace)
+                    if (value.Type is AddressSpaceType && data[value] == targetSpace)
                         return false;
                     break;
                 case Store _:
@@ -264,7 +264,7 @@ namespace ILGPU.IR.Transformations
             TValue value)
             where TValue : Value
             where TProvider : IAddressSpaceProvider =>
-            value.Type is IAddressSpaceType type &&
+            value.Type is AddressSpaceType type &&
             type.AddressSpace != data[value];
 
         /// <summary>

--- a/Src/ILGPU/IR/Types/PointerTypes.cs
+++ b/Src/ILGPU/IR/Types/PointerTypes.cs
@@ -16,25 +16,9 @@ using System.Diagnostics;
 namespace ILGPU.IR.Types
 {
     /// <summary>
-    /// An abstract type that has an element type and an address space.
-    /// </summary>
-    public interface IAddressSpaceType
-    {
-        /// <summary>
-        /// Returns the underlying element type.
-        /// </summary>
-        TypeNode ElementType { get; }
-
-        /// <summary>
-        /// Returns the associated address space.
-        /// </summary>
-        MemoryAddressSpace AddressSpace { get; }
-    }
-
-    /// <summary>
     /// Represents an abstract type that relies on addresses.
     /// </summary>
-    public abstract class AddressSpaceType : TypeNode, IAddressSpaceType
+    public abstract class AddressSpaceType : TypeNode
     {
         #region Nested Types
 

--- a/Src/ILGPU/IR/Types/StructureType.cs
+++ b/Src/ILGPU/IR/Types/StructureType.cs
@@ -494,9 +494,16 @@ namespace ILGPU.IR.Types
                 public int Offset { get; }
 
                 /// <summary>
+                /// Returns the size of this chunk in bytes.
+                /// </summary>
+                public readonly int Size => Count * Type.Size;
+
+                /// <summary>
                 /// Returns the required alignment in bytes.
                 /// </summary>
-                public readonly int RequiredAlignment => Count * Type.Size;
+                public readonly int RequiredAlignment =>
+                    // The alignment is equal to the size in bytes
+                    Size;
 
                 #endregion
 
@@ -561,7 +568,10 @@ namespace ILGPU.IR.Types
             /// Constructs a new field collection.
             /// </summary>
             /// <param name="structureType">The parent structure type.</param>
-            internal VectorizableFieldCollection(StructureType structureType)
+            /// <param name="maxSizeInBytes">The maximum vector size in bytes.</param>
+            internal VectorizableFieldCollection(
+                StructureType structureType,
+                int maxSizeInBytes)
             {
                 structureType.Assert(structureType.NumFields > 0);
                 ranges = new List<Entry>(structureType.NumFields);
@@ -579,7 +589,8 @@ namespace ILGPU.IR.Types
                     // If the next type is not compatible or is not properly aligned
                     // we have to split at this point
                     if (current.Type != nextType ||
-                        currentOffset + nextType.Size != nextOffset)
+                        currentOffset + nextType.Size != nextOffset ||
+                        current.Size + nextType.Size > maxSizeInBytes)
                     {
                         // Register the current vectorizable entry
                         RegisterRange(structureType, current);
@@ -738,12 +749,6 @@ namespace ILGPU.IR.Types
         public OffsetCollection Offsets => new OffsetCollection(this);
 
         /// <summary>
-        /// Returns a readonly collection of all vectorized field configurations.
-        /// </summary>
-        public VectorizableFieldCollection VectorizableFields =>
-            new VectorizableFieldCollection(this);
-
-        /// <summary>
         /// Returns the number of associated fields.
         /// </summary>
         public int NumFields => Fields.Length;
@@ -758,6 +763,15 @@ namespace ILGPU.IR.Types
         #endregion
 
         #region Methods
+
+        /// <summary>
+        /// Returns a readonly collection of all vectorized field configurations that
+        /// do not exceed the maximum size in bytes.
+        /// </summary>
+        /// <param name="maxSizeInBytes">The maximum vector size in bytes.</param>
+        /// <returns>The vectorizable field collection.</returns>
+        public VectorizableFieldCollection GetVectorizableFields(int maxSizeInBytes) =>
+            new VectorizableFieldCollection(this, maxSizeInBytes);
 
         /// <summary>
         /// Gets a specific field offset in bytes from the beginning of the structure.

--- a/Src/ILGPU/IR/Values/PointerValues.cs
+++ b/Src/ILGPU/IR/Values/PointerValues.cs
@@ -56,7 +56,7 @@ namespace ILGPU.IR.Values
         /// <summary>
         /// Returns the view element type.
         /// </summary>
-        public IAddressSpaceType AddressSpaceType => Type as IAddressSpaceType;
+        public AddressSpaceType AddressSpaceType => Type as AddressSpaceType;
 
         /// <summary>
         /// Returns the pointer address space.
@@ -194,7 +194,7 @@ namespace ILGPU.IR.Values
         /// <summary cref="Value.ComputeType(in ValueInitializer)"/>
         protected override TypeNode ComputeType(in ValueInitializer initializer)
         {
-            var sourceType = Source.Type as IAddressSpaceType;
+            var sourceType = Source.Type as AddressSpaceType;
             Location.AssertNotNull(sourceType);
 
             return sourceType is PointerType


### PR DESCRIPTION
The use of reinterpret casts can cause the internal analyses to determine invalid alignment information. This can lead to the emission of vectorized IO instructions that access memory locations that are not correctly aligned. This PR fixes these alignment issues and adds additional constraints on the maximum bit width of vectorized instructions (e.g. 128 bits in PTX).