### PR TITLE
Synchronized RuntimeSystem class

### DIFF
--- a/Src/ILGPU/Backends/Backend.cs
+++ b/Src/ILGPU/Backends/Backend.cs
@@ -483,6 +483,11 @@ namespace ILGPU.Backends
         public Context Context { get; }
 
         /// <summary>
+        /// Returns the current runtime system instance.
+        /// </summary>
+        protected RuntimeSystem RuntimeSystem => Context.RuntimeSystem;
+
+        /// <summary>
         /// Returns the supported capabilities.
         /// </summary>
         public CapabilityContext Capabilities { get; }

--- a/Src/ILGPU/Backends/EntryPoints/EntryPoint.cs
+++ b/Src/ILGPU/Backends/EntryPoints/EntryPoint.cs
@@ -10,6 +10,7 @@
 // ---------------------------------------------------------------------------------------
 
 using ILGPU.Runtime;
+using ILGPU.Util;
 using System;
 using System.Reflection;
 
@@ -141,11 +142,29 @@ namespace ILGPU.Backends.EntryPoints
         /// <summary>
         /// Creates a new launcher method.
         /// </summary>
+        /// <param name="runtimeSystem">The current runtime system.</param>
+        /// <param name="methodEmitter">The method emitter.</param>
+        /// <returns>The acquired scoped lock.</returns>
+        internal RuntimeSystem.ScopedLock CreateLauncherMethod(
+            RuntimeSystem runtimeSystem,
+            out RuntimeSystem.MethodEmitter methodEmitter) =>
+            CreateLauncherMethod(runtimeSystem, null, out methodEmitter);
+
+        /// <summary>
+        /// Creates a new launcher method.
+        /// </summary>
+        /// <param name="runtimeSystem">The current runtime system.</param>
         /// <param name="instanceType">The instance type (if any).</param>
-        /// <returns>The method emitter that represents the launcher method.</returns>
-        internal RuntimeSystem.MethodEmitter CreateLauncherMethod(
-            Type instanceType = null) =>
-            Description.CreateLauncherMethod(instanceType);
+        /// <param name="methodEmitter">The method emitter.</param>
+        /// <returns>The acquired scoped lock.</returns>
+        internal RuntimeSystem.ScopedLock CreateLauncherMethod(
+            RuntimeSystem runtimeSystem,
+            Type instanceType,
+            out RuntimeSystem.MethodEmitter methodEmitter) =>
+            Description.CreateLauncherMethod(
+                runtimeSystem,
+                instanceType,
+                out methodEmitter);
 
         #endregion
     }

--- a/Src/ILGPU/Backends/EntryPoints/EntryPointDescription.cs
+++ b/Src/ILGPU/Backends/EntryPoints/EntryPointDescription.cs
@@ -164,10 +164,14 @@ namespace ILGPU.Backends.EntryPoints
         /// <summary>
         /// Creates a new launcher method.
         /// </summary>
+        /// <param name="runtimeSystem">The current runtime system.</param>
         /// <param name="instanceType">The instance type (if any).</param>
-        /// <returns>The method emitter that represents the launcher method.</returns>
-        internal RuntimeSystem.MethodEmitter CreateLauncherMethod(
-            Type instanceType = null)
+        /// <param name="methodEmitter">The method emitter.</param>
+        /// <returns>The acquired scoped lock.</returns>
+        internal RuntimeSystem.ScopedLock CreateLauncherMethod(
+            RuntimeSystem runtimeSystem,
+            Type instanceType,
+            out RuntimeSystem.MethodEmitter methodEmitter)
         {
             var parameterTypes = new Type[
                 Parameters.Count + Kernel.KernelParameterOffset];
@@ -181,9 +185,10 @@ namespace ILGPU.Backends.EntryPoints
                 IndexType.GetManagedIndexType();
             Parameters.CopyTo(parameterTypes, Kernel.KernelParameterOffset);
 
-            var result = RuntimeSystem.Instance.DefineRuntimeMethod(
+            var writeScope = runtimeSystem.DefineRuntimeMethod(
                 typeof(void),
-                parameterTypes);
+                parameterTypes,
+                out methodEmitter);
             // TODO: we have to port the following snippet to .Net Core
             // in order to support "in" parameters
             //if (Parameters.IsByRef(i))
@@ -195,7 +200,7 @@ namespace ILGPU.Backends.EntryPoints
             //        null);
             //}
 
-            return result;
+            return writeScope;
         }
 
         /// <summary>

--- a/Src/ILGPU/Backends/IL/ILBackend.cs
+++ b/Src/ILGPU/Backends/IL/ILBackend.cs
@@ -141,38 +141,43 @@ namespace ILGPU.Backends.IL
                 out ConstructorInfo taskConstructor,
                 out ImmutableArray<FieldInfo> taskArgumentMapping);
 
-            var kernel = RuntimeSystem.Instance.DefineRuntimeMethod(
+            MethodInfo kernelMethod;
+            using (var writeScope = RuntimeSystem.Instance.DefineRuntimeMethod(
                 typeof(void),
-                CPUAcceleratorTask.ExecuteParameterTypes);
-            var emitter = new ILEmitter(kernel.ILGenerator);
-            var kernelData = new KernelGenerationData();
+                CPUAcceleratorTask.ExecuteParameterTypes,
+                out var methodEmitter))
+            {
+                var emitter = new ILEmitter(methodEmitter.ILGenerator);
+                var kernelData = new KernelGenerationData();
 
-            // Generate CPU runtime startup code
-            GenerateStartupCode(
-                entryPoint,
-                emitter,
-                kernelData,
-                taskType,
-                taskArgumentMapping);
+                // Generate CPU runtime startup code
+                GenerateStartupCode(
+                    entryPoint,
+                    emitter,
+                    kernelData,
+                    taskType,
+                    taskArgumentMapping);
 
-            // Generate the actual kernel code
-            GenerateCode(
-                entryPoint,
-                backendContext,
-                emitter,
-                kernelData);
+                // Generate the actual kernel code
+                GenerateCode(
+                    entryPoint,
+                    backendContext,
+                    emitter,
+                    kernelData);
 
-            // Generate CPU runtime finish code
-            GenerateFinishCode(
-                emitter,
-                kernelData);
+                // Generate CPU runtime finish code
+                GenerateFinishCode(
+                    emitter,
+                    kernelData);
 
-            emitter.Finish();
+                emitter.Finish();
+                kernelMethod = methodEmitter.Finish();
+            }
 
             return new ILCompiledKernel(
                 Context,
                 entryPoint,
-                kernel.Finish(),
+                kernelMethod,
                 taskType,
                 taskConstructor,
                 taskArgumentMapping);
@@ -212,43 +217,59 @@ namespace ILGPU.Backends.IL
             out ConstructorInfo taskConstructor,
             out ImmutableArray<FieldInfo> taskArgumentMapping)
         {
+            const string ArgumentFormat = "Arg{0}";
+
             var acceleratorTaskType = typeof(CPUAcceleratorTask);
-            var taskBuilder = RuntimeSystem.Instance.DefineRuntimeClass(
-                acceleratorTaskType);
-
-            var ctor = taskBuilder.DefineConstructor(
-                MethodAttributes.Public,
-                CallingConventions.HasThis,
-                CPUAcceleratorTask.ConstructorParameterTypes);
-
-            // Build constructor
-            {
-                var constructorILGenerator = ctor.GetILGenerator();
-                constructorILGenerator.Emit(OpCodes.Ldarg_0);
-                for (
-                    int i = 0, e = CPUAcceleratorTask.ConstructorParameterTypes.Length;
-                    i < e;
-                    ++i)
-                {
-                    constructorILGenerator.Emit(OpCodes.Ldarg, i + 1);
-                }
-                constructorILGenerator.Emit(
-                    OpCodes.Call,
-                    CPUAcceleratorTask.GetTaskConstructor(acceleratorTaskType));
-                constructorILGenerator.Emit(OpCodes.Ret);
-            }
-
-            // Define all fields
             var argFieldBuilders = new FieldInfo[parameters.Count];
-            for (int i = 0, e = argFieldBuilders.Length; i < e; ++i)
-            {
-                argFieldBuilders[i] = taskBuilder.DefineField(
-                    $"Arg{i}",
-                    parameters[i],
-                    FieldAttributes.Public);
-            }
 
-            var taskType = taskBuilder.CreateTypeInfo().AsType();
+            Type taskType;
+            {
+                using var writeScope = RuntimeSystem.Instance.DefineRuntimeClass(
+                    acceleratorTaskType,
+                    out var taskBuilder);
+
+                var ctor = taskBuilder.DefineConstructor(
+                    MethodAttributes.Public,
+                    CallingConventions.HasThis,
+                    CPUAcceleratorTask.ConstructorParameterTypes);
+
+                // Build constructor
+                {
+                    var constructorILGenerator = ctor.GetILGenerator();
+                    constructorILGenerator.Emit(OpCodes.Ldarg_0);
+                    for (
+                        int i = 0,
+                        e = CPUAcceleratorTask.ConstructorParameterTypes.Length;
+                        i < e;
+                        ++i)
+                    {
+                        constructorILGenerator.Emit(OpCodes.Ldarg, i + 1);
+                    }
+                    constructorILGenerator.Emit(
+                        OpCodes.Call,
+                        CPUAcceleratorTask.GetTaskConstructor(acceleratorTaskType));
+                    constructorILGenerator.Emit(OpCodes.Ret);
+                }
+
+                // Define all fields
+                for (int i = 0, e = argFieldBuilders.Length; i < e; ++i)
+                {
+                    taskBuilder.DefineField(
+                        string.Format(ArgumentFormat, i),
+                        parameters[i],
+                        FieldAttributes.Public);
+                }
+
+                // Create the actual type
+                taskType = taskBuilder.CreateType();
+
+                // Get all fields
+                for (int i = 0, e = argFieldBuilders.Length; i < e; ++i)
+                {
+                    argFieldBuilders[i] = taskBuilder.GetField(
+                        string.Format(ArgumentFormat, i));
+                }
+            }
             taskConstructor = taskType.GetConstructor(
                 CPUAcceleratorTask.ConstructorParameterTypes);
 

--- a/Src/ILGPU/Backends/IL/ILBackend.cs
+++ b/Src/ILGPU/Backends/IL/ILBackend.cs
@@ -142,7 +142,7 @@ namespace ILGPU.Backends.IL
                 out ImmutableArray<FieldInfo> taskArgumentMapping);
 
             MethodInfo kernelMethod;
-            using (var writeScope = RuntimeSystem.Instance.DefineRuntimeMethod(
+            using (var scopedLock = RuntimeSystem.DefineRuntimeMethod(
                 typeof(void),
                 CPUAcceleratorTask.ExecuteParameterTypes,
                 out var methodEmitter))
@@ -212,7 +212,7 @@ namespace ILGPU.Backends.IL
         /// and dynamically-sized shared-memory-variable-length specifications to fields
         /// in the task class.
         /// </param>
-        private static Type GenerateAcceleratorTask(
+        private Type GenerateAcceleratorTask(
             in ParameterCollection parameters,
             out ConstructorInfo taskConstructor,
             out ImmutableArray<FieldInfo> taskArgumentMapping)
@@ -224,7 +224,7 @@ namespace ILGPU.Backends.IL
 
             Type taskType;
             {
-                using var writeScope = RuntimeSystem.Instance.DefineRuntimeClass(
+                using var scopedLock = RuntimeSystem.DefineRuntimeClass(
                     acceleratorTaskType,
                     out var taskBuilder);
 

--- a/Src/ILGPU/Backends/OpenCL/CLArgumentMapper.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLArgumentMapper.cs
@@ -312,7 +312,7 @@ namespace ILGPU.Backends.OpenCL
         /// </summary>
         /// <param name="type">The type.</param>
         /// <returns>The interop size in bytes.</returns>
-        private int GetSizeOf(Type type) => Context.TypeContext.CreateType(type).Size;
+        private int GetSizeOf(Type type) => TypeContext.CreateType(type).Size;
 
         /// <summary>
         /// Emits code that sets an OpenCL kernel argument.

--- a/Src/ILGPU/Backends/OpenCL/CLTypeGenerator.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLTypeGenerator.cs
@@ -188,7 +188,7 @@ namespace ILGPU.Backends.OpenCL
             foreach (var basicValueType in IRTypeContext.BasicValueTypes)
             {
                 if (basicValueType == BasicValueType.Float64
-                    && TypeContext.Context.HasFlags(ContextFlags.Force32BitFloats))
+                    && TypeContext.ContextFlags.HasFlags(ContextFlags.Force32BitFloats))
                 {
                     continue;
                 }

--- a/Src/ILGPU/Context.cs
+++ b/Src/ILGPU/Context.cs
@@ -145,6 +145,7 @@ namespace ILGPU
             OptimizationLevel = optimizationLevel;
             Flags = flags.Prepare();
             TargetPlatform = Backend.RuntimePlatform;
+            RuntimeSystem = new RuntimeSystem();
 
             // Initialize enhanced PTX backend feature flags
             if (optimizationLevel > OptimizationLevel.O1 &&
@@ -202,6 +203,11 @@ namespace ILGPU
         /// Returns the current target platform.
         /// </summary>
         public TargetPlatform TargetPlatform { get; }
+
+        /// <summary>
+        /// Returns the associated runtime system class.
+        /// </summary>
+        public RuntimeSystem RuntimeSystem { get; }
 
         /// <summary>
         /// Returns the main IR context.
@@ -338,8 +344,8 @@ namespace ILGPU
             TypeContext.ClearCache(mode);
             DebugInformationManager.ClearCache(mode);
             DefautltILBackend.ClearCache(mode);
+            RuntimeSystem.ClearCache(mode);
 
-            RuntimeSystem.Instance.ClearCache(mode);
             base.ClearCache(mode);
         }
 

--- a/Src/ILGPU/Frontend/Intrinsic/Intrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/Intrinsics.cs
@@ -275,7 +275,7 @@ namespace ILGPU.Frontend.Intrinsic
             // appropriate store instructions
             Value target = context[0];
             var arrayType = target.Type as ViewType;
-            var elementType = arrayType.ElementType.ManagedType;
+            var elementType = arrayType.ElementType.LoadManagedType();
 
             // Convert values to IR values
             var builder = context.Builder;

--- a/Src/ILGPU/IR/Intrinsics/IntrinsicMapping.cs
+++ b/Src/ILGPU/IR/Intrinsics/IntrinsicMapping.cs
@@ -84,7 +84,7 @@ namespace ILGPU.IR.Intrinsics
 
             /// <summary cref="IGenericArgumentResolver.ResolveGenericArguments"/>
             public Type[] ResolveGenericArguments() =>
-                new Type[] { Value.Type.ManagedType };
+                new Type[] { Value.Type.LoadManagedType() };
         }
 
         /// <summary>

--- a/Src/ILGPU/IR/Types/IRTypeContext.cs
+++ b/Src/ILGPU/IR/Types/IRTypeContext.cs
@@ -9,6 +9,7 @@
 // Source License. See LICENSE.txt for details
 // ---------------------------------------------------------------------------------------
 
+using ILGPU.Backends;
 using ILGPU.Resources;
 using ILGPU.Util;
 using System;
@@ -72,7 +73,12 @@ namespace ILGPU.IR.Types
         /// <param name="context">The associated main context.</param>
         public IRTypeContext(Context context)
         {
-            Context = context ?? throw new ArgumentNullException(nameof(context));
+            if (context is null)
+                throw new ArgumentNullException(nameof(context));
+
+            ContextFlags = context.Flags;
+            TargetPlatform = context.TargetPlatform;
+            RuntimeSystem = context.RuntimeSystem;
 
             VoidType = new VoidType(this);
             StringType = new StringType(this);
@@ -105,9 +111,19 @@ namespace ILGPU.IR.Types
         #region Properties
 
         /// <summary>
-        /// Returns the associated context.
+        /// Returns the associated context flags.
         /// </summary>
-        public Context Context { get; }
+        public ContextFlags ContextFlags { get; }
+
+        /// <summary>
+        /// Returns the associated target platform for all pointer-based types.
+        /// </summary>
+        public TargetPlatform TargetPlatform { get; }
+
+        /// <summary>
+        /// Returns the parent runtime system.
+        /// </summary>
+        public RuntimeSystem RuntimeSystem { get; }
 
         /// <summary>
         /// Returns the void type.

--- a/Src/ILGPU/IR/Types/PointerTypes.cs
+++ b/Src/ILGPU/IR/Types/PointerTypes.cs
@@ -182,7 +182,7 @@ namespace ILGPU.IR.Types
             : base(typeContext, elementType, addressSpace)
         {
             Size = Alignment =
-                typeContext.Context.TargetPlatform == TargetPlatform.X86
+                typeContext.TargetPlatform == TargetPlatform.X86
                 ? 4
                 : 8;
             AddFlags(TypeFlags.PointerDependent);
@@ -196,7 +196,7 @@ namespace ILGPU.IR.Types
         /// Creates a managed pointer type.
         /// </summary>
         protected override Type GetManagedType() =>
-            ElementType.ManagedType.MakePointerType();
+            ElementType.LoadManagedType().MakePointerType();
 
         #endregion
 
@@ -247,7 +247,8 @@ namespace ILGPU.IR.Types
         /// Creates a managed view type.
         /// </summary>
         protected override Type GetManagedType() =>
-            typeof(ArrayView<>).MakeGenericType(ElementType.ManagedType);
+            typeof(ArrayView<>).MakeGenericType(
+                ElementType.LoadManagedType());
 
         #endregion
 

--- a/Src/ILGPU/IR/Types/StructureType.cs
+++ b/Src/ILGPU/IR/Types/StructureType.cs
@@ -25,7 +25,6 @@ namespace ILGPU.IR.Types
     /// <summary>
     /// Represents a structure type.
     /// </summary>
-    [SuppressMessage("Naming", "CA1710:Identifiers should have correct suffix")]
     public sealed class StructureType : ObjectType, IEnumerable<(TypeNode, FieldAccess)>
     {
         #region Nested Types
@@ -888,13 +887,14 @@ namespace ILGPU.IR.Types
         /// </summary>
         protected override Type GetManagedType()
         {
-            var typeBuilder = RuntimeSystem.Instance.DefineRuntimeStruct();
+            using var scopedLock = RuntimeSystem.DefineRuntimeStruct(
+                out var typeBuilder);
             int index = 0;
             foreach (var type in DirectFields)
             {
                 typeBuilder.DefineField(
                     "Field" + index++,
-                    type.ManagedType,
+                    type.LoadManagedType(),
                     FieldAttributes.Public);
 
             }

--- a/Src/ILGPU/IR/Types/TypeNode.cs
+++ b/Src/ILGPU/IR/Types/TypeNode.cs
@@ -56,7 +56,7 @@ namespace ILGPU.IR.Types
         /// <summary>
         /// The type representation in the managed world.
         /// </summary>
-        Type ManagedType { get; }
+        Type LoadManagedType();
     }
 
     /// <summary>
@@ -116,14 +116,14 @@ namespace ILGPU.IR.Types
         #region Properties
 
         /// <summary>
-        /// Returns the parent ILGPU context.
-        /// </summary>
-        public Context Context => TypeContext.Context;
-
-        /// <summary>
         /// Returns the parent type context.
         /// </summary>
         public IRTypeContext TypeContext { get; }
+
+        /// <summary>
+        /// Returns the urrent runtime system.
+        /// </summary>
+        public RuntimeSystem RuntimeSystem => TypeContext.RuntimeSystem;
 
         /// <summary>
         /// The size of the type in bytes (if the type is in its lowered representation).
@@ -213,14 +213,14 @@ namespace ILGPU.IR.Types
             Size > 0 && Alignment > 0 &&
             !HasFlags(TypeFlags.ArrayDependent | TypeFlags.ViewDependent);
 
-        /// <summary>
-        /// The type representation in the managed world.
-        /// </summary>
-        public Type ManagedType => managedType ??= GetManagedType();
-
         #endregion
 
         #region Methods
+
+        /// <summary>
+        /// The type representation in the managed world.
+        /// </summary>
+        public Type LoadManagedType() => managedType ??= GetManagedType();
 
         /// <summary>
         /// Returns true if the given flags are set.
@@ -269,7 +269,7 @@ namespace ILGPU.IR.Types
                 ErrorMessages.LocationTypeMessage,
                     message,
                     ToString(),
-                    ManagedType.ToString());
+                    LoadManagedType().ToString());
 
         #endregion
 

--- a/Src/ILGPU/Resources/RuntimeErrorMessages.Designer.cs
+++ b/Src/ILGPU/Resources/RuntimeErrorMessages.Designer.cs
@@ -115,6 +115,15 @@ namespace ILGPU.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Concurrent modification detected.
+        /// </summary>
+        internal static string InvalidConcurrentModification {
+            get {
+                return ResourceManager.GetString("InvalidConcurrentModification", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid custom group size &gt; 0 in a grouped-index scenario.
         /// </summary>
         internal static string InvalidCustomGroupSize {

--- a/Src/ILGPU/Resources/RuntimeErrorMessages.resx
+++ b/Src/ILGPU/Resources/RuntimeErrorMessages.resx
@@ -135,6 +135,9 @@
   <data name="InvalidCodeGenerationOperation1" xml:space="preserve">
     <value>Invalid code generation operation:\n{0}</value>
   </data>
+  <data name="InvalidConcurrentModification" xml:space="preserve">
+    <value>Concurrent modification detected</value>
+  </data>
   <data name="InvalidCustomGroupSize" xml:space="preserve">
     <value>Invalid custom group size &gt; 0 in a grouped-index scenario</value>
   </data>

--- a/Src/ILGPU/Runtime/CPU/CPUAccelerator.cs
+++ b/Src/ILGPU/Runtime/CPU/CPUAccelerator.cs
@@ -390,7 +390,9 @@ namespace ILGPU.Runtime.CPU
             var entryPoint = kernel.EntryPoint;
             AdjustAndVerifyKernelGroupSize(ref customGroupSize, entryPoint);
 
-            var launcher = entryPoint.CreateLauncherMethod();
+            using var scopedLock = entryPoint.CreateLauncherMethod(
+                Context.RuntimeSystem,
+                out var launcher);
             var emitter = new ILEmitter(launcher.ILGenerator);
 
             var cpuKernel = emitter.DeclareLocal(typeof(CPUKernel));

--- a/Src/ILGPU/Runtime/Cuda/CudaAccelerator.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaAccelerator.cs
@@ -519,7 +519,9 @@ namespace ILGPU.Runtime.Cuda
                     ErrorMessages.NotSupportedByRefKernelParameters);
             }
 
-            var launcher = entryPoint.CreateLauncherMethod();
+            using var scopedLock = entryPoint.CreateLauncherMethod(
+                Context.RuntimeSystem,
+                out var launcher);
             var emitter = new ILEmitter(launcher.ILGenerator);
 
             // Allocate array of pointers as kernel argument(s)

--- a/Src/ILGPU/Runtime/OpenCL/CLAccelerator.cs
+++ b/Src/ILGPU/Runtime/OpenCL/CLAccelerator.cs
@@ -647,7 +647,9 @@ namespace ILGPU.Runtime.OpenCL
                     ErrorMessages.NotSupportedByRefKernelParameters);
             }
 
-            var launcher = entryPoint.CreateLauncherMethod();
+            using var scopedLock = entryPoint.CreateLauncherMethod(
+                Context.RuntimeSystem,
+                out var launcher);
             var emitter = new ILEmitter(launcher.ILGenerator);
 
             // Load kernel instance

--- a/Src/ILGPU/RuntimeAPI.cs
+++ b/Src/ILGPU/RuntimeAPI.cs
@@ -1,0 +1,205 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                        Copyright (c) 2016-2020 Marcel Koester
+//                                    www.ilgpu.net
+//
+// File: RuntimeAPI.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.InteropServices;
+
+namespace ILGPU
+{
+    /// <summary>
+    /// An abstract runtime API that can be used in combination with the dynamic DLL
+    /// loader functionality of the class <see cref="RuntimeSystem"/>.
+    /// </summary>
+    public abstract class RuntimeAPI
+    {
+        /// <summary>
+        /// Loads a runtime API that is implemented via compile-time known classes.
+        /// </summary>
+        /// <typeparam name="T">The abstract class type to implement.</typeparam>
+        /// <typeparam name="TWindows">The Windows implementation.</typeparam>
+        /// <typeparam name="TLinux">The Linux implementation.</typeparam>
+        /// <typeparam name="TMacOS">The MacOS implementation.</typeparam>
+        /// <typeparam name="TNotSupported">The not-supported implementation.</typeparam>
+        /// <returns>The loaded runtime API.</returns>
+        internal static T LoadRuntimeAPI<
+            T,
+            TWindows,
+            TLinux,
+            TMacOS,
+            TNotSupported>()
+            where T : RuntimeAPI
+            where TWindows : T, new()
+            where TLinux : T, new()
+            where TMacOS : T, new()
+            where TNotSupported : T, new()
+        {
+            if (!Backends.Backend.RunningOnNativePlatform)
+                return new TNotSupported();
+            try
+            {
+                T instance =
+                    RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+                    ? new TLinux()
+                    : RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+                    ? new TMacOS() as T
+                    : new TWindows();
+                // Try to initialize the new interface
+                if (!instance.Init())
+                    instance = new TNotSupported();
+                return instance;
+            }
+            catch (Exception ex) when (
+                ex is DllNotFoundException ||
+                ex is EntryPointNotFoundException)
+            {
+                // In case of a critical initialization exception fall back to the
+                // not supported API
+                return new TNotSupported();
+            }
+        }
+
+        /// <summary>
+        /// Returns true if the runtime API instance is supported on this platform.
+        /// </summary>
+        public abstract bool IsSupported { get; }
+
+        /// <summary>
+        /// Initializes the runtime API implementation.
+        /// </summary>
+        /// <returns>
+        /// True, if the API instance could be initialized successfully.
+        /// </returns>
+        public abstract bool Init();
+    }
+
+    /// <summary>
+    /// Marks dynamic DLL-import functions that are compatible with the
+    /// <see cref="RuntimeSystem.CreateDllWrapper{T}(string, string, string, string)"/>
+    /// function.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public sealed class DynamicImportAttribute : Attribute
+    {
+        #region Static
+
+        /// <summary>
+        /// Represents the managed attribute <see cref="DllImportAttribute"/>.
+        /// </summary>
+        private static readonly Type DllImportType = typeof(DllImportAttribute);
+
+        /// <summary>
+        /// The default constructor of the class <see cref="DllImportAttribute"/>.
+        /// </summary>
+        private static readonly ConstructorInfo DllImportConstructor =
+            DllImportType.GetConstructor(new Type[] { typeof(string) });
+
+        /// <summary>
+        /// All supported fields of the class <see cref="DllImportAttribute"/>.
+        /// </summary>
+        private static readonly FieldInfo[] DllImportFields =
+        {
+            DllImportType.GetField(nameof(DllImportAttribute.EntryPoint)),
+            DllImportType.GetField(nameof(DllImportAttribute.CharSet)),
+            DllImportType.GetField(nameof(DllImportAttribute.CallingConvention)),
+            DllImportType.GetField(nameof(DllImportAttribute.BestFitMapping)),
+            DllImportType.GetField(nameof(DllImportAttribute.ThrowOnUnmappableChar))
+        };
+
+        #endregion
+
+        #region Instance
+
+        /// <summary>
+        /// Constructs a new dynamic import attribute.
+        /// </summary>
+        public DynamicImportAttribute()
+            : this(null)
+        { }
+
+        /// <summary>
+        /// Constructs a new dynamic import attribute.
+        /// </summary>
+        /// <param name="entryPoint">The entry point.</param>
+        public DynamicImportAttribute(string entryPoint)
+        {
+            EntryPoint = entryPoint;
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Returns the associated native entry point.
+        /// </summary>
+        public string EntryPoint { get; }
+
+        /// <summary>
+        /// Defines the associated character set to use.
+        /// </summary>
+        public CharSet CharSet { get; set; } = CharSet.Auto;
+
+        /// <summary>
+        /// Defines the calling convention.
+        /// </summary>
+        public CallingConvention CallingConvention { get; set; } =
+            CallingConvention.Winapi;
+
+        /// <summary>
+        /// Enables or disabled best-fit mapping when mapping ANSI characters.
+        /// </summary>
+        public bool BestFitMapping { get; set; } = false;
+
+        /// <summary>
+        /// If true, it throws an exception in the case of an unmappable character.
+        /// </summary>
+        public bool ThrowOnUnmappableChar { get; set; } = false;
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Returns the name of the native entry point to use.
+        /// </summary>
+        /// <param name="method">The associated method.</param>
+        /// <returns>The resolved native entry-point name.</returns>
+        public string GetEntryPoint(MethodInfo method) =>
+            EntryPoint ?? method.Name;
+
+        /// <summary>
+        /// Converts this attribute instance into a custom attribute builder assembling
+        /// an instance of type <see cref="DllImportAttribute"/>.
+        /// </summary>
+        /// <param name="libraryName">The library name.</param>
+        /// <param name="method">The associated method.</param>
+        /// <returns>The created attribute builder.</returns>
+        public CustomAttributeBuilder ToImportAttributeBuilder(
+            string libraryName,
+            MethodInfo method) =>
+            new CustomAttributeBuilder(
+                DllImportConstructor,
+                new object[] { libraryName },
+                DllImportFields,
+                new object[]
+                {
+                    GetEntryPoint(method),
+                    CharSet,
+                    CallingConvention,
+                    BestFitMapping,
+                    ThrowOnUnmappableChar
+                });
+
+        #endregion
+    }
+}

--- a/Src/ILGPU/RuntimeSystem.cs
+++ b/Src/ILGPU/RuntimeSystem.cs
@@ -10,6 +10,7 @@
 // ---------------------------------------------------------------------------------------
 
 using ILGPU.Backends.IL;
+using ILGPU.Resources;
 using ILGPU.Util;
 using System;
 using System.Linq;
@@ -17,13 +18,14 @@ using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.InteropServices;
 using System.Security;
+using System.Threading;
 
 namespace ILGPU
 {
     /// <summary>
     /// Represents the dynamic ILGPU assembly runtime system.
     /// </summary>
-    public sealed class RuntimeSystem : ICache
+    public sealed class RuntimeSystem : DisposeBase, ICache
     {
         #region Constants
 
@@ -45,6 +47,50 @@ namespace ILGPU
         #endregion
 
         #region Nested Types
+
+        /// <summary>
+        /// A scoped lock that can be used in combination with a
+        /// <see cref="RuntimeSystem"/> instance.
+        /// </summary>
+        public readonly struct ScopedLock : IDisposable
+        {
+            private readonly WriteScopedLock writeScope;
+
+            internal ScopedLock(RuntimeSystem parent)
+            {
+                writeScope = parent.assemblyLock.EnterWriteScope();
+
+                Parent = parent;
+                AssemblyVersion = parent.assemblyVersion;
+            }
+
+            /// <summary>
+            /// Returns the parent runtime system instance.
+            /// </summary>
+            public RuntimeSystem Parent { get; }
+
+            /// <summary>
+            /// Returns the original assembly version this lock has been created from.
+            /// </summary>
+            /// <remarks>
+            /// This information is used to detect internal assembly corruption.
+            /// </remarks>
+            public int AssemblyVersion { get; }
+
+            /// <summary>
+            /// Releases the lock.
+            /// </summary>
+            public readonly void Dispose()
+            {
+                // Verify the assembly version
+                if (AssemblyVersion != Parent.assemblyVersion)
+                {
+                    throw new InvalidOperationException(
+                        RuntimeErrorMessages.InvalidConcurrentModification);
+                }
+                writeScope.Dispose();
+            }
+        }
 
         /// <summary>
         /// Represents a method builder in the .Net world.
@@ -322,29 +368,34 @@ namespace ILGPU
             }
         }
 
-        #endregion
-
-        #region Static Instance
+        /// <summary>
+        /// The globally unique assembly version.
+        /// </summary>
+        private static volatile int globalAssemblyVersion = 0;
 
         /// <summary>
-        /// Returns the static runtime-system instance.
+        /// Determines the next global assembly version.
         /// </summary>
-        public static RuntimeSystem Instance { get; } = new RuntimeSystem();
+        private static int GetNextAssemblyVersion() =>
+            Interlocked.Add(ref globalAssemblyVersion, 1);
 
         #endregion
 
         #region Instance
 
-        private readonly object assemblyLock = new object();
-        private int assemblyVersion = 0;
+        private readonly ReaderWriterLockSlim assemblyLock = new ReaderWriterLockSlim(
+            LockRecursionPolicy.SupportsRecursion);
+
         private AssemblyBuilder assemblyBuilder;
         private ModuleBuilder moduleBuilder;
+
+        private volatile int assemblyVersion;
         private volatile int typeBuilderIdx = 0;
 
         /// <summary>
         /// Constructs a new runtime system.
         /// </summary>
-        private RuntimeSystem()
+        public RuntimeSystem()
         {
             // Initialize assembly builder and context data
             ReloadAssemblyBuilder();
@@ -359,17 +410,17 @@ namespace ILGPU
         /// </summary>
         private void ReloadAssemblyBuilder()
         {
-            lock (assemblyLock)
+            using var writerLock = assemblyLock.EnterWriteScope();
+
+            assemblyVersion = GetNextAssemblyVersion();
+            var assemblyName = new AssemblyName(AssemblyName)
             {
-                var assemblyName = new AssemblyName(AssemblyName)
-                {
-                    Version = new Version(1, assemblyVersion++),
-                };
-                assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(
-                    assemblyName,
-                    AssemblyBuilderAccess.RunAndCollect);
-                moduleBuilder = assemblyBuilder.DefineDynamicModule(assemblyName.Name);
-            }
+                Version = new Version(1, assemblyVersion),
+            };
+            assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(
+                assemblyName,
+                AssemblyBuilderAccess.RunAndCollect);
+            moduleBuilder = assemblyBuilder.DefineDynamicModule(assemblyName.Name);
         }
 
         /// <summary>
@@ -377,23 +428,32 @@ namespace ILGPU
         /// </summary>
         /// <param name="attributes">The custom type attributes.</param>
         /// <param name="baseClass">The base class.</param>
-        /// <returns>A new runtime type builder.</returns>
-        private TypeBuilder DefineRuntimeType(TypeAttributes attributes, Type baseClass)
+        /// <param name="typeBuilder">The type builder.</param>
+        /// <returns>The acquired scoped lock.</returns>
+        private ScopedLock DefineRuntimeType(
+            TypeAttributes attributes,
+            Type baseClass,
+            out TypeBuilder typeBuilder)
         {
-            lock (assemblyLock)
-            {
-                return moduleBuilder.DefineType(
-                    CustomTypeName + typeBuilderIdx++,
-                    attributes,
-                    baseClass);
-            }
+            var scopedLock = new ScopedLock(this);
+
+            typeBuilder = moduleBuilder.DefineType(
+                CustomTypeName + typeBuilderIdx++,
+                attributes,
+                baseClass);
+
+            return scopedLock;
         }
 
         /// <summary>
         /// Defines a new runtime class.
         /// </summary>
-        /// <returns>A new runtime type builder.</returns>
-        public TypeBuilder DefineRuntimeClass(Type baseClass) =>
+        /// <param name="baseClass">The base class.</param>
+        /// <param name="typeBuilder">The type builder.</param>
+        /// <returns>The acquired scoped lock.</returns>
+        public ScopedLock DefineRuntimeClass(
+            Type baseClass,
+            out TypeBuilder typeBuilder) =>
             DefineRuntimeType(
                 TypeAttributes.Public |
                 TypeAttributes.Class |
@@ -402,13 +462,16 @@ namespace ILGPU
                 TypeAttributes.BeforeFieldInit |
                 TypeAttributes.AutoLayout |
                 TypeAttributes.Sealed,
-                baseClass ?? typeof(object));
+                baseClass ?? typeof(object),
+                out typeBuilder);
 
         /// <summary>
         /// Defines a new runtime structure.
         /// </summary>
-        /// <returns>A new runtime type builder.</returns>
-        public TypeBuilder DefineRuntimeStruct() => DefineRuntimeStruct(false);
+        /// <param name="typeBuilder">The type builder.</param>
+        /// <returns>The acquired scoped lock.</returns>
+        public ScopedLock DefineRuntimeStruct(out TypeBuilder typeBuilder) =>
+            DefineRuntimeStruct(false, out typeBuilder);
 
         /// <summary>
         /// Defines a new runtime structure.
@@ -416,8 +479,11 @@ namespace ILGPU
         /// <param name="explicitLayout">
         /// True, if the individual fields have an explicit structure layout.
         /// </param>
-        /// <returns>A new runtime type builder.</returns>
-        public TypeBuilder DefineRuntimeStruct(bool explicitLayout) =>
+        /// <param name="typeBuilder">The type builder.</param>
+        /// <returns>The acquired scoped lock.</returns>
+        public ScopedLock DefineRuntimeStruct(
+            bool explicitLayout,
+            out TypeBuilder typeBuilder) =>
             DefineRuntimeType(
                 TypeAttributes.Public |
                 TypeAttributes.Class |
@@ -427,28 +493,32 @@ namespace ILGPU
                 (explicitLayout
                     ? TypeAttributes.ExplicitLayout
                     : TypeAttributes.SequentialLayout),
-                typeof(ValueType));
+                typeof(ValueType),
+                out typeBuilder);
 
         /// <summary>
         /// Defines a new runtime method.
         /// </summary>
         /// <param name="returnType">The return type.</param>
         /// <param name="parameterTypes">All parameter types.</param>
-        /// <returns>The defined method.</returns>
-        public MethodEmitter DefineRuntimeMethod(
+        /// <param name="methodEmitter">The method emitter.</param>
+        /// <returns>The acquired scoped lock.</returns>
+        public ScopedLock DefineRuntimeMethod(
             Type returnType,
-            Type[] parameterTypes)
+            Type[] parameterTypes,
+            out MethodEmitter methodEmitter)
         {
-            var typeBuilder = DefineRuntimeStruct();
-            var type = typeBuilder.CreateType();
+            var scopedLock = new ScopedLock(this);
 
-            var method = new DynamicMethod(
-                LauncherMethodName,
-                typeof(void),
-                parameterTypes,
-                type,
-                true);
-            return new MethodEmitter(method);
+            methodEmitter = new MethodEmitter(
+                new DynamicMethod(
+                    LauncherMethodName,
+                    returnType,
+                    parameterTypes,
+                    moduleBuilder,
+                    true));
+
+            return scopedLock;
         }
 
         /// <summary>
@@ -486,7 +556,9 @@ namespace ILGPU
                 throw new InvalidOperationException();
 
             // Define the runtime class an implement all functions
-            var implTypeBuilder = DefineRuntimeClass(classType);
+            using var writeScope = DefineRuntimeClass(
+                classType,
+                out var implTypeBuilder);
             callback(implTypeBuilder, methods);
 
             // Create the actual implementation instance
@@ -580,195 +652,21 @@ namespace ILGPU
         /// Clears all internal caches.
         /// </summary>
         /// <param name="mode">Not used.</param>
-        public void ClearCache(ClearCacheMode mode) =>
-            ReloadAssemblyBuilder();
+        public void ClearCache(ClearCacheMode mode) => ReloadAssemblyBuilder();
 
         #endregion
-    }
 
-    /// <summary>
-    /// An abstract runtime API that can be used in combination with the dynamic DLL
-    /// loader functionality of the class <see cref="RuntimeSystem"/>.
-    /// </summary>
-    public abstract class RuntimeAPI
-    {
+        #region IDisposable
+
         /// <summary>
-        /// Loads a runtime API that is implemented via compile-time known classes.
+        /// Disposes the internal assembly lock.
         /// </summary>
-        /// <typeparam name="T">The abstract class type to implement.</typeparam>
-        /// <typeparam name="TWindows">The Windows implementation.</typeparam>
-        /// <typeparam name="TLinux">The Linux implementation.</typeparam>
-        /// <typeparam name="TMacOS">The MacOS implementation.</typeparam>
-        /// <typeparam name="TNotSupported">The not-supported implementation.</typeparam>
-        /// <returns>The loaded runtime API.</returns>
-        internal static T LoadRuntimeAPI<
-            T,
-            TWindows,
-            TLinux,
-            TMacOS,
-            TNotSupported>()
-            where T : RuntimeAPI
-            where TWindows : T, new()
-            where TLinux : T, new()
-            where TMacOS : T, new()
-            where TNotSupported : T, new()
+        protected override void Dispose(bool disposing)
         {
-            if (!Backends.Backend.RunningOnNativePlatform)
-                return new TNotSupported();
-            try
-            {
-                T instance =
-                    RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
-                    ? new TLinux()
-                    : RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
-                    ? new TMacOS() as T
-                    : new TWindows();
-                // Try to initialize the new interface
-                if (!instance.Init())
-                    instance = new TNotSupported();
-                return instance;
-            }
-            catch (Exception ex) when (
-                ex is DllNotFoundException ||
-                ex is EntryPointNotFoundException)
-            {
-                // In case of a critical initialization exception fall back to the
-                // not supported API
-                return new TNotSupported();
-            }
+            if (disposing)
+                assemblyLock.Dispose();
+            base.Dispose(disposing);
         }
-
-        /// <summary>
-        /// Returns true if the runtime API instance is supported on this platform.
-        /// </summary>
-        public abstract bool IsSupported { get; }
-
-        /// <summary>
-        /// Initializes the runtime API implementation.
-        /// </summary>
-        /// <returns>
-        /// True, if the API instance could be initialized successfully.
-        /// </returns>
-        public abstract bool Init();
-    }
-
-    /// <summary>
-    /// Marks dynamic DLL-import functions that are compatible with the
-    /// <see cref="RuntimeSystem.CreateDllWrapper{T}(string, string, string, string)"/>
-    /// function.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
-    public sealed class DynamicImportAttribute : Attribute
-    {
-        #region Static
-
-        /// <summary>
-        /// Represents the managed attribute <see cref="DllImportAttribute"/>.
-        /// </summary>
-        private static readonly Type DllImportType = typeof(DllImportAttribute);
-
-        /// <summary>
-        /// The default constructor of the class <see cref="DllImportAttribute"/>.
-        /// </summary>
-        private static readonly ConstructorInfo DllImportConstructor =
-            DllImportType.GetConstructor(new Type[] { typeof(string) });
-
-        /// <summary>
-        /// All supported fields of the class <see cref="DllImportAttribute"/>.
-        /// </summary>
-        private static readonly FieldInfo[] DllImportFields =
-        {
-            DllImportType.GetField(nameof(DllImportAttribute.EntryPoint)),
-            DllImportType.GetField(nameof(DllImportAttribute.CharSet)),
-            DllImportType.GetField(nameof(DllImportAttribute.CallingConvention)),
-            DllImportType.GetField(nameof(DllImportAttribute.BestFitMapping)),
-            DllImportType.GetField(nameof(DllImportAttribute.ThrowOnUnmappableChar))
-        };
-
-        #endregion
-
-        #region Instance
-
-        /// <summary>
-        /// Constructs a new dynamic import attribute.
-        /// </summary>
-        public DynamicImportAttribute()
-            : this(null)
-        { }
-
-        /// <summary>
-        /// Constructs a new dynamic import attribute.
-        /// </summary>
-        /// <param name="entryPoint">The entry point.</param>
-        public DynamicImportAttribute(string entryPoint)
-        {
-            EntryPoint = entryPoint;
-        }
-
-        #endregion
-
-        #region Properties
-
-        /// <summary>
-        /// Returns the associated native entry point.
-        /// </summary>
-        public string EntryPoint { get; }
-
-        /// <summary>
-        /// Defines the associated character set to use.
-        /// </summary>
-        public CharSet CharSet { get; set; } = CharSet.Auto;
-
-        /// <summary>
-        /// Defines the calling convention.
-        /// </summary>
-        public CallingConvention CallingConvention { get; set; } =
-            CallingConvention.Winapi;
-
-        /// <summary>
-        /// Enables or disabled best-fit mapping when mapping ANSI characters.
-        /// </summary>
-        public bool BestFitMapping { get; set; } = false;
-
-        /// <summary>
-        /// If true, it throws an exception in the case of an unmappable character.
-        /// </summary>
-        public bool ThrowOnUnmappableChar { get; set; } = false;
-
-        #endregion
-
-        #region Methods
-
-        /// <summary>
-        /// Returns the name of the native entry point to use.
-        /// </summary>
-        /// <param name="method">The associated method.</param>
-        /// <returns>The resolved native entry-point name.</returns>
-        public string GetEntryPoint(MethodInfo method) =>
-            EntryPoint ?? method.Name;
-
-        /// <summary>
-        /// Converts this attribute instance into a custom attribute builder assembling
-        /// an instance of type <see cref="DllImportAttribute"/>.
-        /// </summary>
-        /// <param name="libraryName">The library name.</param>
-        /// <param name="method">The associated method.</param>
-        /// <returns>The created attribute builder.</returns>
-        public CustomAttributeBuilder ToImportAttributeBuilder(
-            string libraryName,
-            MethodInfo method) =>
-            new CustomAttributeBuilder(
-                DllImportConstructor,
-                new object[] { libraryName },
-                DllImportFields,
-                new object[]
-                {
-                    GetEntryPoint(method),
-                    CharSet,
-                    CallingConvention,
-                    BestFitMapping,
-                    ThrowOnUnmappableChar
-                });
 
         #endregion
     }

--- a/Src/ILGPU/Static/DllImports.tt
+++ b/Src/ILGPU/Static/DllImports.tt
@@ -26,7 +26,6 @@ using System;
 using System.Runtime.InteropServices;
 
 #pragma warning disable IDE1006 // Naming
-#pragma warning disable CA1060 // Move pinvokes to native methods class
 
 <# foreach (var importFile in importFiles) { #>
 <#      var imports = Imports.Load(rootPath, importFile); #>
@@ -164,5 +163,4 @@ namespace <#= imports.Namespace #>
 
 <# } #>
 
-#pragma warning restore CA1060 // Move pinvokes to native methods class
 #pragma warning restore IDE1006 // Naming

--- a/Src/ILGPU/Util/ScopedLock.cs
+++ b/Src/ILGPU/Util/ScopedLock.cs
@@ -17,7 +17,7 @@ namespace ILGPU.Util
     /// <summary>
     /// Represents read only scoped lock based on a <see cref="ReaderWriterLockSlim"/>.
     /// </summary>
-    internal readonly struct ReadOnlyScopedLock : IDisposable
+    public readonly struct ReadOnlyScopedLock : IDisposable
     {
         private readonly ReaderWriterLockSlim syncLock;
 
@@ -41,7 +41,7 @@ namespace ILGPU.Util
     /// <summary>
     /// Represents write scoped lock based on a <see cref="ReaderWriterLockSlim"/>.
     /// </summary>
-    internal readonly struct WriteScopedLock : IDisposable
+    public readonly struct WriteScopedLock : IDisposable
     {
         private readonly ReaderWriterLockSlim syncLock;
 
@@ -66,7 +66,7 @@ namespace ILGPU.Util
     /// Represents an upgradeable read scoped lock based on a
     /// <see cref="ReaderWriterLockSlim"/>.
     /// </summary>
-    internal readonly struct UpgradeableScopedLock : IDisposable
+    public readonly struct UpgradeableScopedLock : IDisposable
     {
         private readonly ReaderWriterLockSlim syncLock;
 
@@ -96,7 +96,7 @@ namespace ILGPU.Util
     /// <summary>
     /// Additional extensions for scoped locks.
     /// </summary>
-    internal static class LockExtensions
+    public static class LockExtensions
     {
         /// <summary>
         /// Enters a new read scope.


### PR DESCRIPTION
Currently, multiple `Context`s share the same static `RuntimeSystem` instance to emit dynamically generated MSIL types and code. This can lead to concurrency issues if another user-defined thread clears its internal caches in the background.

This PR works around these concurrency issues by instantiating a separate `RuntimeSystem` instance with each `Context` instance. Moreover, it adds an additional synchronization layer on top of the internal synchronization infrastructure of the `ModuleBuilder` and `TypeBuilder` types, which is .Net implementation specific and not guaranteed in general according to the documentation.