### PR TITLE
Skip the CUDA tests when the CI runs for forked repositories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,11 +49,26 @@ jobs:
             Exit 1
           }
 
+  # Setup the OS matrix so that CUDA tests do not run on forks, as it needs self-hosted runners
+  setup-os-matrix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup OS matrix
+        id: setup-os-matrix
+        run: |
+          os='["ubuntu-latest","windows-latest","macos-latest"'
+          [ "${{ github.event.repository.fork }}" == "false" ] && os="$os,\"cuda\""
+          os="$os]"
+          echo "::set-output name=os::$os"
+    outputs:
+      os: ${{ steps.setup-os-matrix.outputs.os }}
+
   build-and-test:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
+    needs: setup-os-matrix
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, cuda]
+        os: ${{ fromJson(needs.setup-os-matrix.outputs.os) }}
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
This PR changes the CI to skip the CUDA tests when the CI runs for forked repositories. Currently, contributors to ILGPU get build failures because the CUDA tests cannot run.