### PR TITLE
Gracefully fail when loading symbols from in-memory assemblies.

### DIFF
--- a/Src/ILGPU/Frontend/DebugInformation/DebugInformationManager.cs
+++ b/Src/ILGPU/Frontend/DebugInformation/DebugInformationManager.cs
@@ -150,17 +150,12 @@ namespace ILGPU.Frontend.DebugInformation
             public DebugInformationManager Parent { get; }
 
             /// <summary cref="ILoader.Load(Assembly, out AssemblyDebugInformation)"/>
-            [SuppressMessage(
-                "Microsoft.Design",
-                "CA1031:DoNotCatchGeneralExceptionTypes",
-                Justification = "Loading exceptions will be published on the " +
-                "debug output")]
             public bool Load(
                 Assembly assembly,
                 out AssemblyDebugInformation assemblyDebugInformation)
             {
                 assemblyDebugInformation = null;
-                if (assembly.IsDynamic)
+                if (assembly.IsDynamic || string.IsNullOrEmpty(assembly.Location))
                     return false;
 
                 var debugDir = Path.GetDirectoryName(assembly.Location);


### PR DESCRIPTION
When using Roslyn to compile code at run-time, if the `Assembly` is in-memory, it is not considered to be "dynamic" and has an empty location. This PR gracefully ignores assemblies without a location (skipping symbols), rather than throwing an exception and preventing the kernel from loading.

NOTE: `Assembly.Load` has an overload for passing the PDB bytes, but it is currently unknown how to retrieve the embedded symbols from the assembly.