### PR TITLE
Fixed invalid PrintF formats for int64 and uintX types.

### DIFF
--- a/Src/ILGPU/IR/Values/IOValues.cs
+++ b/Src/ILGPU/IR/Values/IOValues.cs
@@ -180,16 +180,16 @@ namespace ILGPU.IR.Values
                 "%d",
                 "%d",
                 "%d",
-                "%ld",
+                "%lld",
 
                 "%n",
                 "%f",
                 "%lf",
 
-                "%i",
-                "%i",
-                "%i",
-                "%lu");
+                "%u",
+                "%u",
+                "%u",
+                "%llu");
 
         /// <summary>
         /// The native PrintF pointer format.


### PR DESCRIPTION
This PR fixes incompatible `printf` (`Interop.Write` / `Interop.WriteLine`) formats in `Cuda` and `OpenCL`.

Note that this PR does not contain any tests since the output of these operations will be written to an arbitrary output stream that is determined by the driver.