### PR TITLE
Pin .NET Core SDK version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,8 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 3.1.407
+      - name: Pin .NET Core SDK
+        run: dotnet new globaljson --sdk-version 3.1.407
       - name: Restore tools
         run: dotnet tool restore
         working-directory: ./Src

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.300
+          dotnet-version: 3.1.407
       - name: Restore tools
         run: dotnet tool restore
         working-directory: ./Src

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+env:
+  DOTNET_NOLOGO: true
+
 jobs:
   check-style:
     runs-on: windows-latest


### PR DESCRIPTION
This PR fixes the latest build failures on macOS ([example](https://github.com/m4rs-mt/ILGPU/pull/428/checks?check_run_id=2090486774)) by pinning the version of the .NET Core SDK used in the CI. It does so by generating a `global.json` file during the workflow run. This prevents `dotnet` from using the latest available SDK installed on the GitHub Actions runner (which is unfortunately incompatible with ILGPU at this time — and might be again in the future).

This PR also upgrades the CI workflow to use the latest version of .NET Core 3.1 (3.1.407) and disables displaying the "welcome screen" (aka the logo).