### PR TITLE
Ensure that Cuda and CL accelerators are running on the native OS (X86/X64) platform.

### DIFF
--- a/Src/ILGPU/Runtime/Cuda/CudaAccelerator.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaAccelerator.cs
@@ -186,6 +186,11 @@ namespace ILGPU.Runtime.Cuda
             CudaAcceleratorFlags acceleratorFlags)
             : base(context, AcceleratorType.Cuda)
         {
+            if (deviceId < 0)
+                throw new ArgumentOutOfRangeException(nameof(deviceId));
+
+            Backends.Backend.EnsureRunningOnNativePlatform();
+
             CudaException.ThrowIfFailed(
                 CurrentAPI.CreateContext(
                     out var contextPtr,
@@ -602,8 +607,6 @@ namespace ILGPU.Runtime.Cuda
             if (!(kernel is CudaKernel cudaKernel))
                 throw new NotSupportedException(RuntimeErrorMessages.NotSupportedKernel);
 
-            Backends.Backend.EnsureRunningOnNativePlatform();
-
             CudaException.ThrowIfFailed(
                 CurrentAPI.ComputeOccupancyMaxPotentialBlockSize(
                     out minGridSize,
@@ -627,8 +630,6 @@ namespace ILGPU.Runtime.Cuda
         {
             if (!(kernel is CudaKernel cudaKernel))
                 throw new NotSupportedException(RuntimeErrorMessages.NotSupportedKernel);
-
-            Backends.Backend.EnsureRunningOnNativePlatform();
 
             CudaException.ThrowIfFailed(
                 CurrentAPI.ComputeOccupancyMaxPotentialBlockSize(

--- a/Src/ILGPU/Runtime/OpenCL/CLAccelerator.cs
+++ b/Src/ILGPU/Runtime/OpenCL/CLAccelerator.cs
@@ -218,6 +218,8 @@ namespace ILGPU.Runtime.OpenCL
             if (acceleratorId == null)
                 throw new ArgumentNullException(nameof(acceleratorId));
 
+            Backends.Backend.EnsureRunningOnNativePlatform();
+
             PlatformId = acceleratorId.PlatformId;
             DeviceId = acceleratorId.DeviceId;
             CVersion = acceleratorId.CVersion;


### PR DESCRIPTION
This PR adds additional checks to the `CudaAccelerator` and `CLAccelerator` classes. The constructors will throw an exception when a .Net application does not run on the native (underlying) X86/X64 OS platform. Fixes #369.