### PR TITLE
Enabled constant propgation in all transformation pipelines.

### DIFF
--- a/Src/ILGPU/ContextFlags.cs
+++ b/Src/ILGPU/ContextFlags.cs
@@ -140,6 +140,7 @@ namespace ILGPU
         /// Disables the on-the-fly constant propagation functionality
         /// (e.g. for debugging purposes).
         /// </summary>
+        [Obsolete("This flag is no longer supported.")]
         DisableConstantPropagation = 1 << 20,
 
         /// <summary>

--- a/Src/ILGPU/IR/Construction/Arithmetic.cs
+++ b/Src/ILGPU/IR/Construction/Arithmetic.cs
@@ -50,7 +50,7 @@ namespace ILGPU.IR.Construction
             ArithmeticFlags flags)
         {
             // Check for constants
-            if (UseConstantPropagation && node is PrimitiveValue value)
+            if (node is PrimitiveValue value)
                 return UnaryArithmeticFoldConstants(location, value, kind);
 
             return
@@ -154,7 +154,7 @@ namespace ILGPU.IR.Construction
             VerifyBinaryArithmeticOperands(location, left, right, kind);
 
             Value simplified;
-            if (UseConstantPropagation && right is PrimitiveValue rightValue)
+            if (right is PrimitiveValue rightValue)
             {
                 // Check for constants
                 if (left is PrimitiveValue leftPrimitive)
@@ -298,27 +298,24 @@ namespace ILGPU.IR.Construction
             TernaryArithmeticKind kind,
             ArithmeticFlags flags)
         {
-            if (UseConstantPropagation)
+            // Check for constants
+            if (first is PrimitiveValue firstValue &&
+                second is PrimitiveValue secondValue)
             {
-                // Check for constants
-                if (first is PrimitiveValue firstValue &&
-                    second is PrimitiveValue secondValue)
-                {
-                    var value = BinaryArithmeticFoldConstants(
-                        location,
-                        firstValue,
-                        secondValue,
-                        TernaryArithmeticValue.GetLeftBinaryKind(kind),
-                        flags);
+                var value = BinaryArithmeticFoldConstants(
+                    location,
+                    firstValue,
+                    secondValue,
+                    TernaryArithmeticValue.GetLeftBinaryKind(kind),
+                    flags);
 
-                    // Try to fold right hand side as well
-                    var rightOperation = TernaryArithmeticValue.GetRightBinaryKind(kind);
-                    return CreateArithmetic(
-                        location,
-                        value,
-                        third,
-                        rightOperation);
-                }
+                // Try to fold right hand side as well
+                var rightOperation = TernaryArithmeticValue.GetRightBinaryKind(kind);
+                return CreateArithmetic(
+                    location,
+                    value,
+                    third,
+                    rightOperation);
             }
 
             return Append(new TernaryArithmeticValue(

--- a/Src/ILGPU/IR/Construction/Cast.cs
+++ b/Src/ILGPU/IR/Construction/Cast.cs
@@ -158,7 +158,7 @@ namespace ILGPU.IR.Construction
             Value node)
         {
             var primitiveType = node.Type.As<PrimitiveType>(location);
-            if (UseConstantPropagation && node is PrimitiveValue primitive)
+            if (node is PrimitiveValue primitive)
             {
                 return primitiveType.BasicValueType switch
                 {
@@ -204,7 +204,7 @@ namespace ILGPU.IR.Construction
             Value node)
         {
             var primitiveType = node.Type.As<PrimitiveType>(location);
-            if (UseConstantPropagation && node is PrimitiveValue primitive)
+            if (node is PrimitiveValue primitive)
             {
                 return primitiveType.BasicValueType switch
                 {

--- a/Src/ILGPU/IR/Construction/Convert.cs
+++ b/Src/ILGPU/IR/Construction/Convert.cs
@@ -172,7 +172,7 @@ namespace ILGPU.IR.Construction
 
 
             // Match primitive types
-            if (UseConstantPropagation && node is PrimitiveValue value)
+            if (node is PrimitiveValue value)
             {
                 var targetBasicValueType = targetType.BasicValueType;
 

--- a/Src/ILGPU/IR/Construction/IRBuilder.cs
+++ b/Src/ILGPU/IR/Construction/IRBuilder.cs
@@ -33,8 +33,6 @@ namespace ILGPU.IR.Construction
         {
             BasicBlock = basicBlock;
             BaseContext = Method.BaseContext;
-            UseConstantPropagation = !BaseContext.HasFlags(
-                ContextFlags.DisableConstantPropagation);
         }
 
         #endregion
@@ -55,11 +53,6 @@ namespace ILGPU.IR.Construction
         /// Returns the associated basic block.
         /// </summary>
         public BasicBlock BasicBlock { get; }
-
-        /// <summary>
-        /// True, if the IR builder should use constant propagation.
-        /// </summary>
-        public bool UseConstantPropagation { get; }
 
         #endregion
 

--- a/Src/ILGPU/IR/Construction/Predicate.cs
+++ b/Src/ILGPU/IR/Construction/Predicate.cs
@@ -41,52 +41,49 @@ namespace ILGPU.IR.Construction
             }
 
             // Match simple constant predicates
-            if (UseConstantPropagation)
-            {
-                if (condition is PrimitiveValue constant)
-                    return constant.Int1Value ? trueValue : falseValue;
+            if (condition is PrimitiveValue constant)
+                return constant.Int1Value ? trueValue : falseValue;
 
-                // Match bool predicates that can be represented via simple expressions
-                if (trueValue.BasicValueType == BasicValueType.Int1)
+            // Match bool predicates that can be represented via simple expressions
+            if (trueValue.BasicValueType == BasicValueType.Int1)
+            {
+                // Check for two cases: condition ? True : falseValue
+                //                       --> condition | falseValue
+                //                      condition ? False : falseValue
+                //                       --> !condition & falseValue
+                if (trueValue is PrimitiveValue truePrimitive)
                 {
-                    // Check for two cases: condition ? True : falseValue
-                    //                       --> condition | falseValue
-                    //                      condition ? False : falseValue
-                    //                       --> !condition & falseValue
-                    if (trueValue is PrimitiveValue truePrimitive)
+                    var kind = BinaryArithmeticKind.Or;
+                    // Check for: condition ? False ...
+                    if (!truePrimitive.Int1Value)
                     {
-                        var kind = BinaryArithmeticKind.Or;
-                        // Check for: condition ? False ...
-                        if (!truePrimitive.Int1Value)
-                        {
-                            kind = BinaryArithmeticKind.And;
-                            condition = CreateArithmetic(
-                                location,
-                                condition,
-                                UnaryArithmeticKind.Not);
-                        }
-                        return CreateArithmetic(
+                        kind = BinaryArithmeticKind.And;
+                        condition = CreateArithmetic(
                             location,
                             condition,
-                            falseValue,
-                            kind,
-                            ArithmeticFlags.Unsigned);
+                            UnaryArithmeticKind.Not);
                     }
-                    // Move constants to the left
-                    else if (falseValue is PrimitiveValue falsePrimitive)
-                    {
-                        return CreatePredicate(
-                            location,
-                            CreateArithmetic(
-                                location,
-                                condition,
-                                UnaryArithmeticKind.Not),
-                            falseValue,
-                            trueValue);
-                    }
-
-                    // If we arrive here we cannot merge any constants
+                    return CreateArithmetic(
+                        location,
+                        condition,
+                        falseValue,
+                        kind,
+                        ArithmeticFlags.Unsigned);
                 }
+                // Move constants to the left
+                else if (falseValue is PrimitiveValue falsePrimitive)
+                {
+                    return CreatePredicate(
+                        location,
+                        CreateArithmetic(
+                            location,
+                            condition,
+                            UnaryArithmeticKind.Not),
+                        falseValue,
+                        trueValue);
+                }
+
+                // If we arrive here we cannot merge any constants
             }
 
             // Match negated predicates


### PR DESCRIPTION
Currently, constant propagation is enabled by default within all transformation pipelines. However, there has been an option to disable all constant propagation features, mainly for compiler debugging purposes. This PR removes the ability to disable constant propagation, which simplifies code generation internals and improves code coverage in terms of available test cases.