### PR TITLE
Restrict list of Cuda devices to only return supported devices.

### DIFF
--- a/Src/ILGPU/Backends/PTX/PTXCodeGenerator.cs
+++ b/Src/ILGPU/Backends/PTX/PTXCodeGenerator.cs
@@ -40,6 +40,7 @@ namespace ILGPU.Backends.PTX
             ImmutableSortedSet.Create(
                 Comparer<CudaInstructionSet>.Create((first, second) =>
                     second.CompareTo(first)),
+                CudaInstructionSet.ISA_72,
                 CudaInstructionSet.ISA_71,
                 CudaInstructionSet.ISA_70,
                 CudaInstructionSet.ISA_65,

--- a/Src/ILGPU/Backends/PTX/PTXCodeGenerator.cs
+++ b/Src/ILGPU/Backends/PTX/PTXCodeGenerator.cs
@@ -36,8 +36,8 @@ namespace ILGPU.Backends.PTX
         /// <summary>
         /// The supported PTX instruction sets (in descending order).
         /// </summary>
-        public static readonly IEnumerable<CudaInstructionSet> SupportedInstructionSets =
-            ImmutableSortedSet.Create(
+        public static readonly IImmutableSet<CudaInstructionSet>
+            SupportedInstructionSets = ImmutableSortedSet.Create(
                 Comparer<CudaInstructionSet>.Create((first, second) =>
                     second.CompareTo(first)),
                 CudaInstructionSet.ISA_72,

--- a/Src/ILGPU/Runtime/Cuda/CudaContextExtensions.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaContextExtensions.cs
@@ -9,6 +9,7 @@
 // Source License. See LICENSE.txt for details
 // ---------------------------------------------------------------------------------------
 
+using ILGPU.Backends.PTX;
 using System;
 
 namespace ILGPU.Runtime.Cuda
@@ -28,7 +29,9 @@ namespace ILGPU.Runtime.Cuda
         public static Context.Builder Cuda(this Context.Builder builder) =>
             builder.Cuda(desc =>
                 desc.Architecture.HasValue &&
-                desc.InstructionSet.HasValue);
+                desc.InstructionSet.HasValue &&
+                PTXCodeGenerator.SupportedInstructionSets.Contains(
+                    desc.InstructionSet.Value));
 
         /// <summary>
         /// Enables all Cuda devices.

--- a/Src/ILGPU/Runtime/Cuda/CudaDriverVersion.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaDriverVersion.cs
@@ -287,6 +287,7 @@ namespace ILGPU.Runtime.Cuda
 
             { CudaInstructionSet.ISA_70, CudaDriverVersion.FromMajorMinor(11, 0) },
             { CudaInstructionSet.ISA_71, CudaDriverVersion.FromMajorMinor(11, 1) },
+            { CudaInstructionSet.ISA_72, CudaDriverVersion.FromMajorMinor(11, 2) },
         };
 
         /// <summary>

--- a/Src/ILGPU/Runtime/Cuda/CudaInstructionSet.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaInstructionSet.cs
@@ -104,6 +104,11 @@ namespace ILGPU.Runtime.Cuda
         /// </summary>
         public static readonly CudaInstructionSet ISA_71 = new CudaInstructionSet(7, 1);
 
+        /// <summary>
+        /// The 7.2 ISA.
+        /// </summary>
+        public static readonly CudaInstructionSet ISA_72 = new CudaInstructionSet(7, 2);
+
         #endregion
 
         #region Instance


### PR DESCRIPTION
When querying the list of Cuda accelerators, we used to return all devices, even if they were too old to support ILGPU. Added a simple check for whether the Cuda device is compatible with the supported instruction sets.

Also added the new ISA 7.2 instruction set.

~~Also changed the instruction set detection to deal with future/unknown instruction sets - in the same way as the PTX architecture detection.~~

