### PR TITLE
Added support for inline PTX assembly instructions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -262,6 +262,7 @@ Src/ILGPU/Memory.cs
 Src/ILGPU/ReductionOperations.cs
 Src/ILGPU/Runtime/ArrayViewExtensions.Generated.cs
 Src/ILGPU/Runtime/ArrayViews.cs
+Src/ILGPU/Runtime/Cuda/CudaAsm.Generated.cs
 Src/ILGPU/Runtime/KernelLoaders.cs
 Src/ILGPU/Runtime/MemoryBuffers.cs
 Src/ILGPU/Runtime/SharedMemoryKernelLoaders.cs

--- a/Src/ILGPU.Tests/Configurations.txt
+++ b/Src/ILGPU.Tests/Configurations.txt
@@ -42,3 +42,4 @@ BasicSwitches: Debug, Release, O2
 BasicPhis: Debug, Release, O2
 
 FormatStringTests: Debug, Release, O2
+LanguageTests: Debug, Release, O2

--- a/Src/ILGPU.Tests/LanguageTests.cs
+++ b/Src/ILGPU.Tests/LanguageTests.cs
@@ -1,0 +1,165 @@
+﻿using ILGPU.Runtime;
+using ILGPU.Runtime.Cuda;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ILGPU.Tests
+{
+    public abstract class LanguageTests : TestBase
+    {
+        protected LanguageTests(ITestOutputHelper output, TestContext testContext)
+            : base(output, testContext)
+        { }
+
+
+        internal static void PlainEmitKernel(
+            Index1D index,
+            ArrayView1D<int, Stride1D.Dense> buffer)
+        {
+            if (CudaAsm.IsSupported)
+            {
+                CudaAsm.Emit("membar.gl;");
+            }
+            buffer[index] = index;
+        }
+
+        [Fact]
+        [KernelMethod(nameof(PlainEmitKernel))]
+        public void PlainEmit()
+        {
+            const int Length = 64;
+            var expected = Enumerable.Range(0, Length).ToArray();
+
+            using var buffer = Accelerator.Allocate1D<int>(Length);
+            Execute(Length, buffer.View);
+            Verify(buffer.View, expected);
+        }
+
+        internal static void OutputEmitKernel(
+            Index1D index,
+            ArrayView1D<int, Stride1D.Dense> buffer)
+        {
+            if (CudaAsm.IsSupported)
+            {
+                CudaAsm.Emit("add.s32 %0, %1, %2;", out int result, index.X, 42);
+                buffer[index] = result;
+            }
+            else
+            {
+                buffer[index] = index;
+            }
+        }
+
+        [Fact]
+        [KernelMethod(nameof(OutputEmitKernel))]
+        public void OutputEmit()
+        {
+            const int Length = 64;
+            var expected = Enumerable.Range(0, Length)
+                .Select(x =>
+                {
+                    if (Accelerator.AcceleratorType == AcceleratorType.Cuda)
+                    {
+                        return x + 42;
+                    }
+                    else
+                    {
+                        return x;
+                    }
+                })
+                .ToArray();
+
+            using var buffer = Accelerator.Allocate1D<int>(Length);
+            Execute(Length, buffer.View);
+            Verify(buffer.View, expected);
+        }
+
+        internal static void MultipleEmitKernel(
+            Index1D index,
+            ArrayView1D<double, Stride1D.Dense> buffer)
+        {
+            if (CudaAsm.IsSupported)
+            {
+                CudaAsm.Emit(
+                    "{\n\t" +
+                    "   .reg .f64 t1;\n\t" +
+                    "   add.f64 t1, %1, %2;\n\t" +
+                    "   add.f64 %0, t1, %2;\n\t" +
+                    "}",
+                    out double result,
+                    (double)index.X,
+                    42.0);
+                buffer[index] = result;
+            }
+            else
+            {
+                buffer[index] = index;
+            }
+        }
+
+        [Fact]
+        [KernelMethod(nameof(MultipleEmitKernel))]
+        public void MultipleEmit()
+        {
+            const int Length = 64;
+            var expected = Enumerable.Range(0, Length)
+                .Select(x => (double)x)
+                .Select(x =>
+                {
+                    if (Accelerator.AcceleratorType == AcceleratorType.Cuda)
+                    {
+                        return x + 42.0 + 42.0;
+                    }
+                    else
+                    {
+                        return x;
+                    }
+                })
+                .ToArray();
+
+            using var buffer = Accelerator.Allocate1D<double>(Length);
+            Execute(Length, buffer.View);
+            Verify(buffer.View, expected);
+        }
+
+        internal static void EscapedEmitKernel(
+            Index1D index,
+            ArrayView1D<int, Stride1D.Dense> buffer)
+        {
+            if (CudaAsm.IsSupported)
+            {
+                CudaAsm.Emit("mov.u32 %0, %%laneid;", out int lane);
+                buffer[index] = lane;
+            }
+            else
+            {
+                buffer[index] = index;
+            }
+        }
+
+        [Fact]
+        [KernelMethod(nameof(EscapedEmitKernel))]
+        public void EscapedEmit()
+        {
+            const int Length = 64;
+            var expected = Enumerable.Range(0, Length)
+                .Select(x =>
+                {
+                    if (Accelerator.AcceleratorType == AcceleratorType.Cuda)
+                    {
+                        return x % Accelerator.WarpSize;
+                    }
+                    else
+                    {
+                        return x;
+                    }
+                })
+                .ToArray();
+
+            using var buffer = Accelerator.Allocate1D<int>(Length);
+            Execute(Length, buffer.View);
+            Verify(buffer.View, expected);
+        }
+    }
+}

--- a/Src/ILGPU/Backends/IBackendCodeGenerator.cs
+++ b/Src/ILGPU/Backends/IBackendCodeGenerator.cs
@@ -330,6 +330,12 @@ namespace ILGPU.Backends
         /// </summary>
         /// <param name="branch">The node.</param>
         void GenerateCode(SwitchBranch branch);
+
+        /// <summary>
+        /// Generates code for the given value.
+        /// </summary>
+        /// <param name="emit">The node.</param>
+        void GenerateCode(LanguageEmitValue emit);
     }
 
     /// <summary>
@@ -573,6 +579,10 @@ namespace ILGPU.Backends
             /// <summary cref="IValueVisitor.Visit(SwitchBranch)"/>
             public void Visit(SwitchBranch branch) =>
                 CodeGenerator.GenerateCode(branch);
+
+            /// <summary cref="IValueVisitor.Visit(LanguageEmitValue)"/>
+            public void Visit(LanguageEmitValue value) =>
+                CodeGenerator.GenerateCode(value);
         }
 
         /// <summary>

--- a/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Values.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Values.cs
@@ -706,5 +706,10 @@ namespace ILGPU.Backends.OpenCL
         public void GenerateCode(DebugAssertOperation debug) =>
             // Invalid debug node -> should have been removed
             debug.Assert(false);
+
+        /// <summary cref="IBackendCodeGenerator.GenerateCode(LanguageEmitValue)"/>
+        public void GenerateCode(LanguageEmitValue value) =>
+            // Ignore PTX instructions.
+            value.Assert(value.LanguageKind == LanguageKind.PTX);
     }
 }

--- a/Src/ILGPU/Backends/PTX/PTXCodeGenerator.Emitter.cs
+++ b/Src/ILGPU/Backends/PTX/PTXCodeGenerator.Emitter.cs
@@ -32,16 +32,33 @@ namespace ILGPU.Backends.PTX
             private readonly StringBuilder stringBuilder;
             private bool argMode;
             private int argumentCount;
+            private readonly string argumentSeparator;
+            private readonly string commandTerminator;
 
             /// <summary>
             /// Constructs a new command emitter using the given target.
             /// </summary>
             /// <param name="target">The target builder.</param>
             public CommandEmitter(StringBuilder target)
+                : this(target, argSeparator: ", ", terminator: ";")
+            { }
+
+            /// <summary>
+            /// Constructs a new command emitter using the given target.
+            /// </summary>
+            /// <param name="target">The target builder.</param>
+            /// <param name="argSeparator">The string used to separate arguments.</param>
+            /// <param name="terminator">The string used to end the command.</param>
+            public CommandEmitter(
+                StringBuilder target,
+                string argSeparator,
+                string terminator)
             {
                 stringBuilder = target;
                 argumentCount = 0;
                 argMode = false;
+                argumentSeparator = argSeparator;
+                commandTerminator = terminator;
             }
 
             #endregion
@@ -123,7 +140,7 @@ namespace ILGPU.Backends.PTX
                     argMode = true;
                 }
                 if (argumentCount > 0)
-                    stringBuilder.Append(", ");
+                    stringBuilder.Append(argumentSeparator);
                 ++argumentCount;
             }
 
@@ -379,6 +396,13 @@ namespace ILGPU.Backends.PTX
                 stringBuilder.Append(valueReference);
             }
 
+            /// <summary>
+            /// Appends the given string without modification.
+            /// </summary>
+            /// <param name="value">The string value.</param>
+            public void AppendRawString(string value) =>
+                stringBuilder.Append(value);
+
             #endregion
 
             #region IDisposable
@@ -386,7 +410,7 @@ namespace ILGPU.Backends.PTX
             /// <summary cref="IDisposable.Dispose"/>
             public void Dispose()
             {
-                stringBuilder.Append(';');
+                stringBuilder.Append(commandTerminator);
                 stringBuilder.AppendLine();
             }
 

--- a/Src/ILGPU/Frontend/Intrinsic/Intrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/Intrinsics.cs
@@ -41,6 +41,7 @@ namespace ILGPU.Frontend.Intrinsic
         View,
         Warp,
         Utility,
+        Language,
     }
 
     /// <summary>
@@ -132,6 +133,9 @@ namespace ILGPU.Frontend.Intrinsic
             (ref InvocationContext context, IntrinsicAttribute attribute) =>
                 HandleUtilityOperation(
                     ref context, attribute as UtilityIntrinsicAttribute),
+            (ref InvocationContext context, IntrinsicAttribute attribute) =>
+                HandleLanguageOperation(
+                    ref context, attribute as LanguageIntrinsicAttribute),
         };
 
         #endregion

--- a/Src/ILGPU/Frontend/Intrinsic/LanguageIntrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/LanguageIntrinsics.cs
@@ -109,15 +109,8 @@ namespace ILGPU.Frontend.Intrinsic
             // Valid all argument types
             foreach (var arg in arguments)
             {
-                if (arg.BasicValueType == BasicValueType.Int16 ||
-                    arg.BasicValueType == BasicValueType.Int32 ||
-                    arg.BasicValueType == BasicValueType.Int64 ||
-                    arg.BasicValueType == BasicValueType.Float16 ||
-                    arg.BasicValueType == BasicValueType.Float32 ||
-                    arg.BasicValueType == BasicValueType.Float64)
-                {
+                if (arg.BasicValueType != BasicValueType.None)
                     continue;
-                }
                 throw location.GetNotSupportedException(
                     ErrorMessages.NotSupportedInlinePTXFormatArgumentType,
                     ptxExpression,

--- a/Src/ILGPU/Frontend/Intrinsic/LanguageIntrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/LanguageIntrinsics.cs
@@ -1,0 +1,235 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                        Copyright (c) 2016-2020 Marcel Koester
+//                                    www.ilgpu.net
+//
+// File: LanguageIntrinsics.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+
+using ILGPU.IR;
+using ILGPU.IR.Values;
+using ILGPU.Resources;
+using ILGPU.Util;
+using System;
+using System.Collections.Immutable;
+using static ILGPU.Util.FormatString;
+using FormatArray = System.Collections.Immutable.ImmutableArray<
+    ILGPU.Util.FormatString.FormatExpression>;
+
+namespace ILGPU.Frontend.Intrinsic
+{
+    enum LanguageIntrinsicKind
+    {
+        EmitPTX,
+    }
+
+    /// <summary>
+    /// Marks inline language methods that are built in.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    sealed class LanguageIntrinsicAttribute : IntrinsicAttribute
+    {
+        public LanguageIntrinsicAttribute(LanguageIntrinsicKind intrinsicKind)
+        {
+            IntrinsicKind = intrinsicKind;
+        }
+
+        public override IntrinsicType Type => IntrinsicType.Language;
+
+        /// <summary>
+        /// Returns the assigned intrinsic kind.
+        /// </summary>
+        public LanguageIntrinsicKind IntrinsicKind { get; }
+    }
+
+    partial class Intrinsics
+    {
+        /// <summary>
+        /// Handles language operations.
+        /// </summary>
+        /// <param name="context">The current invocation context.</param>
+        /// <param name="attribute">The intrinsic attribute.</param>
+        /// <returns>The resulting value.</returns>
+        private static ValueReference HandleLanguageOperation(
+            ref InvocationContext context,
+            LanguageIntrinsicAttribute attribute)
+        {
+            var builder = context.Builder;
+            return attribute.IntrinsicKind switch
+            {
+                LanguageIntrinsicKind.EmitPTX =>
+                    CreateLanguageEmitPTX(ref context),
+                _ => throw context.Location.GetNotSupportedException(
+                    ErrorMessages.NotSupportedLanguageIntrinsic,
+                    attribute.IntrinsicKind.ToString()),
+            };
+        }
+
+        /// <summary>
+        /// Creates a new inline PTX instruction.
+        /// </summary>
+        /// <param name="ptxExpression">The PTX expression string.</param>
+        /// <param name="context">The current invocation context.</param>
+        private static ValueReference CreateLanguageEmitPTX(
+            string ptxExpression,
+            ref InvocationContext context)
+        {
+            // Parse PTX expression and ensure valid argument references
+            var location = context.Location;
+            if (!TryParse(ptxExpression, out var expressions))
+            {
+                throw location.GetNotSupportedException(
+                    ErrorMessages.NotSupportedInlinePTXFormat,
+                    ptxExpression);
+            }
+
+            // Validate all expressions
+            foreach (var expression in expressions)
+            {
+                if (!expression.HasArgument)
+                    continue;
+                if (expression.Argument < 0 ||
+                    expression.Argument >= context.NumArguments - 1)
+                {
+                    throw location.GetNotSupportedException(
+                        ErrorMessages.NotSupportedInlinePTXFormatArgumentRef,
+                        ptxExpression,
+                        expression.Argument);
+                }
+            }
+
+            // Gather all arguments
+            var arguments = InlineList<ValueReference>.Empty;
+            context.Arguments.CopyTo(ref arguments);
+            arguments.RemoveAt(0);
+
+            // Valid all argument types
+            foreach (var arg in arguments)
+            {
+                if (arg.BasicValueType == BasicValueType.Int16 ||
+                    arg.BasicValueType == BasicValueType.Int32 ||
+                    arg.BasicValueType == BasicValueType.Int64 ||
+                    arg.BasicValueType == BasicValueType.Float16 ||
+                    arg.BasicValueType == BasicValueType.Float32 ||
+                    arg.BasicValueType == BasicValueType.Float64)
+                {
+                    continue;
+                }
+                throw location.GetNotSupportedException(
+                    ErrorMessages.NotSupportedInlinePTXFormatArgumentType,
+                    ptxExpression,
+                    arg.Type.ToString());
+            }
+
+            // The method parameter at position 0 is the PTX string.
+            // The method parameter at position 1 is the first argument to the PTX string.
+            var methodParams = context.Method.GetParameters();
+            var hasOutput = methodParams.Length >= 2 && methodParams[1].IsOut;
+
+            // Create the language statement
+            return context.Builder.CreateLanguageEmitPTX(
+                location,
+                expressions,
+                hasOutput,
+                ref arguments);
+        }
+
+        /// <summary>
+        /// Creates a new inline PTX instruction to the standard output stream.
+        /// </summary>
+        /// <param name="context">The current invocation context.</param>
+        private static ValueReference CreateLanguageEmitPTX(
+            ref InvocationContext context) =>
+            CreateLanguageEmitPTX(
+                GetEmitPTXExpression(ref context),
+                ref context);
+
+        /// <summary>
+        /// Resolves a PTX expression string.
+        /// </summary>
+        /// <param name="context">The current invocation context.</param>
+        /// <returns>The resolved PTX expression string.</returns>
+        private static string GetEmitPTXExpression(ref InvocationContext context)
+        {
+            var ptxExpression = context[0].ResolveAs<StringValue>();
+            return ptxExpression is null
+                ? throw context.Location.GetNotSupportedException(
+                    ErrorMessages.NotSupportedInlinePTXFormatConstant,
+                    context[0].ToString())
+                : ptxExpression.String ?? string.Empty;
+        }
+
+        /// <summary>
+        /// Parses the given PTX expression into an array of format expressions.
+        /// </summary>
+        /// <param name="ptxExpression">The PTX format expression.</param>
+        /// <param name="expressions">The array of managed format expressions.</param>
+        /// <returns>True, if all expressions could be parsed successfully.</returns>
+        public static bool TryParse(
+            string ptxExpression,
+            out FormatArray expressions)
+        {
+            expressions = FormatArray.Empty;
+
+            // Search for '%n' format arguments
+            var result = ImmutableArray.CreateBuilder<FormatExpression>(10);
+            var expression = ptxExpression.AsSpan();
+
+            while (expression.Length > 0)
+            {
+                // Search for next %
+                int foundIndex = expression.IndexOf('%');
+                if (foundIndex < 0)
+                {
+                    result.Add(new FormatExpression(expression));
+                    break;
+                }
+
+                var escaped =
+                    foundIndex + 1 < expression.Length &&
+                    expression[foundIndex] == expression[foundIndex + 1];
+                if (escaped)
+                {
+                    result.Add(new FormatExpression(expression.Slice(0, foundIndex + 1)));
+                    expression = expression.Slice(foundIndex + 2);
+                }
+                else
+                {
+                    // Append text before new argument
+                    if (foundIndex > 0)
+                    {
+                        result.Add(new FormatExpression(
+                            expression.Slice(0, foundIndex)));
+                    }
+                    expression = expression.Slice(foundIndex + 1);
+
+                    // Retrieve all the numeric text
+                    if (expression.Length == 0)
+                        return false;
+
+                    int endIndex = 0;
+                    while (endIndex < expression.Length &&
+                        char.IsDigit(expression[endIndex]))
+                    {
+                        endIndex++;
+                    }
+
+                    // Check whether the argument can be resolved to an integer
+                    var numericExpr = expression.Slice(0, endIndex);
+                    if (!int.TryParse(numericExpr.ToString(), out int argument))
+                        return false;
+
+                    // Append current argument
+                    result.Add(new FormatExpression(argument));
+                    expression = expression.Slice(endIndex);
+                }
+            }
+
+            expressions = result.ToImmutable();
+            return true;
+        }
+    }
+}

--- a/Src/ILGPU/ILGPU.csproj
+++ b/Src/ILGPU/ILGPU.csproj
@@ -85,6 +85,11 @@
           <AutoGen>True</AutoGen>
           <DependentUpon>IntrinsicMatchers.tt</DependentUpon>
         </None>
+        <None Include="Runtime\Cuda\CudaAsm.Generated.cs">
+          <DesignTime>True</DesignTime>
+          <AutoGen>True</AutoGen>
+          <DependentUpon>CudaAsm.Generated.tt</DependentUpon>
+        </None>
         <None Include="Static\ArithmeticEnums.cs">
           <DesignTime>True</DesignTime>
           <AutoGen>True</AutoGen>
@@ -197,6 +202,11 @@
           <DesignTime>True</DesignTime>
           <AutoGen>True</AutoGen>
           <DependentUpon>ValueTuples.tt</DependentUpon>
+        </Compile>
+        <Compile Update="Runtime\Cuda\CudaAsm.Generated.cs">
+          <DesignTime>True</DesignTime>
+          <AutoGen>True</AutoGen>
+          <DependentUpon>CudaAsm.Generated.tt</DependentUpon>
         </Compile>
         <Compile Update="Runtime\MemoryBuffers.cs">
           <DesignTime>True</DesignTime>
@@ -311,6 +321,10 @@
         <None Update="IR\Types\ValueTuples.tt">
           <Generator>TextTemplatingFileGenerator</Generator>
           <LastGenOutput>ValueTuples.cs</LastGenOutput>
+        </None>
+        <None Update="Runtime\Cuda\CudaAsm.Generated.tt">
+          <Generator>TextTemplatingFileGenerator</Generator>
+          <LastGenOutput>CudaAsm.Generated.cs</LastGenOutput>
         </None>
         <None Update="Runtime\ExchangeBufferExtensions.tt">
           <Generator>TextTemplatingFileGenerator</Generator>

--- a/Src/ILGPU/IR/Construction/LanguageValues.cs
+++ b/Src/ILGPU/IR/Construction/LanguageValues.cs
@@ -1,0 +1,43 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                        Copyright (c) 2016-2020 Marcel Koester
+//                                    www.ilgpu.net
+//
+// File: LanguageValues.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+
+using ILGPU.IR.Values;
+using ILGPU.Runtime;
+using FormatArray = System.Collections.Immutable.ImmutableArray<
+    ILGPU.Util.FormatString.FormatExpression>;
+using ValueList = ILGPU.Util.InlineList<ILGPU.IR.Values.ValueReference>;
+
+namespace ILGPU.IR.Construction
+{
+    partial class IRBuilder
+    {
+        /// <summary>
+        /// Creates an inline language output operation using typed expression formats.
+        /// </summary>
+        /// <param name="location">The current location.</param>
+        /// <param name="expressions">The list of all format expressions.</param>
+        /// <param name="hasOutput">Indicates if the first argument is output.</param>
+        /// <param name="arguments">The arguments to format.</param>
+        /// <returns>A node that represents the language emit operation.</returns>
+        public ValueReference CreateLanguageEmitPTX(
+            Location location,
+            FormatArray expressions,
+            bool hasOutput,
+            ref ValueList arguments) =>
+            Append(new LanguageEmitValue(
+                GetInitializer(location),
+                LanguageKind.PTX,
+                expressions,
+                hasOutput,
+                ref arguments,
+                VoidType));
+    }
+}

--- a/Src/ILGPU/IR/Transformations/DeadCodeElimination.cs
+++ b/Src/ILGPU/IR/Transformations/DeadCodeElimination.cs
@@ -56,6 +56,9 @@ namespace ILGPU.IR.Transformations
             // Mark all calls as non dead
             blocks.ForEachValue<MethodCall>(call => toProcess.Push(call));
 
+            // Mark all inline language statements as non dead
+            blocks.ForEachValue<LanguageEmitValue>(emit => toProcess.Push(emit));
+
             // Mark all nodes as live
             var liveValues = new HashSet<Value>();
             while (toProcess.Count > 0)

--- a/Src/ILGPU/IR/Values/IOValues.cs
+++ b/Src/ILGPU/IR/Values/IOValues.cs
@@ -221,6 +221,7 @@ namespace ILGPU.IR.Values
             VoidType voidType)
             : base(initializer, voidType)
         {
+#if DEBUG
             foreach (var argument in arguments)
                 this.Assert(argument.BasicValueType != BasicValueType.None);
             foreach (var expression in expressions)
@@ -229,6 +230,7 @@ namespace ILGPU.IR.Values
                     !expression.HasArgument ||
                     expression.Argument >= 0 && expression.Argument < arguments.Count);
             }
+#endif
 
             Expressions = expressions;
             Seal(ref arguments);
@@ -317,7 +319,7 @@ namespace ILGPU.IR.Values
 
         #endregion
 
-        #region Methods
+        #region Object
 
         /// <summary cref="Node.ToPrefixString"/>
         protected override string ToPrefixString() => "write";

--- a/Src/ILGPU/IR/Values/IValueVisitor.cs
+++ b/Src/ILGPU/IR/Values/IValueVisitor.cs
@@ -353,5 +353,13 @@ namespace ILGPU.IR.Values
         /// </summary>
         /// <param name="branch">The node.</param>
         void Visit(SwitchBranch branch);
+
+        // Language operations
+
+        /// <summary>
+        /// Visits the node.
+        /// </summary>
+        /// <param name="value">The node.</param>
+        void Visit(LanguageEmitValue value);
     }
 }

--- a/Src/ILGPU/IR/Values/LanguageValues.cs
+++ b/Src/ILGPU/IR/Values/LanguageValues.cs
@@ -1,0 +1,170 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                        Copyright (c) 2016-2020 Marcel Koester
+//                                    www.ilgpu.net
+//
+// File: LanguageValues.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+
+using ILGPU.IR.Construction;
+using ILGPU.IR.Types;
+using ILGPU.Runtime;
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using FormatArray = System.Collections.Immutable.ImmutableArray<
+    ILGPU.Util.FormatString.FormatExpression>;
+using ValueList = ILGPU.Util.InlineList<ILGPU.IR.Values.ValueReference>;
+
+namespace ILGPU.IR.Values
+{
+    /// <summary>
+    /// Represents the kind of inline language.
+    /// </summary>
+    public enum LanguageKind
+    {
+        /// <summary>
+        /// Inline PTX assembly.
+        /// </summary>
+        PTX,
+    }
+
+    /// <summary>
+    /// Represents an inline lanaguage statement.
+    /// </summary>
+    [ValueKind(ValueKind.LanguageEmit)]
+    public sealed class LanguageEmitValue : MemoryValue
+    {
+        #region Instance
+
+        /// <summary>
+        /// Constructs a new inline language statement.
+        /// </summary>
+        /// <param name="initializer">The value initializer.</param>
+        /// <param name="languageKind">The language kind.</param>
+        /// <param name="expressions">The list of all format expressions.</param>
+        /// <param name="hasOutput">Indicates if the first argument is output.</param>
+        /// <param name="arguments">The arguments to format.</param>
+        /// <param name="voidType">The void type.</param>
+        internal LanguageEmitValue(
+            in ValueInitializer initializer,
+            LanguageKind languageKind,
+            FormatArray expressions,
+            bool hasOutput,
+            ref ValueList arguments,
+            VoidType voidType)
+            : base(initializer, voidType)
+        {
+#if DEBUG
+            foreach (var argument in arguments)
+                this.Assert(argument.BasicValueType != BasicValueType.None);
+            foreach (var expression in expressions)
+            {
+                this.Assert(
+                    !expression.HasArgument ||
+                    expression.Argument >= 0 && expression.Argument < arguments.Count);
+            }
+#endif
+
+            LanguageKind = languageKind;
+            HasOutput = hasOutput;
+            Expressions = expressions;
+            Seal(ref arguments);
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary cref="Value.ValueKind"/>
+        public override ValueKind ValueKind => ValueKind.LanguageEmit;
+
+        /// <summary>
+        /// Returns the language kind.
+        /// </summary>
+        public LanguageKind LanguageKind { get; }
+
+        /// <summary>
+        /// Returns true if the first argument is an output argument.
+        /// </summary>
+        public bool HasOutput { get; }
+
+        /// <summary>
+        /// Returns the underlying native format expressions.
+        /// </summary>
+        public FormatArray Expressions { get; }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary cref="Value.Rebuild(IRBuilder, IRRebuilder)"/>
+        protected internal override Value Rebuild(
+            IRBuilder builder,
+            IRRebuilder rebuilder)
+        {
+            var arguments = ValueList.Create(Count);
+            foreach (Value argument in this)
+                arguments.Add(rebuilder[argument]);
+            return builder.CreateLanguageEmitPTX(
+                Location,
+                Expressions,
+                HasOutput,
+                ref arguments);
+        }
+
+        /// <summary cref="Value.Accept"/>
+        public override void Accept<T>(T visitor) => visitor.Visit(this);
+
+        #endregion
+
+        #region Object
+
+        /// <summary cref="Node.ToPrefixString"/>
+        protected override string ToPrefixString() => "emit";
+
+        /// <summary cref="Value.ToArgString"/>
+        [SuppressMessage(
+            "Globalization",
+            "CA1307:Specify StringComparison",
+            Justification = "string.Replace(string, string, StringComparison) not " +
+            "available in net47")]
+        protected override string ToArgString() =>
+            ToStringExpression().Replace(
+                Environment.NewLine,
+                string.Empty) +
+            " " + base.ToArgString();
+
+        /// <summary>
+        /// Converts the internal format expressions into a string for debugging purposes.
+        /// </summary>
+        /// <returns>The converted string.</returns>
+        private string ToStringExpression()
+        {
+            var result = new StringBuilder();
+            foreach (var expression in Expressions)
+            {
+                if (expression.HasArgument)
+                {
+                    var argument = this[expression.Argument];
+                    string argumentFormat = argument.Type.ToString();
+                    result.Append('{');
+                    result.Append(expression.Argument);
+                    result.Append(':');
+                    result.Append(argumentFormat);
+                    result.Append('}');
+                }
+                else
+                {
+                    result.Append(expression.String);
+                }
+            }
+            return result.ToString();
+        }
+
+        #endregion
+    }
+}

--- a/Src/ILGPU/IR/Values/ValueKind.cs
+++ b/Src/ILGPU/IR/Values/ValueKind.cs
@@ -326,6 +326,13 @@ namespace ILGPU.IR
         /// A <see cref="Values.HandleValue"/> managed handle value.
         /// </summary>
         Handle,
+
+        // Language
+
+        /// <summary>
+        /// A <see cref="Values.LanguageEmitValue"/> value.
+        /// </summary>
+        LanguageEmit,
     }
 
     /// <summary>
@@ -357,7 +364,7 @@ namespace ILGPU.IR
         /// <summary>
         /// The number of different value kinds.
         /// </summary>
-        public const int NumValueKinds = (int)ValueKind.Handle + 1;
+        public const int NumValueKinds = (int)ValueKind.LanguageEmit + 1;
 
         /// <summary>
         /// Gets the value kind of the value type specified.

--- a/Src/ILGPU/Resources/ErrorMessages.Designer.cs
+++ b/Src/ILGPU/Resources/ErrorMessages.Designer.cs
@@ -466,6 +466,42 @@ namespace ILGPU.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Not supported inline PTX format &apos;{0}&apos;.
+        /// </summary>
+        internal static string NotSupportedInlinePTXFormat {
+            get {
+                return ResourceManager.GetString("NotSupportedInlinePTXFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Not supported inline PTX format argument reference &apos;{1}&apos; in &apos;{0}&apos;.
+        /// </summary>
+        internal static string NotSupportedInlinePTXFormatArgumentRef {
+            get {
+                return ResourceManager.GetString("NotSupportedInlinePTXFormatArgumentRef", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Not supported inline PTX format argument type &apos;{1} in &apos;{0}&apos;.
+        /// </summary>
+        internal static string NotSupportedInlinePTXFormatArgumentType {
+            get {
+                return ResourceManager.GetString("NotSupportedInlinePTXFormatArgumentType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Not supported inline PTX format &apos;{0}; must be a constant string reference.
+        /// </summary>
+        internal static string NotSupportedInlinePTXFormatConstant {
+            get {
+                return ResourceManager.GetString("NotSupportedInlinePTXFormatConstant", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Not supported instruction &apos;{0}&apos; in method &apos;{1}&apos;..
         /// </summary>
         internal static string NotSupportedInstruction {
@@ -543,6 +579,15 @@ namespace ILGPU.Resources {
         internal static string NotSupportedKernelParameterType {
             get {
                 return ResourceManager.GetString("NotSupportedKernelParameterType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The language intrinsic &apos;{0}&apos; is not supported.
+        /// </summary>
+        internal static string NotSupportedLanguageIntrinsic {
+            get {
+                return ResourceManager.GetString("NotSupportedLanguageIntrinsic", resourceCulture);
             }
         }
         

--- a/Src/ILGPU/Resources/ErrorMessages.resx
+++ b/Src/ILGPU/Resources/ErrorMessages.resx
@@ -354,4 +354,19 @@
   <data name="NotSupportedVoidType" xml:space="preserve">
     <value>Void type is not supported</value>
   </data>
+  <data name="NotSupportedLanguageIntrinsic" xml:space="preserve">
+    <value>The language intrinsic '{0}' is not supported</value>
+  </data>
+  <data name="NotSupportedInlinePTXFormat" xml:space="preserve">
+    <value>Not supported inline PTX format '{0}'</value>
+  </data>
+  <data name="NotSupportedInlinePTXFormatArgumentRef" xml:space="preserve">
+    <value>Not supported inline PTX format argument reference '{1}' in '{0}'</value>
+  </data>
+  <data name="NotSupportedInlinePTXFormatArgumentType" xml:space="preserve">
+    <value>Not supported inline PTX format argument type '{1} in '{0}'</value>
+  </data>
+  <data name="NotSupportedInlinePTXFormatConstant" xml:space="preserve">
+    <value>Not supported inline PTX format '{0}; must be a constant string reference</value>
+  </data>
 </root>

--- a/Src/ILGPU/Runtime/Cuda/CudaAsm.Generated.tt
+++ b/Src/ILGPU/Runtime/Cuda/CudaAsm.Generated.tt
@@ -1,0 +1,73 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                        Copyright (c) 2016-2020 Marcel Koester
+//                                    www.ilgpu.net
+//
+// File: CudaAsm.Generated.tt/CudaAsm.Generated.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ output extension=".cs" #>
+<#
+    int numArguments = 10;
+    var cfgs =
+        from argNum in Enumerable.Range(1, numArguments)
+        let range = Enumerable.Range(0, argNum)
+        select new
+        {
+            TypeParams = string.Join(", ", from r in range select $"T{r}"),
+            TypeRestrictions = string.Join(
+                $"{Environment.NewLine}            ",
+                from r in range select $"where T{r} : struct"),
+            MethodParams = string.Join(", ", from r in range select $"T{r} arg{r}"),
+            MethodParamsDocumentation = string.Join(
+                $"{Environment.NewLine}        /// ",
+                from r in range select
+                $"<param name=\"arg{r}\">Argument %{r} of the PTX instruction.</param>"),
+        };
+#>
+
+using ILGPU.Frontend.Intrinsic;
+using System;
+
+namespace ILGPU.Runtime.Cuda
+{
+    /// <summary>
+    /// Provides library calls for inline PTX assembly instructions.
+    /// </summary>
+    partial class CudaAsm
+    {
+<# foreach (var cfg in cfgs) { #>
+        /// <summary>
+        /// Writes the inline PTX assembly instructions into the kernel.
+        /// </summary>
+        /// <param name="asm">The PTX assembly instruction string.</param>
+        /// <#= cfg.MethodParamsDocumentation #>
+        [LanguageIntrinsic(LanguageIntrinsicKind.EmitPTX)]
+        public static void Emit<<#= cfg.TypeParams #>>(
+            string asm,
+            <#= cfg.MethodParams #>)
+            <#= cfg.TypeRestrictions #> =>
+            throw new NotImplementedException();
+
+        /// <summary>
+        /// Writes the inline PTX assembly instructions into the kernel.
+        /// </summary>
+        /// <param name="asm">The PTX assembly instruction string.</param>
+        /// <#= cfg.MethodParamsDocumentation #>
+        [LanguageIntrinsic(LanguageIntrinsicKind.EmitPTX)]
+        public static void Emit<<#= cfg.TypeParams #>>(
+            string asm,
+            out <#= cfg.MethodParams #>)
+            <#= cfg.TypeRestrictions #> =>
+            throw new NotImplementedException();
+
+<# } #>
+    }
+}

--- a/Src/ILGPU/Runtime/Cuda/CudaAsm.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaAsm.cs
@@ -1,0 +1,40 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                        Copyright (c) 2016-2020 Marcel Koester
+//                                    www.ilgpu.net
+//
+// File: CudaAsm.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+
+using ILGPU.Frontend.Intrinsic;
+using System;
+using System.Runtime.CompilerServices;
+
+namespace ILGPU.Runtime.Cuda
+{
+    /// <summary>
+    /// Provides library calls for inline PTX assembly instructions.
+    /// </summary>
+    public static partial class CudaAsm
+    {
+        /// <summary>
+        /// Returns true if running on a Cuda accelerator.
+        /// </summary>
+        public static bool IsSupported
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => Accelerator.CurrentType == AcceleratorType.Cuda;
+        }
+
+        /// <summary>
+        /// Writes the inline PTX assembly instructions into the kernel.
+        /// </summary>
+        /// <param name="asm">The PTX assembly instruction string.</param>
+        [LanguageIntrinsic(LanguageIntrinsicKind.EmitPTX)]
+        public static void Emit(string asm) =>
+            throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
Related to https://github.com/m4rs-mt/ILGPU/issues/416.

Provides a new `CudaAsm` class that can be used within a kernel to embed PTX instructions. This makes it easier to use advanced PTX instructions without the need to create a custom ILGPU intrinsic.

It supports multiple input arguments (arbitrarily capped at 10 in the T4 template), and a single output value per instruction statement.

```CSharp
public static void MyKernel(Index1D index, ArrayView<double> view)
{
    CudaAsm.Emit(
        "{\n\t" +
        "   .reg .f64 t1;\n\t" +
        "   add.f64 t1, %1, %2;\n\t" +
        "   add.f64 %0, t1, %2;\n\t" +
        "}",
        out double result,
        (double)index.X,
        42.0);
    view[index] = result;
}
```
The format string uses `%0` rather than the .NET way of `{0}`. This was to make it match the [inline PTX assembly](https://docs.nvidia.com/cuda/inline-ptx-assembly/index.html) in C++. If you want to use the `%`, then you should escape it with double `%%`.

UPDATE: The selective detection of PTX version, described below has been removed as it was causing issues. May revisit in a separate PR in the future.

It is also possible to selectively detect the PTX version available:
```CSharp
if (CudaAsm.IsPTXVersionAtLeast(CudaInstructionSet.ISA_70)) { }
else if (CudaAsm.IsPTXVersionAtLeast(CudaInstructionSet.ISA_60)) { }
else { }
```

KNOWN ISSUES:
- Using `CudaAsm.IsPTXVersionAtLeast` produces a complex constant expression that the ILGPU compiler is not currently able to fold into an unconditional branch. This means that the PTX compiler may fail if it does not support a newer instruction, that should have been optimised out.  Further work required to improve this area.
