### PR TITLE
Fixed bounds check on large views.

### DIFF
--- a/Src/ILGPU/ArrayView.cs
+++ b/Src/ILGPU/ArrayView.cs
@@ -229,11 +229,7 @@ namespace ILGPU
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             [ViewIntrinsic(ViewIntrinsicKind.GetViewElementAddressByIndex)]
-            get
-            {
-                IndexTypeExtensions.AssertIntIndex(Length);
-                return ref this[(long)index.X];
-            }
+            get => ref this[(long)index.X];
         }
 
         /// <summary>
@@ -257,11 +253,7 @@ namespace ILGPU
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             [ViewIntrinsic(ViewIntrinsicKind.GetViewElementAddress)]
-            get
-            {
-                IndexTypeExtensions.AssertIntIndex(Length);
-                return ref this[(long)index];
-            }
+            get => ref this[(long)index];
         }
 
         /// <summary>
@@ -360,11 +352,8 @@ namespace ILGPU
         /// <returns>The new sub view.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [ViewIntrinsic(ViewIntrinsicKind.GetSubView)]
-        public ArrayView<T> GetSubView(int index, int subViewLength)
-        {
-            IndexTypeExtensions.AssertIntIndexRange(Length);
-            return GetSubView((long)index, subViewLength);
-        }
+        public ArrayView<T> GetSubView(int index, int subViewLength) =>
+            GetSubView((long)index, subViewLength);
 
         /// <summary>
         /// Returns a sub view of the current view starting at the given offset.

--- a/Src/ILGPU/Frontend/Intrinsic/ViewIntrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/ViewIntrinsics.cs
@@ -161,20 +161,20 @@ namespace ILGPU.Frontend.Intrinsic
             // Build a new assertion
             if (context.Context.HasFlags(ContextFlags.EnableAssertions))
             {
+                // Convert the index to 'long'.
+                var index64 = index.BasicValueType == BasicValueType.Int64
+                    ? index
+                    : builder.CreateConvertToInt64(location, index).Resolve();
+
                 // Determine base offset and max length
-                var baseOffset = builder.CreatePrimitiveValue(
-                    location,
-                    index.BasicValueType,
-                    0L);
-                var viewLength = index.BasicValueType == BasicValueType.Int64
-                    ? builder.CreateGetViewLongLength(location, instanceValue)
-                    : builder.CreateGetViewLength(location, instanceValue);
+                var baseOffset = builder.CreatePrimitiveValue(location, 0L);
+                var viewLength = builder.CreateGetViewLongLength(location, instanceValue);
 
                 // Verify the lower bound, which must be >= 0 in all cases:
                 // index >= 0
                 var lowerBoundsCheck = builder.CreateCompare(
                     location,
-                    index,
+                    index64,
                     baseOffset,
                     CompareKind.GreaterEqual);
 
@@ -186,11 +186,11 @@ namespace ILGPU.Frontend.Intrinsic
                     builder.CreateCompare(
                         location,
                         viewLength,
-                        builder.CreatePrimitiveValue(location, 0),
+                        builder.CreatePrimitiveValue(location, 0L),
                         CompareKind.LessThan),
                     builder.CreateCompare(
                         location,
-                        index,
+                        index64,
                         viewLength,
                         CompareKind.LessThan),
                     BinaryArithmeticKind.Or);

--- a/Src/ILGPU/Frontend/Intrinsic/ViewIntrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/ViewIntrinsics.cs
@@ -76,8 +76,8 @@ namespace ILGPU.Frontend.Intrinsic
                 context[paramOffset++]);
             return attribute.IntrinsicKind switch
             {
-                ViewIntrinsicKind.GetViewLength => builder.CreateGetViewLength(
-                    location,
+                ViewIntrinsicKind.GetViewLength => GetViewLength(
+                    ref context,
                     instanceValue),
                 ViewIntrinsicKind.GetViewLongLength => builder.CreateGetViewLongLength(
                     location,
@@ -120,7 +120,7 @@ namespace ILGPU.Frontend.Intrinsic
                     CompareKind.GreaterThan),
                 ViewIntrinsicKind.GetViewExtent => builder.CreateIndex(
                     location,
-                    builder.CreateGetViewLength(location, instanceValue)),
+                    GetViewLength(ref context, instanceValue)),
                 ViewIntrinsicKind.GetViewLongExtent => builder.CreateIndex(
                     location,
                     builder.CreateGetViewLongLength(location, instanceValue)),
@@ -244,6 +244,48 @@ namespace ILGPU.Frontend.Intrinsic
             for (int i = 1, e = context.NumArguments; i < e; ++i)
                 callBuilder.Add(context[i]);
             return callBuilder.Seal();
+        }
+
+        /// <summary>
+        /// Constructs a new view length that is bounds checked in debug mode.
+        /// </summary>
+        private static ValueReference GetViewLength(
+            ref InvocationContext context,
+            Value instanceValue)
+        {
+            var builder = context.Builder;
+            var location = context.Location;
+
+            // Build a new assertion
+            if (context.Context.HasFlags(ContextFlags.EnableAssertions))
+            {
+                // When reading the length of a 64-bit ArrayView as a 32-bit value,
+                // the upper 32 bits will be discarded. This will cause truncation
+                // when the length is greater than int.MaxValue.
+                //
+                // Verify the bounds:
+                // viewLength >= 0 && viewLength <= int.MaxValue
+                var viewLength = builder.CreateGetViewLongLength(location, instanceValue);
+                var inRange = builder.CreateArithmetic(
+                    location,
+                    builder.CreateCompare(
+                        location,
+                        viewLength,
+                        builder.CreatePrimitiveValue(location, 0L),
+                        CompareKind.GreaterEqual),
+                    builder.CreateCompare(
+                        location,
+                        viewLength,
+                        builder.CreatePrimitiveValue(location, (long)int.MaxValue),
+                        CompareKind.LessEqual),
+                    BinaryArithmeticKind.And);
+                builder.CreateDebugAssert(
+                    location,
+                    inRange,
+                    builder.CreatePrimitiveValue(location, "32-bit index out of range"));
+            }
+
+            return builder.CreateGetViewLength(location, instanceValue);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/m4rs-mt/ILGPU/issues/429.

When injection assertions into Cuda kernels, the `index` should be converted to `long`. Otherwise, if the length of the `ArrayView` is larger than `int.MaxValue`, the upper 32 bits will be truncated.

QUESTION: What should we do about the differences between CPU and Cuda accelerators?
On the CPU, the assertion will check if `ArrayView.Length` is less than `int.MaxValue`. This is not checked on the GPU.