### PR TITLE
Removed incorrect assertion on repeating successors.

### DIFF
--- a/Src/ILGPU/Frontend/Block.CFGBuilder.cs
+++ b/Src/ILGPU/Frontend/Block.CFGBuilder.cs
@@ -164,8 +164,6 @@ namespace ILGPU.Frontend
                     successors = new List<Block>();
                     successorMapping.Add(current, successors);
                 }
-                current.BasicBlock.Assert(
-                    !successors.Contains(successor));
                 successors.Add(successor);
             }
 


### PR DESCRIPTION
Fixes #445.

Removed assertion that the successor should not already exist.

It looks like the MSIL code itself is repeating the same successor:
`IL_001f: switch (IL_004a, IL_003e, IL_0056, IL_0044, IL_0056, IL_0050)`


Full MSIL:
```CSharp
.method public hidebysig static void MyKernel (
            valuetype [ILGPU]ILGPU.Index1 index,
            valuetype [ILGPU]ILGPU.ArrayView`1<float64> output,
            char func
        ) cil managed 
    {
        .locals init (
            [0] float64 V_0,
            [1] float64 V_1,
            [2] float64 V_2,
            [3] char V_3,
            [4] char V_4
        )

        IL_0000: nop
        IL_0001: ldarga.s output
        IL_0003: ldarg.0
        IL_0004: call instance float64& valuetype [ILGPU]ILGPU.ArrayView`1<float64>::get_Item(valuetype [ILGPU]ILGPU.Index1)
        IL_0009: ldind.r8
        IL_000a: stloc.1
        IL_000b: ldarga.s output
        IL_000d: ldarg.0
        IL_000e: call instance float64& valuetype [ILGPU]ILGPU.ArrayView`1<float64>::get_Item(valuetype [ILGPU]ILGPU.Index1)
        IL_0013: ldind.r8
        IL_0014: stloc.2
        IL_0015: ldarg.2
        IL_0016: stloc.s V_4
        IL_0018: ldloc.s V_4
        IL_001a: stloc.3
        IL_001b: ldloc.3
        IL_001c: ldc.i4.s 42
        IL_001e: sub
        IL_001f: switch (IL_004a, IL_003e, IL_0056, IL_0044, IL_0056, IL_0050)

        IL_003c: br.s IL_0056

        IL_003e: ldloc.1
        IL_003f: ldloc.2
        IL_0040: add
        IL_0041: stloc.0
        IL_0042: br.s IL_0062

        IL_0044: ldloc.1
        IL_0045: ldloc.2
        IL_0046: sub
        IL_0047: stloc.0
        IL_0048: br.s IL_0062

        IL_004a: ldloc.1
        IL_004b: ldloc.2
        IL_004c: mul
        IL_004d: stloc.0
        IL_004e: br.s IL_0062

        IL_0050: ldloc.1
        IL_0051: ldloc.2
        IL_0052: div
        IL_0053: stloc.0
        IL_0054: br.s IL_0062

        IL_0056: ldc.r8 0.0
        IL_005f: stloc.0
        IL_0060: br.s IL_0062

        IL_0062: ldarga.s output
        IL_0064: ldc.i4.0
        IL_0065: call instance float64& valuetype [ILGPU]ILGPU.ArrayView`1<float64>::get_Item(int32)
        IL_006a: ldloc.0
        IL_006b: stind.r8
        IL_006c: ret
    }
```