### PR TITLE
Improved location reporting of disassembler errors.

### DIFF
--- a/Src/ILGPU/Frontend/ILFrontend.cs
+++ b/Src/ILGPU/Frontend/ILFrontend.cs
@@ -466,7 +466,10 @@ namespace ILGPU.Frontend
                 SequencePointEnumerator sequencePoints =
                     DebugInformationManager?.LoadSequencePoints(method)
                     ?? SequencePointEnumerator.Empty;
-                var disassembler = new Disassembler(method, sequencePoints);
+                var disassembler = new Disassembler(
+                    method,
+                    sequencePoints,
+                    compilationStackLocation);
                 var disassembledMethod = disassembler.Disassemble();
 
                 using (var builder = generatedMethod.CreateBuilder())


### PR DESCRIPTION
Using the following code as an example:
```CSharp
using System;
using System.Linq;
using ILGPU;
using ILGPU.Runtime;
using ILGPU.Runtime.CPU;

namespace ILGPU
{
    class Program
    {
        public static int MyKernelHelper(Index1 index)
        {
            var arr = new int[10];
            var span = arr.AsSpan();
            var i = span[0];
            return i;
        }

        public static void MyKernel(Index1 index, ArrayView<int> input, ArrayView<int> output)
        {
            output[index] = MyKernelHelper(index);
        }

        static void Main(string[] args)
        {
            using var context = Context.CreateDefault();
            using var accelerator = context.CreateCPUAccelerator(0);
            using var input = accelerator.Allocate(Enumerable.Range(1, 64).ToArray());
            using var output = accelerator.Allocate<int>(input.Length);

            var kernel = accelerator.LoadAutoGroupedStreamKernel<Index1, ArrayView<int>, ArrayView<int>>(MyKernel);
            kernel(input.Length, input, output);
        }
    }
}
```
The method `MyKernelHelper` uses `AsSpan`, which internally contains a `throw` statement, and is not supported by ILGPU.

When the ILGPU `Disassembler` class detects this condition, it raises an exception such as:
```
ILGPU.InternalCompilerException: 'An internal compiler error has been detected in method Int32& Add[Int32](Int32 ByRef, Int32) declared in type Internal.Runtime.CompilerServices.Unsafe'

Inner Exception
NotSupportedException: Not supported IL instruction of type 'Throw'
```

This PR improves on the error reporting by showing the call stack:
```
ILGPU.InternalCompilerException: 'An internal compiler error has been detected
- in method Int32& Add[Int32](Int32 ByRef, Int32) declared in type Internal.Runtime.CompilerServices.Unsafe
- in method Int32& get_Item(Int32) declared in type System.Span`1[System.Int32]
- in file 'C:\dev\ILGPU\Program.cs', line 15 column 13 to 29
- in file 'C:\dev\ILGPU\Program.cs', line 21 column 13 to 51
- in method Void MyKernel(ILGPU.Index1, ILGPU.ArrayView`1[System.Int32], ILGPU.ArrayView`1[System.Int32]) declared in type ILGPU.Program'

Inner Exception
NotSupportedException: Not supported IL instruction of type 'Throw'
```