### PR TITLE
Improved error message when kernel uses allocation of dynamic length.

### DIFF
--- a/Src/ILGPU/Frontend/CodeGenerator/Calls.cs
+++ b/Src/ILGPU/Frontend/CodeGenerator/Calls.cs
@@ -33,7 +33,7 @@ namespace ILGPU.Frontend
         {
             var intrinsicContext = new InvocationContext(
                 this,
-                Location,
+                CompilationStackLocation.Append(Location),
                 Block,
                 Method,
                 method,

--- a/Src/ILGPU/IR/Analyses/Allocas.cs
+++ b/Src/ILGPU/IR/Analyses/Allocas.cs
@@ -55,8 +55,9 @@ namespace ILGPU.IR.Analyses
             }
             else
             {
-                throw new NotSupportedException(
-                    ErrorMessages.NotSupportedDynamicAllocation);
+                throw alloca.Location.GetNotSupportedException(
+                    ErrorMessages.NotSupportedDynamicAllocation,
+                    alloca.AllocaType);
             }
         }
 

--- a/Src/ILGPU/Resources/ErrorMessages.Designer.cs
+++ b/Src/ILGPU/Resources/ErrorMessages.Designer.cs
@@ -412,7 +412,7 @@ namespace ILGPU.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The allocation size of type &apos;{0}&apos; must be statically known and not a dynamic value &apos;{1}&apos;.
+        ///   Looks up a localized string similar to The allocation size of type &apos;{0}&apos; must be statically known and not a dynamic value.
         /// </summary>
         internal static string NotSupportedDynamicAllocation {
             get {

--- a/Src/ILGPU/Resources/ErrorMessages.resx
+++ b/Src/ILGPU/Resources/ErrorMessages.resx
@@ -277,7 +277,7 @@
     <value>Not supported by-ref kernel parameters</value>
   </data>
   <data name="NotSupportedDynamicAllocation" xml:space="preserve">
-    <value>The allocation size of type '{0}' must be statically known and not a dynamic value '{1}'</value>
+    <value>The allocation size of type '{0}' must be statically known and not a dynamic value</value>
   </data>
   <data name="NotSupportedIntrinsicImplementation0" xml:space="preserve">
     <value>A function does not have an intrinsic implementation for this backend. 'EnableAlgorithms' from the Algorithms library not invoked?</value>


### PR DESCRIPTION
Changed the message of `ErrorMessages.NotSupportedDynamicAllocation`, and fixed the missing parameter.

Also, used location information when throwing exception in `AllocaInformation` constructor. However, this location is just the method name. To make this more useful, altered the location of the `InvocationContext` to include the compilation stack trace.