### PR TITLE
[CI] Build templates in a single thread to avoid parallelism-related issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,8 @@ jobs:
         working-directory: ./Src
       - name: Build templates
         # TargetFramework specified so this only runs once rather than per framework
-        run: dotnet msbuild -t:TextTemplateTransform -p:TargetFramework=NA Src
+        # WORKAROUND: maxCpuCount set to 1 to avoid parallelism-related issues
+        run: dotnet msbuild -t:TextTemplateTransform -p:TargetFramework=NA -m:1 Src
       - name: Release Build
         run: dotnet build --configuration=Release -p:TreatWarningsAsErrors=true Src
       - name: CPU Tests


### PR DESCRIPTION
This PR changes the CI to build the T4 templates in a single thread instead of the default multi-threaded approach which is known to cause issues (our CI [randomly fails](https://github.com/m4rs-mt/ILGPU/runs/1779235590?check_suite_focus=true) during that step).

This changes causes the templates building step to be 50% slower in average (going from ~40s to ~1m).

Credits to @Joey9801 for figuring out the `-m:1` flag to `dotnet msbuild` (aka `-maxCpuCount:1`).