### PR TITLE
Improved reporting on invalid kernel arguments.

### DIFF
--- a/Src/ILGPU.Tests/KernelEntryPoints.cs
+++ b/Src/ILGPU.Tests/KernelEntryPoints.cs
@@ -555,5 +555,27 @@ namespace ILGPU.Tests
             var expected = Enumerable.Range(0, Length).ToArray();
             Verify(buffer, expected);
         }
+
+        internal struct UnsupportedKernelParam
+        {
+            public int[] Data;
+        }
+
+        [Fact]
+        public void UnsupportedEntryPointParameter()
+        {
+            Action<Index1, ArrayView<int>, UnsupportedKernelParam> kernel =
+                (index, output, param) =>
+                {
+                    output[index] = param.Data[index];
+                };
+
+            var extent = new Index1(32);
+            var param = new UnsupportedKernelParam() { Data = new int[extent.Size] };
+            using var buffer = Accelerator.Allocate<int>(extent.Size);
+            var e = Assert.Throws<ArgumentException>(() =>
+                Execute(kernel.Method, extent, buffer.View, param));
+            Assert.IsType<NotSupportedException>(e.InnerException);
+        }
     }
 }

--- a/Src/ILGPU/Backends/EntryPoints/EntryPointDescription.cs
+++ b/Src/ILGPU/Backends/EntryPoints/EntryPointDescription.cs
@@ -96,7 +96,8 @@ namespace ILGPU.Backends.EntryPoints
                 if (type.IsPointer || type.IsPassedViaPtr())
                 {
                     throw new NotSupportedException(string.Format(
-                        ErrorMessages.NotSupportedKernelParameterType, i));
+                        ErrorMessages.NotSupportedKernelParameterType,
+                        type));
                 }
                 parameterTypes.Add(type);
             }

--- a/Src/ILGPU/Backends/IL/DefaultILBackend.cs
+++ b/Src/ILGPU/Backends/IL/DefaultILBackend.cs
@@ -29,7 +29,7 @@ namespace ILGPU.Backends.IL
         /// </summary>
         /// <param name="context">The context to use.</param>
         protected internal DefaultILBackend(Context context)
-            : base(context, new CPUCapabilityContext(), 1, null)
+            : base(context, new CPUCapabilityContext(), 1, new ILArgumentMapper(context))
         { }
 
         #endregion

--- a/Src/ILGPU/Backends/IL/ILArgumentMapper.cs
+++ b/Src/ILGPU/Backends/IL/ILArgumentMapper.cs
@@ -1,0 +1,84 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                        Copyright (c) 2016-2020 Marcel Koester
+//                                    www.ilgpu.net
+//
+// File: ILArgumentMapper.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+
+using ILGPU.Backends.EntryPoints;
+using ILGPU.Backends.PointerViews;
+using System.Diagnostics;
+using System.IO;
+
+namespace ILGPU.Backends.IL
+{
+    /// <summary>
+    /// Constructs mappings for CPU kernels.
+    /// </summary>
+    /// <remarks>Members of this class are not thread safe.</remarks>
+    public sealed class ILArgumentMapper : ViewArgumentMapper
+    {
+        #region Nested Types
+
+        /// <summary>
+        /// Implements the actual argument mapping.
+        /// </summary>
+        private readonly struct MappingHandler : IMappingHandler
+        {
+            /// <summary>
+            /// Emits code to set an individual argument.
+            /// </summary>
+            public readonly void MapArgument<TILEmitter, TSource>(
+                in TILEmitter emitter,
+                in TSource source,
+                int argumentIndex)
+                where TILEmitter : struct, IILEmitter
+                where TSource : struct, ISource
+            { }
+        }
+
+        #endregion
+
+        #region Instance
+
+        /// <summary>
+        /// No-op emitter used to mimic a real IL emitter.
+        /// </summary>
+        private readonly DebugILEmitter emitter = new DebugILEmitter(TextWriter.Null);
+
+        /// <summary>
+        /// Constructs a new IL argument mapper.
+        /// </summary>
+        /// <param name="context">The current context.</param>
+        public ILArgumentMapper(Context context)
+            : base(context)
+        { }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Creates code that maps the given parameter specification to
+        /// a compatible representation.
+        /// </summary>
+        /// <param name="entryPoint">The entry point.</param>
+        public void Map(EntryPoint entryPoint)
+        {
+            Debug.Assert(entryPoint != null, "Invalid entry point");
+
+            // Map all arguments
+            var mappingHandler = new MappingHandler();
+            MapArguments(
+                emitter,
+                mappingHandler,
+                entryPoint.Parameters);
+        }
+
+        #endregion
+    }
+}

--- a/Src/ILGPU/Backends/IL/ILBackend.cs
+++ b/Src/ILGPU/Backends/IL/ILBackend.cs
@@ -94,6 +94,12 @@ namespace ILGPU.Backends.IL
         /// </summary>
         public int WarpSize { get; }
 
+        /// <summary>
+        /// Returns the associated <see cref="Backend.ArgumentMapper"/>.
+        /// </summary>
+        public new ILArgumentMapper ArgumentMapper =>
+            base.ArgumentMapper as ILArgumentMapper;
+
         #endregion
 
         #region Methods

--- a/Src/ILGPU/Resources/ErrorMessages.Designer.cs
+++ b/Src/ILGPU/Resources/ErrorMessages.Designer.cs
@@ -403,6 +403,15 @@ namespace ILGPU.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Delegate type &apos;{0}&apos; is not supported.
+        /// </summary>
+        internal static string NotSupportedDelegateType {
+            get {
+                return ResourceManager.GetString("NotSupportedDelegateType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The allocation size of type &apos;{0}&apos; must be statically known and not a dynamic value &apos;{1}&apos;.
         /// </summary>
         internal static string NotSupportedDynamicAllocation {
@@ -583,6 +592,15 @@ namespace ILGPU.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Pointer type &apos;{0}&apos; is not supported.
+        /// </summary>
+        internal static string NotSupportedPointerType {
+            get {
+                return ResourceManager.GetString("NotSupportedPointerType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Not supported recursive program.
         /// </summary>
         internal static string NotSupportedRecursiveProgram {
@@ -687,6 +705,15 @@ namespace ILGPU.Resources {
         internal static string NotSupportedVirtualMethodCallToUnconstrainedInstance {
             get {
                 return ResourceManager.GetString("NotSupportedVirtualMethodCallToUnconstrainedInstance", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Void type is not supported.
+        /// </summary>
+        internal static string NotSupportedVoidType {
+            get {
+                return ResourceManager.GetString("NotSupportedVoidType", resourceCulture);
             }
         }
         

--- a/Src/ILGPU/Resources/ErrorMessages.resx
+++ b/Src/ILGPU/Resources/ErrorMessages.resx
@@ -345,4 +345,13 @@
   <data name="NotSupportedSharedImplicitlyGroupedKernel" xml:space="preserve">
     <value>Shared memory is not supported by implicitly grouped kernels.</value>
   </data>
+  <data name="NotSupportedDelegateType" xml:space="preserve">
+    <value>Delegate type '{0}' is not supported</value>
+  </data>
+  <data name="NotSupportedPointerType" xml:space="preserve">
+    <value>Pointer type '{0}' is not supported</value>
+  </data>
+  <data name="NotSupportedVoidType" xml:space="preserve">
+    <value>Void type is not supported</value>
+  </data>
 </root>


### PR DESCRIPTION
Related to #382.

When a kernel argument uses an unsupported type (e.g. a struct with an array member), the exception thrown is similar to:
```
System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter 'type')
```
This exception is throw for the Cuda and OpenCL accelerators, but not for the CPU accelerator.

This PR adds argument mapping to the CPU accelerator to mimic the behaviour of the other accelerators.
Further, it improves on the exception thrown, to produce something like:
```
System.ArgumentException: 'Not supported kernel-parameter type 'Test.Program+UnsupportedKernelParam''
Inner Exception
NotSupportedException: Class type 'System.Int32[]' is not supported
```