### PR TITLE
Fixed invalid remapping of previously replaced PhiValues in UCE.

### DIFF
--- a/Src/ILGPU.Tests/BasicLoops.cs
+++ b/Src/ILGPU.Tests/BasicLoops.cs
@@ -447,8 +447,42 @@ namespace ILGPU.Tests
 
             source.MemSetToZero();
             buffer.MemSetToZero();
+            Accelerator.Synchronize();
 
             Execute(buffer.Length, source.View, buffer.View);
+
+            var expected = Enumerable.Repeat(0, Length).ToArray();
+            Verify(buffer, expected);
+        }
+
+        internal static void LoopUnrolling_UCE_DCE_Kernel(
+            Index1 index,
+            ArrayView<int> view)
+        {
+            int value = 0;
+
+            for (int i = 0; i < 2; i++)
+            {
+                if (value < 1)
+                {
+                    int newValue = 0;
+                    if (newValue == 0)
+                    {
+                        value = newValue;
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        [KernelMethod(nameof(LoopUnrolling_UCE_DCE_Kernel))]
+        public void LoopUnrolling_UCE_DCE()
+        {
+            using var buffer = Accelerator.Allocate<int>(Length);
+            buffer.MemSetToZero();
+            Accelerator.Synchronize();
+
+            Execute(buffer.Length, buffer.View);
 
             var expected = Enumerable.Repeat(0, Length).ToArray();
             Verify(buffer, expected);

--- a/Src/ILGPU/IR/Transformations/UnreachableCodeElimination.cs
+++ b/Src/ILGPU/IR/Transformations/UnreachableCodeElimination.cs
@@ -124,8 +124,15 @@ namespace ILGPU.IR.Transformations
             PhiArgumentRemapper remapper,
             PhiValue phiValue)
         {
+            // Check whether this phi has become unreachable
             if (!remapper.IsReachable(phiValue.BasicBlock))
                 return;
+
+            // Check whether this phi has been replaced due to a previous simplification
+            if (phiValue.IsReplaced)
+                return;
+
+            // Remap all arguments and simplify phi values recursively
             phiValue.RemapArguments(context.GetMethodBuilder(), remapper);
         }
 


### PR DESCRIPTION
This PR fixes #406.