### PR TITLE
Fixed emitting switch statement with constant condition.

### DIFF
--- a/Src/ILGPU.Tests/Configurations.txt
+++ b/Src/ILGPU.Tests/Configurations.txt
@@ -40,3 +40,5 @@ BasicIfs: Debug, Release, O2
 BasicLoops: Debug, Release, O2
 BasicSwitches: Debug, Release, O2
 BasicPhis: Debug, Release, O2
+
+FormatStringTests: Debug, Release, O2

--- a/Src/ILGPU.Tests/FormatStringTests.cs
+++ b/Src/ILGPU.Tests/FormatStringTests.cs
@@ -1,0 +1,51 @@
+﻿using ILGPU.Util;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ILGPU.Tests
+{
+    public abstract class FormatStringTests : TestBase
+    {
+        protected FormatStringTests(ITestOutputHelper output, TestContext testContext)
+            : base(output, testContext)
+        { }
+
+        [Fact]
+        public void EscapedArgument()
+        {
+            Assert.True(FormatString.TryParse("{{{0}}}", out var expressions));
+            Assert.Equal(3, expressions.Length);
+            Assert.Equal("{", expressions[0].String);
+            Assert.Equal(0, expressions[1].Argument);
+            Assert.Equal("}", expressions[2].String);
+        }
+
+        [Fact]
+        public void DanglingOpenBracket()
+        {
+            Assert.True(FormatString.TryParse("{0} {", out var expressions));
+            Assert.Equal(3, expressions.Length);
+            Assert.Equal(0, expressions[0].Argument);
+            Assert.Equal(" ", expressions[1].String);
+            Assert.Equal("{", expressions[2].String);
+        }
+
+        [Fact]
+        public void DanglingCloseBracket()
+        {
+            Assert.False(FormatString.TryParse("{0} }", out _));
+        }
+
+        [Fact]
+        public void MultipleArguments()
+        {
+            Assert.True(FormatString.TryParse("{1} {0}{2} ", out var expressions));
+            Assert.Equal(5, expressions.Length);
+            Assert.Equal(1, expressions[0].Argument);
+            Assert.Equal(" ", expressions[1].String);
+            Assert.Equal(0, expressions[2].Argument);
+            Assert.Equal(2, expressions[3].Argument);
+            Assert.Equal(" ", expressions[4].String);
+        }
+    }
+}

--- a/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Terminators.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Terminators.cs
@@ -61,28 +61,21 @@ namespace ILGPU.Backends.OpenCL
         public void GenerateCode(SwitchBranch branch)
         {
             var condition = Load(branch.Condition);
-            AppendIndent();
-            Builder.Append("switch (");
-            Builder.Append(condition.ToString());
-            Builder.AppendLine(")");
+            var indentStr = new string('\t', Indent);
 
-            AppendIndent();
-            Builder.AppendLine("{");
-
+            using var statement = BeginStatement($"switch ({condition}) {{\n");
             for (int i = 0, e = branch.NumCasesWithoutDefault; i < e; ++i)
             {
-                Builder.Append("case ");
-                Builder.Append(i.ToString());
-                Builder.AppendLine(":");
-                PushAndAppendIndent();
-                GotoStatement(branch.GetCaseTarget(i));
-                PopIndent();
+                statement.AppendOperation("{0}case {1}:\n{0}\t{2} {3};\n",
+                    indentStr,
+                    i,
+                    CLInstructions.GotoStatement,
+                    branch.GetCaseTarget(i));
             }
-
-            AppendIndent();
-            Builder.AppendLine("default:");
-            GotoStatement(branch.Targets[0]);
-            Builder.AppendLine("}");
+            statement.AppendOperation("{0}default:\n{0}\t{1} {2};\n{0}}}",
+                indentStr,
+                CLInstructions.GotoStatement,
+                branch.Targets[0]);
         }
     }
 }

--- a/Src/ILGPU/Frontend/Intrinsic/InteropIntrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/InteropIntrinsics.cs
@@ -133,7 +133,7 @@ namespace ILGPU.Frontend.Intrinsic
         {
             // Parse format expression and ensure valid argument references
             var location = context.Location;
-            if (!WriteToOutput.TryParse(formatExpression, out var expressions))
+            if (!FormatString.TryParse(formatExpression, out var expressions))
             {
                 throw location.GetNotSupportedException(
                     ErrorMessages.NotSupportedWriteFormat,

--- a/Src/ILGPU/IR/Construction/IOValues.cs
+++ b/Src/ILGPU/IR/Construction/IOValues.cs
@@ -11,7 +11,7 @@
 
 using ILGPU.IR.Values;
 using FormatArray = System.Collections.Immutable.ImmutableArray<
-    ILGPU.IR.Values.WriteToOutput.FormatExpression>;
+    ILGPU.Util.FormatString.FormatExpression>;
 using ValueList = ILGPU.Util.InlineList<ILGPU.IR.Values.ValueReference>;
 
 namespace ILGPU.IR.Construction

--- a/Src/ILGPU/IR/Values/IOValues.cs
+++ b/Src/ILGPU/IR/Values/IOValues.cs
@@ -18,7 +18,7 @@ using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
 using System.Text;
 using FormatArray = System.Collections.Immutable.ImmutableArray<
-    ILGPU.IR.Values.WriteToOutput.FormatExpression>;
+    ILGPU.Util.FormatString.FormatExpression>;
 using ValueList = ILGPU.Util.InlineList<ILGPU.IR.Values.ValueReference>;
 
 namespace ILGPU.IR.Values
@@ -49,47 +49,6 @@ namespace ILGPU.IR.Values
     public sealed class WriteToOutput : IOValue
     {
         #region Nested Types
-
-        /// <summary>
-        /// Represents a single format command.
-        /// </summary>
-        public readonly struct FormatExpression
-        {
-            /// <summary>
-            /// Constructs a new format expression.
-            /// </summary>
-            /// <param name="string">The string expression.</param>
-            public FormatExpression(string @string)
-            {
-                String = @string ?? string.Empty;
-                Argument = -1;
-            }
-
-            /// <summary>
-            /// Constructs a new format expression.
-            /// </summary>
-            /// <param name="argument">The argument reference.</param>
-            public FormatExpression(int argument)
-            {
-                String = null;
-                Argument = argument;
-            }
-
-            /// <summary>
-            /// Returns the string to output (if any).
-            /// </summary>
-            public string String { get; }
-
-            /// <summary>
-            /// Returns the argument reference to output.
-            /// </summary>
-            public int Argument { get; }
-
-            /// <summary>
-            /// Returns true if the current expression has an argument reference.
-            /// </summary>
-            public readonly bool HasArgument => String is null;
-        }
 
         /// <summary>
         /// Represents an write argument collection.
@@ -240,59 +199,6 @@ namespace ILGPU.IR.Values
                 default:
                     return value;
             }
-        }
-
-        /// <summary>
-        /// Parses the given format expression into an array of format expressions.
-        /// </summary>
-        /// <param name="formatExpression">The format expression.</param>
-        /// <param name="expressions">The array of managed format expressions.</param>
-        /// <returns>True, if all expressions could be parsed successfully.</returns>
-        public static bool TryParse(string formatExpression, out FormatArray expressions)
-        {
-            expressions = FormatArray.Empty;
-
-            // Search for '{xyz}' patterns
-            var result = ImmutableArray.CreateBuilder<FormatExpression>(10);
-            while (formatExpression.Length > 0)
-            {
-                // Search for next {
-                int startIndex = formatExpression.IndexOf('{', 0);
-                if (startIndex < 0)
-                {
-                    result.Add(new FormatExpression(formatExpression));
-                    break;
-                }
-                else if (startIndex > 0)
-                {
-                    result.Add(new FormatExpression(
-                        formatExpression.Substring(0, startIndex)));
-                }
-
-                // Search for next }
-                int endIndex = formatExpression.IndexOf('}', startIndex);
-                if (endIndex < 0)
-                {
-                    result.Add(new FormatExpression(formatExpression));
-                    break;
-                }
-
-                // Check sub expression
-                var subExpr = formatExpression.Substring(
-                    startIndex + 1,
-                    endIndex - startIndex - 1);
-
-                // Check whether the argument can be resolved to an integer
-                if (!int.TryParse(subExpr, out int argument) || argument < 0)
-                    return false;
-
-                // Append current argument
-                result.Add(new FormatExpression(argument));
-                formatExpression = formatExpression.Substring(endIndex + 1);
-            }
-
-            expressions = result.ToImmutable();
-            return true;
         }
 
         #endregion

--- a/Src/ILGPU/Util/FormatString.cs
+++ b/Src/ILGPU/Util/FormatString.cs
@@ -1,0 +1,123 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                        Copyright (c) 2016-2020 Marcel Koester
+//                                    www.ilgpu.net
+//
+// File: FormatString.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Immutable;
+using FormatArray = System.Collections.Immutable.ImmutableArray<
+    ILGPU.Util.FormatString.FormatExpression>;
+
+namespace ILGPU.Util
+{
+    /// <summary>
+    /// Helper class to parse a string containing .NET style string formatting.
+    /// e.g. "Hello {0}"
+    /// </summary>
+    public static class FormatString
+    {
+        #region Nested Types
+
+        /// <summary>
+        /// Represents a single format command.
+        /// </summary>
+        public readonly struct FormatExpression
+        {
+            /// <summary>
+            /// Constructs a new format expression.
+            /// </summary>
+            /// <param name="string">The string expression.</param>
+            public FormatExpression(string @string)
+            {
+                String = @string ?? string.Empty;
+                Argument = -1;
+            }
+
+            /// <summary>
+            /// Constructs a new format expression.
+            /// </summary>
+            /// <param name="argument">The argument reference.</param>
+            public FormatExpression(int argument)
+            {
+                String = null;
+                Argument = argument;
+            }
+
+            /// <summary>
+            /// Returns the string to output (if any).
+            /// </summary>
+            public string String { get; }
+
+            /// <summary>
+            /// Returns the argument reference to output.
+            /// </summary>
+            public int Argument { get; }
+
+            /// <summary>
+            /// Returns true if the current expression has an argument reference.
+            /// </summary>
+            public readonly bool HasArgument => String is null;
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Parses the given format expression into an array of format expressions.
+        /// </summary>
+        /// <param name="formatExpression">The format expression.</param>
+        /// <param name="expressions">The array of managed format expressions.</param>
+        /// <returns>True, if all expressions could be parsed successfully.</returns>
+        public static bool TryParse(string formatExpression, out FormatArray expressions)
+        {
+            expressions = FormatArray.Empty;
+
+            // Search for '{xyz}' patterns
+            var result = ImmutableArray.CreateBuilder<FormatExpression>(10);
+            while (formatExpression.Length > 0)
+            {
+                // Search for next {
+                int startIndex = formatExpression.IndexOf('{', 0);
+                if (startIndex < 0)
+                {
+                    result.Add(new FormatExpression(formatExpression));
+                    break;
+                }
+                else if (startIndex > 0)
+                {
+                    result.Add(new FormatExpression(
+                        formatExpression.Substring(0, startIndex)));
+                }
+
+                // Search for next }
+                int endIndex = formatExpression.IndexOf('}', startIndex);
+                if (endIndex < 0)
+                {
+                    result.Add(new FormatExpression(formatExpression));
+                    break;
+                }
+
+                // Check sub expression
+                var subExpr = formatExpression.Substring(
+                    startIndex + 1,
+                    endIndex - startIndex - 1);
+
+                // Check whether the argument can be resolved to an integer
+                if (!int.TryParse(subExpr, out int argument) || argument < 0)
+                    return false;
+
+                // Append current argument
+                result.Add(new FormatExpression(argument));
+                formatExpression = formatExpression.Substring(endIndex + 1);
+            }
+
+            expressions = result.ToImmutable();
+            return true;
+        }
+    }
+}

--- a/Src/ILGPU/Util/RawString.cs
+++ b/Src/ILGPU/Util/RawString.cs
@@ -1,0 +1,53 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                        Copyright (c) 2016-2020 Marcel Koester
+//                                    www.ilgpu.net
+//
+// File: RawString.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+
+using System;
+
+// disable: max_line_length
+
+namespace ILGPU.Util
+{
+    /// <summary>
+    /// Helper to coerce the C# compiler into preferencing the FormattableString
+    /// overload of a function, and to also accept a regular string.
+    ///
+    /// https://www.damirscorner.com/blog/posts/20180921-FormattableStringAsMethodParameter.html
+    /// </summary>
+    public struct RawString
+    {
+        /// <summary>
+        /// The string value.
+        /// </summary>
+        public string Value { get; }
+
+        private RawString(string value)
+        {
+            Value = value;
+        }
+
+        /// <summary>
+        /// Implicit conversion from string.
+        /// </summary>
+        /// <param name="value">The string value.</param>
+        public static implicit operator RawString(string value) =>
+            new RawString(value);
+
+        /// <summary>
+        /// Implicit conversion from <see cref="FormattableString"/>.
+        /// </summary>
+        /// <remarks>
+        /// This should not be used, but is necessary to coerce the C# compiler.
+        /// </remarks>
+        /// <param name="value">The string value.</param>
+        public static implicit operator RawString(FormattableString value) =>
+            new RawString(value.ToString());
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/m4rs-mt/ILGPU/issues/441.

Refactored parsing of string format from WriteToOutput into a utility class so that it can be shared.
Also refactored that parsing code to use spans, and also support escapeing brackets. 

Added `FormattableString` to `StatementEmitter`, with support for `Variable`, `BasicBlock` and all basic types.
This was then used to generate a `switch` statement that could handle a constant condition.

NOTE: I have not tried to emit an optimised `switch` statement with a single `goto` branch, like the `if` condition. Should I add this optimisation? or should we require that the ILGPU compilation transforms perform the folding?