### PR TITLE
Added intrinsic mappings for BitConverter functions.

### DIFF
--- a/Src/ILGPU/Frontend/Intrinsic/RemappedIntrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/RemappedIntrinsics.cs
@@ -72,6 +72,7 @@ namespace ILGPU.Frontend.Intrinsic
                 typeof(double));
 
             RegisterMathRemappings();
+            RegisterBitConverterRemappings();
         }
 
         #endregion
@@ -138,6 +139,65 @@ namespace ILGPU.Frontend.Intrinsic
         {
             if (FunctionRemappers.TryGetValue(context.Method, out var remapper))
                 remapper(ref context);
+        }
+
+        #endregion
+
+        #region BitConverter remappings
+
+        /// <summary>
+        /// Internal class to handle the signed/unsigned difference between functions
+        /// of <see cref="System.BitConverter"/> and <see cref="Interop"/>.
+        /// </summary>
+        static class BitConverter
+        {
+            /// <summary cref="System.BitConverter.DoubleToInt64Bits(double)"/>
+            public static long DoubleToInt64Bits(double value) =>
+                (long)Interop.FloatAsInt(value);
+
+            /// <summary cref="System.BitConverter.Int64BitsToDouble(long)"/>
+            public static double Int64BitsToDouble(long value) =>
+                Interop.IntAsFloat((ulong)value);
+
+#if !NETFRAMEWORK
+            /// <summary cref="System.BitConverter.SingleToInt32Bits(float)"/>
+            public static int SingleToInt32Bits(float value) =>
+                (int)Interop.FloatAsInt(value);
+
+            /// <summary cref="System.BitConverter.Int32BitsToSingle(int)"/>
+            public static float Int32BitsToSingle(int value) =>
+                Interop.IntAsFloat((uint)value);
+#endif
+        }
+
+        /// <summary>
+        /// Registers instrinsic mappings for BitConverter functions.
+        /// </summary>
+        private static void RegisterBitConverterRemappings()
+        {
+            AddRemapping(
+                typeof(System.BitConverter),
+                typeof(BitConverter),
+                nameof(System.BitConverter.DoubleToInt64Bits),
+                typeof(double));
+            AddRemapping(
+                typeof(System.BitConverter),
+                typeof(BitConverter),
+                nameof(System.BitConverter.Int64BitsToDouble),
+                typeof(long));
+
+#if !NETFRAMEWORK
+            AddRemapping(
+                typeof(System.BitConverter),
+                typeof(BitConverter),
+                nameof(System.BitConverter.SingleToInt32Bits),
+                typeof(float));
+            AddRemapping(
+                typeof(System.BitConverter),
+                typeof(BitConverter),
+                nameof(System.BitConverter.Int32BitsToSingle),
+                typeof(int));
+#endif
         }
 
         #endregion


### PR DESCRIPTION
Related to https://github.com/m4rs-mt/ILGPU/issues/425.

`Math.Round` does not have an intrinsic implementation. However, when ILGPU attempts to parse it like a normal function, in `net5.0`, the implementation of `BitConverter.Int64BitsToDouble` makes a call to `System.Runtime.Intrinsics.X86.Sse2+X64.IsSupported`. Unfortunately, ILGPU does not support code in the `System.Runtime` namespace.

This PR helps address the issue by providing intrinsic mappings for some `BitConverter` functions.