### PR TITLE
Reverses a backwards assertion in ArrayView.cs

### DIFF
--- a/Src/ILGPU/ArrayView.cs
+++ b/Src/ILGPU/ArrayView.cs
@@ -495,7 +495,7 @@ namespace ILGPU
         /// <param name="extent">The extent (number of elements).</param>
         public ArrayView(ArrayView<T> baseView, TIndex extent)
         {
-            Trace.Assert(baseView.Length <= extent.Size, "Extent out of range");
+            Trace.Assert(extent.Size <= baseView.Length, "Extent out of range");
             BaseView = baseView;
             Extent = extent;
         }


### PR DESCRIPTION
The extent of the new ArrayView should surely be smaller than the extent of the one underlying it, as opposed to larger.