### PR TITLE
Another compatibility fix for .NET 5.0

### DIFF
--- a/Src/ILGPU/IntrinsicMath.cs
+++ b/Src/ILGPU/IntrinsicMath.cs
@@ -666,7 +666,7 @@ namespace ILGPU
         [MathIntrinsic(MathIntrinsicKind.CopySignF)]
         public static double CopySign(double x, double y) =>
 #if !NETFRAMEWORK && !NETSTANDARD
-            Math.CopySign(x, y)
+            Math.CopySign(x, y);
 #else
             // NB: net47 and netstandard2.1 do not support Math.CopySign.
             Interop.IntAsFloat(
@@ -683,7 +683,7 @@ namespace ILGPU
         [MathIntrinsic(MathIntrinsicKind.CopySignF)]
         public static float CopySign(float x, float y) =>
 #if !NETFRAMEWORK && !NETSTANDARD
-            Math.CopySign(x, y)
+            MathF.CopySign(x, y);
 #else
             // NB: net47 and netstandard2.1 do not support Math.CopySign.
             Interop.IntAsFloat(


### PR DESCRIPTION
ILGPU is still not building on .NET 5.0 for me (with `p:Channel=experimental`).
I tried on macOS with the latest SDK (5.0.201), and on Linux with all the currently available SDKs (5.0.100 -> 5.0.201).

This PR is trying to fix that. This is my first foray into actual ILGPU code, so let me know if I got this wrong 😅