### PR TITLE
Added bounds validation to kernel launch delegates.

### DIFF
--- a/Src/ILGPU.Tests.CPU/ILGPU.Tests.CPU.csproj
+++ b/Src/ILGPU.Tests.CPU/ILGPU.Tests.CPU.csproj
@@ -30,6 +30,7 @@
     </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     <PackageReference Include="T4.Build" Version="0.2.0" PrivateAssets="All" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/ILGPU.Tests.Cuda/ILGPU.Tests.Cuda.csproj
+++ b/Src/ILGPU.Tests.Cuda/ILGPU.Tests.Cuda.csproj
@@ -30,6 +30,7 @@
     </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     <PackageReference Include="T4.Build" Version="0.2.0" PrivateAssets="All" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/ILGPU.Tests.OpenCL/ILGPU.Tests.OpenCL.csproj
+++ b/Src/ILGPU.Tests.OpenCL/ILGPU.Tests.OpenCL.csproj
@@ -30,6 +30,7 @@
     </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     <PackageReference Include="T4.Build" Version="0.2.0" PrivateAssets="All" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/ILGPU.Tests/GridOperations.cs
+++ b/Src/ILGPU.Tests/GridOperations.cs
@@ -1,5 +1,6 @@
 ﻿using ILGPU.Runtime;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using Xunit;
 using Xunit.Abstractions;
@@ -75,6 +76,98 @@ namespace ILGPU.Tests
             int expected = 1;
 
             Assert.Equal(expected, data[0]);
+        }
+
+        private static IEnumerable<Index1> GetIndices1D(Accelerator accelerator)
+        {
+            if (accelerator.MaxGridSize.X < int.MaxValue)
+            {
+                var x = accelerator.MaxGridSize.X * accelerator.MaxNumThreadsPerGroup + 1;
+                yield return x;
+            }
+        }
+
+        [Fact]
+        public void GridLaunchDimensionOutOfRange1D()
+        {
+            const int UnusedParam = 0;
+            var maxBounds = new Index1(int.MaxValue);
+            static void AutoGroupedKernel1D(Index1 index, int _) { }
+
+            foreach (var index in GetIndices1D(Accelerator))
+            {
+                if (index.InBoundsInclusive(maxBounds))
+                {
+                    Assert.Throws<ArgumentOutOfRangeException>(() =>
+                        Accelerator.LaunchAutoGrouped(
+                            AutoGroupedKernel1D,
+                            index,
+                            UnusedParam));
+                }
+            }
+        }
+
+        private static IEnumerable<Index2> GetIndices2D(Accelerator accelerator)
+        {
+            var x = (accelerator.MaxGridSize.X * accelerator.MaxNumThreadsPerGroup) + 1;
+            var y = accelerator.MaxGridSize.Y + 1;
+            yield return new Index2(x, 1);
+            yield return new Index2(1, y);
+            yield return new Index2(x, y);
+        }
+
+        [Fact]
+        public void GridLaunchDimensionOutOfRange2D()
+        {
+            const int UnusedParam = 0;
+            var maxBounds = new Index2(int.MaxValue, int.MaxValue);
+            static void AutoGroupedKernel2D(Index2 index, int _) { }
+
+            foreach (var index2 in GetIndices2D(Accelerator))
+            {
+                if (index2.InBoundsInclusive(maxBounds))
+                {
+                    Assert.Throws<ArgumentOutOfRangeException>(() =>
+                        Accelerator.LaunchAutoGrouped(
+                            AutoGroupedKernel2D,
+                            index2,
+                            UnusedParam));
+                }
+            }
+        }
+
+        private static IEnumerable<Index3> GetIndices3D(Accelerator accelerator)
+        {
+            var x = (accelerator.MaxGridSize.X * accelerator.MaxNumThreadsPerGroup) + 1;
+            var y = accelerator.MaxGridSize.Y + 1;
+            var z = accelerator.MaxGridSize.Z + 1;
+            yield return new Index3(x, 1, 1);
+            yield return new Index3(1, y, 1);
+            yield return new Index3(x, y, 1);
+            yield return new Index3(1, 1, z);
+            yield return new Index3(x, 1, z);
+            yield return new Index3(1, y, z);
+            yield return new Index3(x, y, z);
+        }
+
+        [Fact]
+        public void GridLaunchDimensionOutOfRange3D()
+        {
+            const int UnusedParam = 0;
+            var maxBounds = new Index3(int.MaxValue, int.MaxValue, int.MaxValue);
+            static void AutoGroupedKernel3D(Index3 index, int _) { }
+
+            foreach (var index3 in GetIndices3D(Accelerator))
+            {
+                if (index3.InBoundsInclusive(maxBounds))
+                {
+                    Assert.Throws<ArgumentOutOfRangeException>(() =>
+                        Accelerator.LaunchAutoGrouped(
+                            AutoGroupedKernel3D,
+                            index3,
+                            UnusedParam));
+                }
+            }
         }
     }
 }

--- a/Src/ILGPU.Tests/GroupOperations.cs
+++ b/Src/ILGPU.Tests/GroupOperations.cs
@@ -110,13 +110,15 @@ namespace ILGPU.Tests
             data[idx] = idx;
         }
 
-        [Theory]
+        [SkippableTheory]
         [InlineData(32)]
         [InlineData(256)]
         [InlineData(1024)]
         [KernelMethod(nameof(GroupBarrierKernel))]
         public void GroupBarrier(int length)
         {
+            Skip.If(length > Accelerator.MaxNumThreadsPerGroup);
+
             for (int i = 1; i <= Accelerator.MaxNumThreadsPerGroup; i <<= 1)
             {
                 using var buffer = Accelerator.Allocate<int>(length * i);
@@ -138,13 +140,15 @@ namespace ILGPU.Tests
             data[idx] = Group.BarrierAnd(Group.IdxX < bound) ? 1 : 0;
         }
 
-        [Theory]
+        [SkippableTheory]
         [InlineData(32)]
         [InlineData(256)]
         [InlineData(1024)]
         [KernelMethod(nameof(GroupBarrierAndKernel))]
         public void GroupBarrierAnd(int length)
         {
+            Skip.If(length > Accelerator.MaxNumThreadsPerGroup);
+
             for (int i = 2; i <= Accelerator.MaxNumThreadsPerGroup; i <<= 1)
             {
                 using var buffer = Accelerator.Allocate<int>(length * i);
@@ -169,13 +173,15 @@ namespace ILGPU.Tests
             data[idx] = Group.BarrierOr(Group.IdxX < bound) ? 1 : 0;
         }
 
-        [Theory]
+        [SkippableTheory]
         [InlineData(32)]
         [InlineData(256)]
         [InlineData(1024)]
         [KernelMethod(nameof(GroupBarrierOrKernel))]
         public void GroupBarrierOr(int length)
         {
+            Skip.If(length > Accelerator.MaxNumThreadsPerGroup);
+
             for (int i = 2; i <= Accelerator.MaxNumThreadsPerGroup; i <<= 1)
             {
                 using var buffer = Accelerator.Allocate<int>(length * i);
@@ -202,13 +208,15 @@ namespace ILGPU.Tests
             data2[idx] = Group.BarrierPopCount(Group.IdxX >= bound);
         }
 
-        [Theory]
+        [SkippableTheory]
         [InlineData(32)]
         [InlineData(256)]
         [InlineData(1024)]
         [KernelMethod(nameof(GroupBarrierPopCountKernel))]
         public void GroupBarrierPopCount(int length)
         {
+            Skip.If(length > Accelerator.MaxNumThreadsPerGroup);
+
             for (int i = 2; i <= Accelerator.MaxNumThreadsPerGroup; i <<= 1)
             {
                 using var buffer = Accelerator.Allocate<int>(length * i);
@@ -250,13 +258,15 @@ namespace ILGPU.Tests
             data[idx] = Group.Broadcast(Group.IdxX, Group.DimX - 1);
         }
 
-        [Theory]
+        [SkippableTheory]
         [InlineData(32)]
         [InlineData(256)]
         [InlineData(1024)]
         [KernelMethod(nameof(GroupBroadcastKernel))]
         public void GroupBroadcast(int length)
         {
+            Skip.If(length > Accelerator.MaxNumThreadsPerGroup);
+
             for (int i = 2; i <= Accelerator.MaxNumThreadsPerGroup; i <<= 1)
             {
                 using var buffer = Accelerator.Allocate<int>(length * i);
@@ -280,13 +290,15 @@ namespace ILGPU.Tests
             }
         }
 
-        [Theory]
+        [SkippableTheory]
         [InlineData(32)]
         [InlineData(256)]
         [InlineData(1024)]
         [KernelMethod(nameof(GroupDivergentControlFlowKernel))]
         public void GroupDivergentControlFlow(int length)
         {
+            Skip.If(length > Accelerator.MaxNumThreadsPerGroup);
+
             // IMPORTANT: Iteration range has been limited to the warp size of the
             // accelerator.
             //

--- a/Src/ILGPU.Tests/ILGPU.Tests.csproj
+++ b/Src/ILGPU.Tests/ILGPU.Tests.csproj
@@ -36,7 +36,6 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="1.1.0" />
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/Src/ILGPU.Tests/ILGPU.Tests.csproj
+++ b/Src/ILGPU.Tests/ILGPU.Tests.csproj
@@ -41,6 +41,7 @@
     <PackageReference Include="xunit" Version="2.4.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     <PackageReference Include="T4.Build" Version="0.2.0" PrivateAssets="All" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net47'">

--- a/Src/ILGPU/KernelConfig.cs
+++ b/Src/ILGPU/KernelConfig.cs
@@ -34,12 +34,8 @@ namespace ILGPU
         internal static readonly ConstructorInfo ImplicitlyGroupedKernelConstructor =
             typeof(KernelConfig).GetConstructor(new Type[]
                 {
-                    typeof(int),
-                    typeof(int),
-                    typeof(int),
-                    typeof(int),
-                    typeof(int),
-                    typeof(int)
+                    typeof(Index3),
+                    typeof(Index3)
                 });
 
         #endregion
@@ -151,9 +147,9 @@ namespace ILGPU
             Index3 groupDim,
             SharedMemoryConfig sharedMemoryConfig)
         {
-            if (gridDim.Size < 0)
+            if (gridDim.LongSize < 0)
                 throw new ArgumentOutOfRangeException(nameof(gridDim));
-            if (groupDim.Size < 0)
+            if (groupDim.LongSize < 0)
                 throw new ArgumentOutOfRangeException(nameof(groupDim));
 
             GridDim = gridDim;

--- a/Src/ILGPU/Resources/RuntimeErrorMessages.Designer.cs
+++ b/Src/ILGPU/Resources/RuntimeErrorMessages.Designer.cs
@@ -169,6 +169,24 @@ namespace ILGPU.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Invalid grid dimensions {0} (exceeds maximum {1}).
+        /// </summary>
+        internal static string InvalidKernelLaunchGridDimension {
+            get {
+                return ResourceManager.GetString("InvalidKernelLaunchGridDimension", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid group dimensions {0} (exceeds maximum {1}).
+        /// </summary>
+        internal static string InvalidKernelLaunchGroupDimension {
+            get {
+                return ResourceManager.GetString("InvalidKernelLaunchGroupDimension", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The given kernel specialization is not compatible with the defined group size..
         /// </summary>
         internal static string InvalidKernelSpecializationGroupSize {

--- a/Src/ILGPU/Resources/RuntimeErrorMessages.resx
+++ b/Src/ILGPU/Resources/RuntimeErrorMessages.resx
@@ -153,6 +153,12 @@
   <data name="InvalidGroupDimension" xml:space="preserve">
     <value>Invalid group dimension</value>
   </data>
+  <data name="InvalidKernelLaunchGridDimension" xml:space="preserve">
+    <value>Invalid grid dimensions {0} (exceeds maximum {1})</value>
+  </data>
+  <data name="InvalidKernelLaunchGroupDimension" xml:space="preserve">
+    <value>Invalid group dimensions {0} (exceeds maximum {1})</value>
+  </data>
   <data name="InvalidKernelSpecializationGroupSize" xml:space="preserve">
     <value>The given kernel specialization is not compatible with the defined group size.</value>
   </data>

--- a/Src/ILGPU/Runtime/CPU/CPUAccelerator.cs
+++ b/Src/ILGPU/Runtime/CPU/CPUAccelerator.cs
@@ -269,13 +269,17 @@ namespace ILGPU.Runtime.CPU
                 KernelLauncherBuilder.EmitLoadKernelConfig(
                     entryPoint,
                     emitter,
-                    Kernel.KernelParamDimensionIdx);
+                    Kernel.KernelParamDimensionIdx,
+                    MaxGridSize,
+                    MaxGroupSize);
 
                 // Load dimensions
                 KernelLauncherBuilder.EmitLoadRuntimeKernelConfig(
                     entryPoint,
                     emitter,
                     Kernel.KernelParamDimensionIdx,
+                    MaxGridSize,
+                    MaxGroupSize,
                     customGroupSize);
 
                 // Create new task object

--- a/Src/ILGPU/Runtime/CPU/CPUDevice.cs
+++ b/Src/ILGPU/Runtime/CPU/CPUDevice.cs
@@ -233,7 +233,7 @@ namespace ILGPU.Runtime.CPU
                 MaxNumThreadsPerGroup);
 
             MemorySize = long.MaxValue;
-            MaxGridSize = new Index3(int.MaxValue, int.MaxValue, int.MaxValue);
+            MaxGridSize = new Index3(int.MaxValue, ushort.MaxValue, ushort.MaxValue);
             MaxSharedMemoryPerGroup = int.MaxValue;
             MaxConstantMemory = int.MaxValue;
             NumThreads = MaxNumThreads * numMultiprocessors;

--- a/Src/ILGPU/Runtime/Cuda/CudaAccelerator.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaAccelerator.cs
@@ -527,6 +527,8 @@ namespace ILGPU.Runtime.Cuda
                 entryPoint,
                 emitter,
                 Kernel.KernelParamDimensionIdx,
+                MaxGridSize,
+                MaxGroupSize,
                 customGroupSize);
 
             // Load kernel arguments

--- a/Src/ILGPU/Runtime/OpenCL/CLAccelerator.cs
+++ b/Src/ILGPU/Runtime/OpenCL/CLAccelerator.cs
@@ -455,6 +455,8 @@ namespace ILGPU.Runtime.OpenCL
                 entryPoint,
                 emitter,
                 Kernel.KernelParamDimensionIdx,
+                MaxGridSize,
+                MaxGroupSize,
                 customGroupSize);
 
             // Dispatch kernel


### PR DESCRIPTION
Fixes https://github.com/m4rs-mt/ILGPU/issues/341.

Show a consistent error message when the kernel launch bounds are out-of-range. For implicitly grouped kernels, we verify the bounds before creating the KernelConfig so that the internal exceptions from that class are not triggered, as they are less descriptive.

Reduced max grid size of CPU accelerator to match Cuda accelerators. Also makes it possible to actually test the CPU grid bounds.

Added skipping of unit tests that will always fail such as when the testing size exceeds the max group size.