### PR TITLE
Record call stack during compilation for error reporting.

### DIFF
--- a/Src/ILGPU/Frontend/CodeGenerator/CodeGenerator.cs
+++ b/Src/ILGPU/Frontend/CodeGenerator/CodeGenerator.cs
@@ -46,17 +46,20 @@ namespace ILGPU.Frontend
         /// <param name="disassembledMethod">
         /// The corresponding disassembled method.
         /// </param>
+        /// <param name="compilationStackLocation">The source location.</param>
         /// <param name="detectedMethods">The set of newly detected methods.</param>
         public CodeGenerator(
             ILFrontend frontend,
             IRContext context,
             Method.Builder methodBuilder,
             DisassembledMethod disassembledMethod,
-            HashSet<MethodBase> detectedMethods)
+            CompilationStackLocation compilationStackLocation,
+            Dictionary<MethodBase, CompilationStackLocation> detectedMethods)
         {
             Frontend = frontend;
             Context = context;
             DisassembledMethod = disassembledMethod;
+            CompilationStackLocation = compilationStackLocation;
             DetectedMethods = detectedMethods;
 
             cfgBuilder = new Block.CFGBuilder(this, methodBuilder);
@@ -174,7 +177,7 @@ namespace ILGPU.Frontend
         /// <summary>
         /// Returns the set of detected methods.
         /// </summary>
-        private HashSet<MethodBase> DetectedMethods { get; }
+        private Dictionary<MethodBase, CompilationStackLocation> DetectedMethods { get; }
 
         /// <summary>
         /// Returns the associated frontend.
@@ -215,6 +218,11 @@ namespace ILGPU.Frontend
         /// Returns the entry block.
         /// </summary>
         public Block EntryBlock { get; }
+
+        /// <summary>
+        /// Gets or sets the source location.
+        /// </summary>
+        private CompilationStackLocation CompilationStackLocation { get; }
 
         #endregion
 
@@ -260,8 +268,14 @@ namespace ILGPU.Frontend
             // current IR context.
             var result = Context.Declare(methodBase, out bool created);
 
-            if (created && result.HasImplementation)
-                DetectedMethods.Add(methodBase);
+            if (created &&
+                result.HasImplementation &&
+                !DetectedMethods.ContainsKey(methodBase))
+            {
+                DetectedMethods.Add(
+                    methodBase,
+                    CompilationStackLocation.Append(Location));
+            }
             return result;
         }
 
@@ -330,14 +344,15 @@ namespace ILGPU.Frontend
                 catch (Exception e)
                 {
                     // Wrap generic exceptions with location information.
-                    throw Location.GetException(e);
+                    throw CompilationStackLocation.Append(Location).GetException(e);
                 }
                 if (!generated)
                 {
-                    throw Location.GetNotSupportedException(
-                        ErrorMessages.NotSupportedInstruction,
-                        instruction,
-                        Method.Name);
+                    throw CompilationStackLocation.Append(Location)
+                        .GetNotSupportedException(
+                            ErrorMessages.NotSupportedInstruction,
+                            instruction,
+                            Method.Name);
                 }
             }
 
@@ -385,9 +400,12 @@ namespace ILGPU.Frontend
                     "System.Reflection",
                     StringComparison.OrdinalIgnoreCase))
             {
-                throw Location.GetNotSupportedException(
-                    ErrorMessages.NotSupportedRuntimeMethod,
-                    method.Name);
+                throw CompilationStackLocation
+                    .Append(Location)
+                    .Append(new Method.MethodLocation(method))
+                    .GetNotSupportedException(
+                        ErrorMessages.NotSupportedRuntimeMethod,
+                        method.Name);
             }
         }
 
@@ -405,7 +423,7 @@ namespace ILGPU.Frontend
             if (isInitOnly &&
                 !Context.HasFlags(ContextFlags.InlineMutableStaticFieldValues))
             {
-                throw Location.GetNotSupportedException(
+                throw CompilationStackLocation.Append(Location).GetNotSupportedException(
                     ErrorMessages.NotSupportedLoadOfStaticField,
                     field);
             }
@@ -422,7 +440,7 @@ namespace ILGPU.Frontend
 
             if (!Context.HasFlags(ContextFlags.IgnoreStaticFieldStores))
             {
-                throw Location.GetNotSupportedException(
+                throw CompilationStackLocation.Append(Location).GetNotSupportedException(
                     ErrorMessages.NotSupportedStoreToStaticField,
                     field);
             }
@@ -480,7 +498,10 @@ namespace ILGPU.Frontend
             ConvertFlags flags)
         {
             if (type == null || !address.Type.IsPointerType)
-                throw Location.GetInvalidOperationException();
+            {
+                throw CompilationStackLocation.Append(Location)
+                    .GetInvalidOperationException();
+            }
 
             address = CreateConversion(
                 address,
@@ -499,7 +520,10 @@ namespace ILGPU.Frontend
         private void CreateStore(Value address, Value value)
         {
             if (!address.Type.IsPointerType)
-                throw Location.GetInvalidOperationException();
+            {
+                throw CompilationStackLocation.Append(Location)
+                    .GetInvalidOperationException();
+            }
 
             address = CreateConversion(
                 address,

--- a/Src/ILGPU/IR/Location.cs
+++ b/Src/ILGPU/IR/Location.cs
@@ -189,12 +189,29 @@ namespace ILGPU.IR
         /// Formats the given message to include detailed file location information.
         /// </summary>
         public override string FormatErrorMessage(string message) =>
-            string.Format(
-                ErrorMessages.LocationFileMessage,
+            StartLine == EndLine
+            ? StartColumn == EndColumn
+                ? string.Format(
+                    ErrorMessages.LocationFileMessageL1C1,
+                        message,
+                        FileName,
+                        StartLine,
+                        StartColumn)
+                : string.Format(
+                    ErrorMessages.LocationFileMessageL1C2,
+                        message,
+                        FileName,
+                        StartLine,
+                        StartColumn,
+                        EndColumn)
+            : string.Format(
+                ErrorMessages.LocationFileMessageL2C2,
                 message,
                 FileName,
-                StartLine.ToString(),
-                EndLine.ToString());
+                StartLine,
+                StartColumn,
+                EndLine,
+                EndColumn);
 
         /// <summary>
         /// Merges this location with the other one.

--- a/Src/ILGPU/Resources/ErrorMessages.Designer.cs
+++ b/Src/ILGPU/Resources/ErrorMessages.Designer.cs
@@ -259,7 +259,16 @@ namespace ILGPU.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; in file &apos;{1}&apos;, line {2} column {3}.
+        ///   Looks up a localized string similar to -.
+        /// </summary>
+        internal static string LocationCompilationStackLinePrefix {
+            get {
+                return ResourceManager.GetString("LocationCompilationStackLinePrefix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} in file &apos;{1}&apos;, line {2} column {3}.
         /// </summary>
         internal static string LocationFileMessageL1C1 {
             get {
@@ -268,7 +277,7 @@ namespace ILGPU.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; in file &apos;{1}&apos;, line {2} column {3} to {4}.
+        ///   Looks up a localized string similar to {0} in file &apos;{1}&apos;, line {2} column {3} to {4}.
         /// </summary>
         internal static string LocationFileMessageL1C2 {
             get {
@@ -277,7 +286,7 @@ namespace ILGPU.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; in file &apos;{1}&apos;, line {2} column {3} to line {4} column {5}.
+        ///   Looks up a localized string similar to {0} in file &apos;{1}&apos;, line {2} column {3} to line {4} column {5}.
         /// </summary>
         internal static string LocationFileMessageL2C2 {
             get {
@@ -286,7 +295,7 @@ namespace ILGPU.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; in method {1} declared in type {2}.
+        ///   Looks up a localized string similar to {0} in method {1} declared in type {2}.
         /// </summary>
         internal static string LocationMethodMessage {
             get {

--- a/Src/ILGPU/Resources/ErrorMessages.Designer.cs
+++ b/Src/ILGPU/Resources/ErrorMessages.Designer.cs
@@ -259,11 +259,29 @@ namespace ILGPU.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; in file &apos;{1}&apos; lines {2} - {3}.
+        ///   Looks up a localized string similar to &apos;{0}&apos; in file &apos;{1}&apos;, line {2} column {3}.
         /// </summary>
-        internal static string LocationFileMessage {
+        internal static string LocationFileMessageL1C1 {
             get {
-                return ResourceManager.GetString("LocationFileMessage", resourceCulture);
+                return ResourceManager.GetString("LocationFileMessageL1C1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; in file &apos;{1}&apos;, line {2} column {3} to {4}.
+        /// </summary>
+        internal static string LocationFileMessageL1C2 {
+            get {
+                return ResourceManager.GetString("LocationFileMessageL1C2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; in file &apos;{1}&apos;, line {2} column {3} to line {4} column {5}.
+        /// </summary>
+        internal static string LocationFileMessageL2C2 {
+            get {
+                return ResourceManager.GetString("LocationFileMessageL2C2", resourceCulture);
             }
         }
         

--- a/Src/ILGPU/Resources/ErrorMessages.resx
+++ b/Src/ILGPU/Resources/ErrorMessages.resx
@@ -301,16 +301,19 @@
     <value>Invalid null value</value>
   </data>
   <data name="LocationFileMessageL1C1" xml:space="preserve">
-    <value>'{0}' in file '{1}', line {2} column {3}</value>
+    <value>{0} in file '{1}', line {2} column {3}</value>
   </data>
   <data name="LocationFileMessageL1C2" xml:space="preserve">
-    <value>'{0}' in file '{1}', line {2} column {3} to {4}</value>
+    <value>{0} in file '{1}', line {2} column {3} to {4}</value>
   </data>
   <data name="LocationFileMessageL2C2" xml:space="preserve">
-    <value>'{0}' in file '{1}', line {2} column {3} to line {4} column {5}</value>
+    <value>{0} in file '{1}', line {2} column {3} to line {4} column {5}</value>
   </data>
   <data name="LocationMethodMessage" xml:space="preserve">
-    <value>'{0}' in method {1} declared in type {2}</value>
+    <value>{0} in method {1} declared in type {2}</value>
+  </data>
+  <data name="LocationCompilationStackLinePrefix" xml:space="preserve">
+    <value>-</value>
   </data>
   <data name="LocationTypeMessage" xml:space="preserve">
     <value>'{0}' related to type {1} (managed type '{2}')</value>

--- a/Src/ILGPU/Resources/ErrorMessages.resx
+++ b/Src/ILGPU/Resources/ErrorMessages.resx
@@ -300,8 +300,14 @@
   <data name="InternalCompilerErrorNull" xml:space="preserve">
     <value>Invalid null value</value>
   </data>
-  <data name="LocationFileMessage" xml:space="preserve">
-    <value>'{0}' in file '{1}' lines {2} - {3}</value>
+  <data name="LocationFileMessageL1C1" xml:space="preserve">
+    <value>'{0}' in file '{1}', line {2} column {3}</value>
+  </data>
+  <data name="LocationFileMessageL1C2" xml:space="preserve">
+    <value>'{0}' in file '{1}', line {2} column {3} to {4}</value>
+  </data>
+  <data name="LocationFileMessageL2C2" xml:space="preserve">
+    <value>'{0}' in file '{1}', line {2} column {3} to line {4} column {5}</value>
   </data>
   <data name="LocationMethodMessage" xml:space="preserve">
     <value>'{0}' in method {1} declared in type {2}</value>


### PR DESCRIPTION
Related to #425.

`Math.Round` does not have a Cuda intrinsic, and therefore does not currrently have a special handler in ILGPU.Algorithms. Instead, the code is dissassembled like any other normal function.

In net5.0, `Math.Round` internally calls a method in the `System.Runtime` namespace, which is not supported by ILGPU. This throws a vague exception about the method `get_IsSupported` not being supported in `Int64BitsToDouble`. However, it is not obvious where that is being called from.

This PR tracks the compilation stack to provide more detailed information about what is causing the compilation to fail. An example exception would look like this:
```
ILGPU.InternalCompilerException
  Message=
An internal compiler error has been detected
- in method Boolean get_IsSupported() declared in type System.Runtime.Intrinsics.X86.Sse2+X64
- in method Double Int64BitsToDouble(Int64) declared in type System.BitConverter
- in method Double Round(Double) declared in type System.Math
- in file 'Program.cs', line 11 column 13 to 57
- in method Void MyKernel(ILGPU.Index1, ILGPU.ArrayView`1[System.Double]) declared in type Program

Inner Exception 1:
NotSupportedException: Not supported runtime method 'get_IsSupported'
```