### PR TITLE
Implemented CopySign intrinsic.

### DIFF
--- a/Src/ILGPU/Backends/OpenCL/CLInstructions.Data.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLInstructions.Data.cs
@@ -369,6 +369,8 @@ namespace ILGPU.Backends.OpenCL
 
                 { (BinaryArithmeticKind.Atan2F, true), ("atan2", true) },
                 { (BinaryArithmeticKind.PowF, true), ("pow", true) },
+
+                { (BinaryArithmeticKind.CopySignF, true), ("copysign", true) },
             };
 
         private static readonly Dictionary<

--- a/Src/ILGPU/Backends/PTX/PTXInstructions.Data.cs
+++ b/Src/ILGPU/Backends/PTX/PTXInstructions.Data.cs
@@ -604,6 +604,9 @@ namespace ILGPU.Backends.PTX
                 { (BinaryArithmeticKind.Min, ArithmeticBasicValueType.Float16), "min.f16" },
                 { (BinaryArithmeticKind.Min, ArithmeticBasicValueType.Float32), "min.f32" },
                 { (BinaryArithmeticKind.Min, ArithmeticBasicValueType.Float64), "min.f64" },
+
+                { (BinaryArithmeticKind.CopySignF, ArithmeticBasicValueType.Float32), "copysign.f32" },
+                { (BinaryArithmeticKind.CopySignF, ArithmeticBasicValueType.Float64), "copysign.f64" },
             };
 
         private static readonly Dictionary<(BinaryArithmeticKind, ArithmeticBasicValueType), string> BinaryArithmeticOperationsFastMath =

--- a/Src/ILGPU/Frontend/Intrinsic/RemappedIntrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/RemappedIntrinsics.cs
@@ -73,6 +73,7 @@ namespace ILGPU.Frontend.Intrinsic
 
             RegisterMathRemappings();
             RegisterBitConverterRemappings();
+            RegisterCopySignRemappings();
         }
 
         #endregion
@@ -197,6 +198,28 @@ namespace ILGPU.Frontend.Intrinsic
                 typeof(BitConverter),
                 nameof(System.BitConverter.Int32BitsToSingle),
                 typeof(int));
+#endif
+        }
+
+        #endregion
+
+        #region CopySign remappings
+
+        private static void RegisterCopySignRemappings()
+        {
+#if !NETFRAMEWORK
+            AddRemapping(
+                typeof(Math),
+                MathType,
+                "CopySign",
+                typeof(double),
+                typeof(double));
+            AddRemapping(
+                typeof(MathF),
+                MathType,
+                "CopySign",
+                typeof(float),
+                typeof(float));
 #endif
         }
 

--- a/Src/ILGPU/IntrinsicMath.cs
+++ b/Src/ILGPU/IntrinsicMath.cs
@@ -654,5 +654,43 @@ namespace ILGPU
         public static long ComposeLong(IntegerParts parts) => (long)ComposeULong(parts);
 
         #endregion
+
+        #region CopySign
+
+        /// <summary>
+        /// Returns a value with the magnitude of x and the sign of y.
+        /// </summary>
+        /// <param name="x">A number whose magnitude is used in the result.</param>
+        /// <param name="y">A number whose sign is the used in the result.</param>
+        /// <returns>A value with the magnitude of x and the sign of y.</returns>
+        [MathIntrinsic(MathIntrinsicKind.CopySignF)]
+        public static double CopySign(double x, double y) =>
+#if !NETFRAMEWORK && !NETSTANDARD
+            Math.CopySign(x, y)
+#else
+            // NB: net47 and netstandard2.1 do not support Math.CopySign.
+            Interop.IntAsFloat(
+                (Interop.FloatAsInt(x) & ~(1UL << 63)) |
+                (Interop.FloatAsInt(y) & (1UL << 63)));
+#endif
+
+        /// <summary>
+        /// Returns a value with the magnitude of x and the sign of y.
+        /// </summary>
+        /// <param name="x">A number whose magnitude is used in the result.</param>
+        /// <param name="y">A number whose sign is the used in the result.</param>
+        /// <returns>A value with the magnitude of x and the sign of y.</returns>
+        [MathIntrinsic(MathIntrinsicKind.CopySignF)]
+        public static float CopySign(float x, float y) =>
+#if !NETFRAMEWORK && !NETSTANDARD
+            Math.CopySign(x, y)
+#else
+            // NB: net47 and netstandard2.1 do not support Math.CopySign.
+            Interop.IntAsFloat(
+                (Interop.FloatAsInt(x) & ~(1U << 31)) |
+                (Interop.FloatAsInt(y) & (1U << 31)));
+#endif
+
+        #endregion
     }
 }

--- a/Src/ILGPU/Static/BinaryMathOperations.xml
+++ b/Src/ILGPU/Static/BinaryMathOperations.xml
@@ -226,4 +226,10 @@
         <Call>IntrinsicMath.CPUOnly.Log</Call>
         <Implementation>{MathType}.Log({Value0}, {Value1})</Implementation>
     </Operation>
+
+    <Operation Name="CopySignF">
+        <Summary>The copy sign operation.</Summary>
+        <Flags>Floats</Flags>
+        <Call>IntrinsicMath.CopySign</Call>
+    </Operation>
 </Operations>


### PR DESCRIPTION
Related to https://github.com/m4rs-mt/ILGPU/issues/425.

`Math.Round` does not have an intrinsic implementation. After adding the `BitConverter` intrinsics from https://github.com/m4rs-mt/ILGPU/pull/437, there is still an additional failure because the `net5.0` implementation of `Math.CopySign` internally also makes a call to the `System.Runtime` namespace.

This PR helps address the issue by providing an intrinsic implementation for `Math.CopySign`.

When the `BitConverter` PR and the `CopySign` PR are combined, they allow `Math.Round` to be compiled by ILGPU like a normal function.