### PR TITLE
Enhanced Accelerator information

### DIFF
--- a/Src/ILGPU/Runtime/Accelerator.cs
+++ b/Src/ILGPU/Runtime/Accelerator.cs
@@ -16,6 +16,7 @@ using ILGPU.Util;
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.IO;
 using System.Threading;
 
 namespace ILGPU.Runtime
@@ -192,19 +193,24 @@ namespace ILGPU.Runtime
         }
 
         /// <summary>
-        /// Returns the memory size in bytes.
-        /// </summary>
-        public long MemorySize { get; protected set; }
-
-        /// <summary>
         /// Returns the name of the device.
         /// </summary>
         public string Name { get; protected set; }
 
         /// <summary>
+        /// Returns the memory size in bytes.
+        /// </summary>
+        public long MemorySize { get; protected set; }
+
+        /// <summary>
         /// Returns the max grid size.
         /// </summary>
         public Index3 MaxGridSize { get; protected set; }
+
+        /// <summary>
+        /// Returns the max group size.
+        /// </summary>
+        public Index3 MaxGroupSize { get; protected set; }
 
         /// <summary>
         /// Returns the maximum number of threads in a group.
@@ -445,6 +451,78 @@ namespace ILGPU.Runtime
                 ClearLaunchCache_SyncRoot();
                 base.ClearCache(mode);
             }
+        }
+
+        /// <summary>
+        /// Prints device information to the standard <see cref="Console.Out"/> stream.
+        /// </summary>
+        public void PrintInformation() => PrintInformation(Console.Out);
+
+        /// <summary>
+        /// Prints device information to the given text writer.
+        /// </summary>
+        /// <param name="writer">The target text writer to write to.</param>
+        public void PrintInformation(TextWriter writer)
+        {
+            if (writer is null)
+                throw new ArgumentNullException(nameof(writer));
+
+            PrintHeader(writer);
+            PrintGeneralInfo(writer);
+        }
+
+        /// <summary>
+        /// Prints general header information that should appear at the top.
+        /// </summary>
+        /// <param name="writer">The target text writer to write to.</param>
+        protected virtual void PrintHeader(TextWriter writer)
+        {
+            writer.Write("Device: ");
+            writer.Write(Name);
+            writer.WriteLine(" [ILGPU InstanceId: {0}]", InstanceId);
+        }
+
+        /// <summary>
+        /// Print general GPU specific information to the given text writer.
+        /// </summary>
+        /// <param name="writer">The target text writer to write to.</param>
+        protected virtual void PrintGeneralInfo(TextWriter writer)
+        {
+            writer.Write("  Number of multiprocessors:               ");
+            writer.WriteLine(NumMultiprocessors);
+
+            writer.Write("  Max number of threads/multiprocessor:    ");
+            writer.WriteLine(MaxNumThreadsPerMultiprocessor);
+
+            writer.Write("  Max number of threads/group:             ");
+            writer.WriteLine(MaxNumThreadsPerGroup);
+
+            writer.Write("  Max number of total threads:             ");
+            writer.WriteLine(MaxNumThreads);
+
+            writer.Write("  Max dimension of a group size:           ");
+            writer.WriteLine(MaxGroupSize.ToString());
+
+            writer.Write("  Max dimension of a grid size:            ");
+            writer.WriteLine(MaxGridSize.ToString());
+
+            writer.Write("  Total amount of global memory:           ");
+            writer.WriteLine(
+                "{0} bytes, {1} MB",
+                MemorySize,
+                MemorySize / (1024 * 1024));
+
+            writer.Write("  Total amount of constant memory:         ");
+            writer.WriteLine(
+                "{0} bytes, {1} KB",
+                MaxConstantMemory,
+                MaxConstantMemory / 1024);
+
+            writer.Write("  Total amount of shared memory per group: ");
+            writer.WriteLine(
+                "{0} bytes, {1} KB",
+                MaxSharedMemoryPerGroup,
+                MaxSharedMemoryPerGroup / 1024);
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/CPU/CPUAccelerator.cs
+++ b/Src/ILGPU/Runtime/CPU/CPUAccelerator.cs
@@ -116,6 +116,10 @@ namespace ILGPU.Runtime.CPU
             MemorySize = long.MaxValue;
             MaxGridSize = new Index3(int.MaxValue, int.MaxValue, int.MaxValue);
             MaxNumThreadsPerGroup = NumThreads;
+            MaxGroupSize = new Index3(
+                MaxNumThreadsPerGroup,
+                MaxNumThreadsPerGroup,
+                MaxNumThreadsPerGroup);
             MaxSharedMemoryPerGroup = CPURuntimeGroupContext.SharedMemorySize;
             MaxConstantMemory = int.MaxValue;
             NumMultiprocessors = 1;

--- a/Src/ILGPU/Runtime/Cuda/CudaNativeMethods.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaNativeMethods.cs
@@ -32,6 +32,22 @@ namespace ILGPU.Runtime.Cuda
         CU_STREAM_NON_BLOCKING = 1
     }
 
+    /// <summary>
+    /// Represents the device driver mode of a particular Cuda device.
+    /// </summary>
+    public enum DeviceDriverMode : int
+    {
+        /// <summary>
+        /// The Windows Display Driver Model.
+        /// </summary>
+        WDDM = 0,
+
+        /// <summary>
+        /// The Tesla Compute Cluster Driver.
+        /// </summary>
+        TCC = 1,
+    }
+
     enum DeviceAttribute
     {
         CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK = 1,

--- a/Src/ILGPU/Runtime/OpenCL/CLAccelerator.cs
+++ b/Src/ILGPU/Runtime/OpenCL/CLAccelerator.cs
@@ -15,6 +15,7 @@ using ILGPU.Resources;
 using ILGPU.Util;
 using System;
 using System.Collections.Immutable;
+using System.IO;
 using System.Reflection;
 using System.Reflection.Emit;
 using static ILGPU.Runtime.OpenCL.CLAPI;
@@ -273,6 +274,10 @@ namespace ILGPU.Runtime.OpenCL
             MaxNumThreadsPerGroup = CurrentAPI.GetDeviceInfo<IntPtr>(
                 DeviceId,
                 CLDeviceInfoType.CL_DEVICE_MAX_WORK_GROUP_SIZE).ToInt32();
+            MaxGroupSize = new Index3(
+                MaxNumThreadsPerGroup,
+                MaxNumThreadsPerGroup,
+                MaxNumThreadsPerGroup);
 
             // Resolve max shared memory per block
             MaxSharedMemoryPerGroup = (int)IntrinsicMath.Min(
@@ -504,6 +509,47 @@ namespace ILGPU.Runtime.OpenCL
         #endregion
 
         #region Methods
+
+        /// <inheritdoc/>
+        protected override void PrintHeader(TextWriter writer)
+        {
+            base.PrintHeader(writer);
+
+            writer.Write("  Platform name:                           ");
+            writer.WriteLine(PlatformName);
+
+            writer.Write("  Platform version:                        ");
+            writer.WriteLine(PlatformVersion.ToString());
+
+            writer.Write("  Vendor name:                             ");
+            writer.WriteLine(VendorName);
+
+            writer.Write("  Vendor:                                  ");
+            writer.WriteLine(Vendor.ToString());
+
+            writer.Write("  Device type:                             ");
+            writer.WriteLine(DeviceType.ToString());
+
+            writer.Write("  Clock rate:                              ");
+            writer.Write(ClockRate);
+            writer.WriteLine(" MHz");
+        }
+
+        /// <inheritdoc/>
+        protected override void PrintGeneralInfo(TextWriter writer)
+        {
+            writer.Write("  OpenCL C version:                        ");
+            writer.WriteLine(CVersion.ToString());
+
+            writer.Write("  Has FP16 support:                        ");
+            writer.WriteLine(Capabilities.Float16);
+
+            writer.Write("  Has Int64 atomics support:               ");
+            writer.WriteLine(Capabilities.Int64_Atomics);
+
+            writer.Write("  Has sub group support:                   ");
+            writer.WriteLine(Capabilities.SubGroups);
+        }
 
         /// <summary cref="Accelerator.CreateExtension{TExtension, TExtensionProvider}(
         /// TExtensionProvider)"/>


### PR DESCRIPTION
This PR adds a `Print` method to all `Accelerator` instances, which allows to print accelerator-related information to an output stream (e.g. `Console.Out`). Furthermore, it adds additional properties to the `CudaAccelerator` class that also include `PCI`-related getters (like the `PCIBusId`) that can be used to query additional driver-specific libraries (like `NVML`).

This PR is also related to #387.

Sample output of an RTX 3090 using `accelerator.PrintInformation()`:
```
Device: GeForce RTX 3090 [ILGPU InstanceId: 20]
  Cuda device id:                          0
  Cuda driver version:                     11.2
  Cuda architecture:                       SM_86
  Instruction set:                         7.1
  Clock rate:                              1860 MHz
  Memory clock rate:                       9751 MHz
  Memory bus width:                        384-bit
  Number of multiprocessors:               82
  Max number of threads/multiprocessor:    1536
  Max number of threads/group:             1024
  Max number of total threads:             125952
  Max dimension of a group size:           (1024, 1024, 64)
  Max dimension of a grid size:            (2147483647, 65535, 65535)
  Total amount of global memory:           25769803776 bytes, 24576 MB
  Total amount of constant memory:         65536 bytes, 64 KB
  Total amount of shared memory per group: 49152 bytes, 48 KB
  Total amount of shared memory per mp:    102400 bytes, 100 KB
  L2 cache size:                           6291456 bytes, 6144 KB
  Max memory pitch:                        2147483647 bytes
  Total number of registers per mp:        65536
  Total number of registers per group:     65536
  Concurrent copy and kernel execution:    True, with 2 copy engines
  Driver mode:                             WDDM
  Has ECC support:                         False
  Supports managed memory:                 True
  Supports compute preemption:             True
  PCI domain id / bus id / device id:      0 / 11 / 0
  NVML PCI bus id:                         0000:0B:00.0
```