### PR TITLE
Refined CudaAPI to use UVA-based operations

### DIFF
--- a/Src/ILGPU/Runtime/CPU/CPUMemoryBuffer.cs
+++ b/Src/ILGPU/Runtime/CPU/CPUMemoryBuffer.cs
@@ -11,10 +11,10 @@
 
 using ILGPU.Resources;
 using ILGPU.Runtime.Cuda;
+using ILGPU.Runtime.OpenCL;
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using static ILGPU.Runtime.Cuda.CudaAPI;
 
 namespace ILGPU.Runtime.CPU
 {
@@ -101,11 +101,21 @@ namespace ILGPU.Runtime.CPU
                     break;
                 case AcceleratorType.Cuda:
                     CudaException.ThrowIfFailed(
-                        CurrentAPI.MemcpyHostToDevice(
+                        CudaAPI.CurrentAPI.MemcpyAsync(
                             new IntPtr(targetAddress),
                             new IntPtr(sourceAddress),
                             new IntPtr(target.LengthInBytes),
                             stream));
+                    break;
+                case AcceleratorType.OpenCL:
+                    CLException.ThrowIfFailed(
+                        CLAPI.CurrentAPI.WriteBuffer(
+                        stream,
+                        target.Source.NativePtr,
+                        false,
+                        new IntPtr(target.Index * ElementSize),
+                        new IntPtr(target.LengthInBytes),
+                        new IntPtr(sourceAddress)));
                     break;
                 default:
                     throw new NotSupportedException(
@@ -137,11 +147,21 @@ namespace ILGPU.Runtime.CPU
                     break;
                 case AcceleratorType.Cuda:
                     CudaException.ThrowIfFailed(
-                        CurrentAPI.MemcpyDeviceToHost(
+                        CudaAPI.CurrentAPI.MemcpyAsync(
                             new IntPtr(targetAddress),
                             new IntPtr(sourceAddress),
                             new IntPtr(source.LengthInBytes),
                             stream));
+                    break;
+                case AcceleratorType.OpenCL:
+                    CLException.ThrowIfFailed(
+                        CLAPI.CurrentAPI.ReadBuffer(
+                            stream,
+                            NativePtr,
+                            false,
+                            new IntPtr(sourceAddress),
+                            new IntPtr(source.LengthInBytes),
+                            new IntPtr(targetAddress)));
                     break;
                 default:
                     throw new NotSupportedException(

--- a/Src/ILGPU/Runtime/Cuda/CudaAPI.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaAPI.cs
@@ -146,7 +146,7 @@ namespace ILGPU.Runtime.Cuda
         /// <param name="attribute">The device attribute.</param>
         /// <param name="device">The device.</param>
         /// <returns>The resolved value.</returns>
-        internal int GetDeviceAttribute(DeviceAttribute attribute, int device)
+        public int GetDeviceAttribute(DeviceAttribute attribute, int device)
         {
             CudaException.ThrowIfFailed(
                 cuDeviceGetAttribute(out int value, attribute, device));
@@ -373,149 +373,23 @@ namespace ILGPU.Runtime.Cuda
         /// <param name="source">The source.</param>
         /// <param name="length">The number of bytes to copy.</param>
         /// <returns>The error status.</returns>
-        public CudaError Memcpy(
+        /// <param name="stream">
+        /// The accelerator stream for asynchronous processing.
+        /// </param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public CudaError MemcpyAsync(
             IntPtr destination,
             IntPtr source,
-            IntPtr length) =>
-            cuMemcpy(destination, source, length);
-
-        /// <summary>
-        /// Performs a memory-copy operation from host to device memory.
-        /// </summary>
-        /// <param name="destinationDevice">The destination in device memory.</param>
-        /// <param name="sourceHost">The source in host memory.</param>
-        /// <param name="length">The number of bytes to copy.</param>
-        /// <param name="stream">
-        /// The accelerator stream for asynchronous processing.
-        /// </param>
-        /// <returns>The error status.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public CudaError MemcpyHostToDevice(
-            IntPtr destinationDevice,
-            IntPtr sourceHost,
             IntPtr length,
             AcceleratorStream stream)
         {
-            CudaStream cudaStream = stream as CudaStream;
-            return MemcpyHostToDevice(
-                destinationDevice,
-                sourceHost,
+            var cudaStream = stream as CudaStream;
+            return cuMemcpyAsync(
+                destination,
+                source,
                 length,
                 cudaStream?.StreamPtr ?? IntPtr.Zero);
         }
-
-        /// <summary>
-        /// Performs a memory-copy operation from host to device memory.
-        /// </summary>
-        /// <param name="destinationDevice">The destination in device memory.</param>
-        /// <param name="sourceHost">The source in host memory.</param>
-        /// <param name="length">The number of bytes to copy.</param>
-        /// <param name="stream">
-        /// The accelerator stream for asynchronous processing.
-        /// </param>
-        /// <returns>The error status.</returns>
-        public CudaError MemcpyHostToDevice(
-            IntPtr destinationDevice,
-            IntPtr sourceHost,
-            IntPtr length,
-            IntPtr stream) =>
-            cuMemcpyHtoDAsync_v2(
-                destinationDevice,
-                sourceHost,
-                length,
-                stream);
-
-        /// <summary>
-        /// Performs a memory-copy operation from device to host memory.
-        /// </summary>
-        /// <param name="destinationHost">The destination in host memory.</param>
-        /// <param name="sourceDevice">The source in device memory.</param>
-        /// <param name="length">The number of bytes to copy.</param>
-        /// <param name="stream">
-        /// The accelerator stream for asynchronous processing.
-        /// </param>
-        /// <returns>The error status.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public CudaError MemcpyDeviceToHost(
-            IntPtr destinationHost,
-            IntPtr sourceDevice,
-            IntPtr length,
-            AcceleratorStream stream)
-        {
-            CudaStream cudaStream = stream as CudaStream;
-            return MemcpyDeviceToHost(
-                destinationHost,
-                sourceDevice,
-                length,
-                cudaStream?.StreamPtr ?? IntPtr.Zero);
-        }
-
-        /// <summary>
-        /// Performs a memory-copy operation from device to host memory.
-        /// </summary>
-        /// <param name="destinationHost">The destination in host memory.</param>
-        /// <param name="sourceDevice">The source in device memory.</param>
-        /// <param name="length">The number of bytes to copy.</param>
-        /// <param name="stream">
-        /// The accelerator stream for asynchronous processing.
-        /// </param>
-        /// <returns>The error status.</returns>
-        public CudaError MemcpyDeviceToHost(
-            IntPtr destinationHost,
-            IntPtr sourceDevice,
-            IntPtr length,
-            IntPtr stream) =>
-            cuMemcpyDtoHAsync_v2(
-                destinationHost,
-                sourceDevice,
-                length,
-                stream);
-
-        /// <summary>
-        /// Performs a memory-copy operation from device to device memory.
-        /// </summary>
-        /// <param name="destinationDevice">The destination in device memory.</param>
-        /// <param name="sourceDevice">The source in device memory.</param>
-        /// <param name="length">The number of bytes to copy.</param>
-        /// <param name="stream">
-        /// The accelerator stream for asynchronous processing.
-        /// </param>
-        /// <returns>The error status.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public CudaError MemcpyDeviceToDevice(
-            IntPtr destinationDevice,
-            IntPtr sourceDevice,
-            IntPtr length,
-            AcceleratorStream stream)
-        {
-            CudaStream cudaStream = stream as CudaStream;
-            return MemcpyDeviceToDevice(
-                destinationDevice,
-                sourceDevice,
-                length,
-                cudaStream?.StreamPtr ?? IntPtr.Zero);
-        }
-
-        /// <summary>
-        /// Performs a memory-copy operation from device to device memory.
-        /// </summary>
-        /// <param name="destinationDevice">The destination in device memory.</param>
-        /// <param name="sourceDevice">The source in device memory.</param>
-        /// <param name="length">The number of bytes to copy.</param>
-        /// <param name="stream">
-        /// The accelerator stream for asynchronous processing.
-        /// </param>
-        /// <returns>The error status.</returns>
-        public CudaError MemcpyDeviceToDevice(
-            IntPtr destinationDevice,
-            IntPtr sourceDevice,
-            IntPtr length,
-            IntPtr stream) =>
-            cuMemcpyDtoDAsync_v2(
-                destinationDevice,
-                sourceDevice,
-                length,
-                stream);
 
         /// <summary>
         /// Performs a memory-set operation.

--- a/Src/ILGPU/Runtime/Cuda/CudaAPI.xml
+++ b/Src/ILGPU/Runtime/Cuda/CudaAPI.xml
@@ -101,26 +101,9 @@
     <Import Name="cuMemFreeHost">
         <Parameter Name="devicePtr" Type="IntPtr" />
     </Import>
-    <Import Name="cuMemcpy">
+    <Import Name="cuMemcpyAsync">
         <Parameter Name="destination" Type="IntPtr" />
         <Parameter Name="source" Type="IntPtr" />
-        <Parameter Name="length" Type="IntPtr" />
-    </Import>
-    <Import Name="cuMemcpyHtoDAsync_v2">
-        <Parameter Name="destinationDevice" Type="IntPtr" />
-        <Parameter Name="sourceHost" Type="IntPtr" />
-        <Parameter Name="length" Type="IntPtr" />
-        <Parameter Name="stream" Type="IntPtr" />
-    </Import>
-    <Import Name="cuMemcpyDtoHAsync_v2">
-        <Parameter Name="destinationHost" Type="IntPtr" />
-        <Parameter Name="sourceDevice" Type="IntPtr" />
-        <Parameter Name="length" Type="IntPtr" />
-        <Parameter Name="stream" Type="IntPtr" />
-    </Import>
-    <Import Name="cuMemcpyDtoDAsync_v2">
-        <Parameter Name="destinationDevice" Type="IntPtr" />
-        <Parameter Name="sourceDevice" Type="IntPtr" />
         <Parameter Name="length" Type="IntPtr" />
         <Parameter Name="stream" Type="IntPtr" />
     </Import>

--- a/Src/ILGPU/Runtime/Cuda/CudaMemoryBuffer.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaMemoryBuffer.cs
@@ -61,16 +61,9 @@ namespace ILGPU.Runtime.Cuda
             switch (targetBuffer.AcceleratorType)
             {
                 case AcceleratorType.CPU:
-                    CudaException.ThrowIfFailed(
-                        CurrentAPI.MemcpyDeviceToHost(
-                            targetAddress,
-                            sourceAddress,
-                            lengthInBytes,
-                            stream));
-                    break;
                 case AcceleratorType.Cuda:
                     CudaException.ThrowIfFailed(
-                        CurrentAPI.MemcpyDeviceToDevice(
+                        CurrentAPI.MemcpyAsync(
                             targetAddress,
                             sourceAddress,
                             lengthInBytes,
@@ -99,16 +92,9 @@ namespace ILGPU.Runtime.Cuda
             switch (source.AcceleratorType)
             {
                 case AcceleratorType.CPU:
-                    CudaException.ThrowIfFailed(
-                        CurrentAPI.MemcpyHostToDevice(
-                            targetAddress,
-                            sourceAddress,
-                            lengthInBytes,
-                            stream));
-                    break;
                 case AcceleratorType.Cuda:
                     CudaException.ThrowIfFailed(
-                        CurrentAPI.MemcpyDeviceToDevice(
+                        CurrentAPI.MemcpyAsync(
                             targetAddress,
                             sourceAddress,
                             lengthInBytes,

--- a/Src/ILGPU/Runtime/Cuda/CudaNativeMethods.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaNativeMethods.cs
@@ -48,7 +48,7 @@ namespace ILGPU.Runtime.Cuda
         TCC = 1,
     }
 
-    enum DeviceAttribute
+    public enum DeviceAttribute
     {
         CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK = 1,
         CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X = 2,

--- a/Src/ILGPU/Runtime/OpenCL/CLAPI.cs
+++ b/Src/ILGPU/Runtime/OpenCL/CLAPI.cs
@@ -925,7 +925,9 @@ namespace ILGPU.Runtime.OpenCL
         /// <summary>
         /// Reads from a buffer into host memory.
         /// </summary>
-        /// <param name="queue">The queue.</param>
+        /// <param name="stream">
+        /// The accelerator stream for asynchronous processing.
+        /// </param>
         /// <param name="buffer">The source buffer to read from.</param>
         /// <param name="blockingRead">
         /// True, if the operation blocks until completion.
@@ -936,16 +938,17 @@ namespace ILGPU.Runtime.OpenCL
         /// <returns>The error code.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public CLError ReadBuffer(
-            IntPtr queue,
+            AcceleratorStream stream,
             IntPtr buffer,
             bool blockingRead,
             IntPtr offset,
             IntPtr size,
             IntPtr ptr)
         {
-            CLException.ThrowIfFailed(EnqueueBarrier(queue));
+            var clStream = stream as CLStream;
+            CLException.ThrowIfFailed(EnqueueBarrier(clStream.CommandQueue));
             return clEnqueueReadBuffer(
-                queue,
+                clStream.CommandQueue,
                 buffer,
                 blockingRead,
                 offset,
@@ -959,7 +962,9 @@ namespace ILGPU.Runtime.OpenCL
         /// <summary>
         /// Writes to a buffer from host memory.
         /// </summary>
-        /// <param name="queue">The queue.</param>
+        /// <param name="stream">
+        /// The accelerator stream for asynchronous processing.
+        /// </param>
         /// <param name="buffer">The target buffer to write to.</param>
         /// <param name="blockingWrite">
         /// True, if the operation blocks until completion.
@@ -970,16 +975,17 @@ namespace ILGPU.Runtime.OpenCL
         /// <returns>The error code.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public CLError WriteBuffer(
-            IntPtr queue,
+            AcceleratorStream stream,
             IntPtr buffer,
             bool blockingWrite,
             IntPtr offset,
             IntPtr size,
             IntPtr ptr)
         {
-            CLException.ThrowIfFailed(EnqueueBarrier(queue));
+            var clStream = stream as CLStream;
+            CLException.ThrowIfFailed(EnqueueBarrier(clStream.CommandQueue));
             return clEnqueueWriteBuffer(
-                queue,
+                clStream.CommandQueue,
                 buffer,
                 blockingWrite,
                 offset,
@@ -994,7 +1000,9 @@ namespace ILGPU.Runtime.OpenCL
         /// Fills the given buffer with the specified pattern.
         /// </summary>
         /// <typeparam name="T">The data type used for filling.</typeparam>
-        /// <param name="queue">The queue.</param>
+        /// <param name="stream">
+        /// The accelerator stream for asynchronous processing.
+        /// </param>
         /// <param name="buffer">The target buffer to fill.</param>
         /// <param name="pattern">The pattern value used for filling.</param>
         /// <param name="offset">The target offset in bytes.</param>
@@ -1002,16 +1010,17 @@ namespace ILGPU.Runtime.OpenCL
         /// <returns>The error code.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public CLError FillBuffer<T>(
-            IntPtr queue,
+            AcceleratorStream stream,
             IntPtr buffer,
             T pattern,
             IntPtr offset,
             IntPtr size)
             where T : unmanaged
         {
-            CLException.ThrowIfFailed(EnqueueBarrier(queue));
+            var clStream = stream as CLStream;
+            CLException.ThrowIfFailed(EnqueueBarrier(clStream.CommandQueue));
             return clEnqueueFillBuffer(
-                queue,
+                clStream.CommandQueue,
                 buffer,
                 Unsafe.AsPointer(ref pattern),
                 new IntPtr(Interop.SizeOf<T>()),
@@ -1025,7 +1034,9 @@ namespace ILGPU.Runtime.OpenCL
         /// <summary>
         /// Copies the contents of the source buffer into the target buffer.
         /// </summary>
-        /// <param name="queue">The queue.</param>
+        /// <param name="stream">
+        /// The accelerator stream for asynchronous processing.
+        /// </param>
         /// <param name="sourceBuffer">The source buffer.</param>
         /// <param name="targetBuffer">The target buffer.</param>
         /// <param name="sourceOffset">
@@ -1038,16 +1049,17 @@ namespace ILGPU.Runtime.OpenCL
         /// <returns>The error code.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public CLError CopyBuffer(
-            IntPtr queue,
+            AcceleratorStream stream,
             IntPtr sourceBuffer,
             IntPtr targetBuffer,
             IntPtr sourceOffset,
             IntPtr targetOffset,
             IntPtr size)
         {
-            CLException.ThrowIfFailed(EnqueueBarrier(queue));
+            var clStream = stream as CLStream;
+            CLException.ThrowIfFailed(EnqueueBarrier(clStream.CommandQueue));
             return clEnqueueCopyBuffer(
-                queue,
+                clStream.CommandQueue,
                 sourceBuffer,
                 targetBuffer,
                 sourceOffset,

--- a/Src/ILGPU/Runtime/OpenCL/CLMemoryBuffer.cs
+++ b/Src/ILGPU/Runtime/OpenCL/CLMemoryBuffer.cs
@@ -56,14 +56,13 @@ namespace ILGPU.Runtime.OpenCL
             LongIndex1 sourceOffset)
         {
             var binding = Accelerator.BindScoped();
-            var clStream = (CLStream)stream;
 
             switch (target.AcceleratorType)
             {
                 case AcceleratorType.CPU:
                     CLException.ThrowIfFailed(
                         CurrentAPI.ReadBuffer(
-                            clStream.CommandQueue,
+                            stream,
                             NativePtr,
                             false,
                             new IntPtr(sourceOffset * ElementSize),
@@ -73,7 +72,7 @@ namespace ILGPU.Runtime.OpenCL
                 case AcceleratorType.OpenCL:
                     CLException.ThrowIfFailed(
                         CurrentAPI.CopyBuffer(
-                            clStream.CommandQueue,
+                            stream,
                             NativePtr,
                             target.Source.NativePtr,
                             new IntPtr(sourceOffset * ElementSize),
@@ -96,14 +95,13 @@ namespace ILGPU.Runtime.OpenCL
             LongIndex1 targetOffset)
         {
             var binding = Accelerator.BindScoped();
-            var clStream = (CLStream)stream;
 
             switch (source.AcceleratorType)
             {
                 case AcceleratorType.CPU:
                     CLException.ThrowIfFailed(
                         CurrentAPI.WriteBuffer(
-                            clStream.CommandQueue,
+                            stream,
                             NativePtr,
                             false,
                             new IntPtr(targetOffset * ElementSize),
@@ -113,7 +111,7 @@ namespace ILGPU.Runtime.OpenCL
                 case AcceleratorType.OpenCL:
                     CLException.ThrowIfFailed(
                         CurrentAPI.CopyBuffer(
-                            clStream.CommandQueue,
+                            stream,
                             source.Source.NativePtr,
                             NativePtr,
                             new IntPtr(source.Index * ElementSize),
@@ -139,7 +137,7 @@ namespace ILGPU.Runtime.OpenCL
 
             CLException.ThrowIfFailed(
                 CurrentAPI.FillBuffer(
-                    ((CLStream)stream).CommandQueue,
+                    stream,
                     NativePtr,
                     value,
                     new IntPtr(offsetInBytes),


### PR DESCRIPTION
This PR refines the current `CudaAPI` implementation to use UVA (unified virtual addressing) features instead of explicit copy operations that define the source and the origin each time (CPU->GPU, GPU->GPU, etc.). It also includes minor changes to the `CLAPI` implementation to accept high level `AcceleratorStream` instead of implementation specific queue pointers of type `IntPtr`.

This PR might fix #378. Current status: waiting for feedback.