### PR TITLE
Fixed incorrect simplification of ConvertValue when truncating value.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -283,7 +283,7 @@ Src/ILGPU.Tests/BinaryIntOperations.cs
 Src/ILGPU.Tests/CompareFloatOperations.cs
 Src/ILGPU.Tests/CompareIntOperations.cs
 Src/ILGPU.Tests/ConvertFloatOperations.cs
-Src/ILGPU.Tests/ConvertIntOperations.cs
+Src/ILGPU.Tests/ConvertIntOperations.Generated.cs
 Src/ILGPU.Tests/FixedBuffers.cs
 Src/ILGPU.Tests/MemoryBufferOperations.cs
 Src/ILGPU.Tests/ReinterpretCasts.cs

--- a/Src/ILGPU.Tests/ConvertIntOperations.Generated.tt
+++ b/Src/ILGPU.Tests/ConvertIntOperations.Generated.tt
@@ -15,12 +15,8 @@ var types = IntTypes.Concat(FloatTypes);
 #>
 namespace ILGPU.Tests
 {
-    public abstract class ConvertIntOperations : TestBase
+    partial class ConvertIntOperations
     {
-        protected ConvertIntOperations(ITestOutputHelper output, TestContext testContext)
-            : base(output, testContext)
-        { }
-
 <# foreach (var type in IntTypes) { #>
 <#      foreach (var targetType in types) { #>
 <#         var baseName = "_" + type.Name + "_" + targetType.Name; #>

--- a/Src/ILGPU.Tests/ConvertIntOperations.cs
+++ b/Src/ILGPU.Tests/ConvertIntOperations.cs
@@ -1,0 +1,67 @@
+﻿using ILGPU.Runtime;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ILGPU.Tests
+{
+    public abstract partial class ConvertIntOperations : TestBase
+    {
+        protected ConvertIntOperations(ITestOutputHelper output, TestContext testContext)
+            : base(output, testContext)
+        { }
+
+        internal static void TruncateIntKernel(
+            Index1D index,
+            ArrayView1D<long, Stride1D.Dense> input,
+            ArrayView1D<int, Stride1D.Dense> output)
+        {
+            var i = (int)input[index];
+            output[i] = i;
+        }
+
+        [Fact]
+        [KernelMethod(nameof(TruncateIntKernel))]
+        public void TruncateIntConversion()
+        {
+            // NB: High 32-bits are discarded.
+            const int Length = 64;
+            var inputValues = Enumerable.Range(1, Length)
+                .Select(x => Length - x + 0x5_0000_0000)
+                .ToArray();
+            var expected = Enumerable.Range(0, Length).ToArray();
+
+            using var input = Accelerator.Allocate1D<long>(inputValues);
+            using var output = Accelerator.Allocate1D<int>(input.Length);
+            Execute(Length, input.View, output.View);
+            Verify(output.View, expected);
+        }
+
+        internal static void TruncateSmallerKernel(
+            Index1D index,
+            ArrayView1D<long, Stride1D.Dense> input,
+            ArrayView1D<short, Stride1D.Dense> output)
+        {
+            var i = (int)input[index];
+            output[(short)i] = (short)i;
+        }
+
+        [Fact]
+        [KernelMethod(nameof(TruncateSmallerKernel))]
+        public void TruncateSmallerConversion()
+        {
+            const int Length = 64;
+            var inputValues = Enumerable.Range(1, Length)
+                .Select(x => Length - x + 0x5_4321_0000)
+                .ToArray();
+            var expected = Enumerable.Range(0, Length)
+                .Select(x => (short)x)
+                .ToArray();
+
+            using var input = Accelerator.Allocate1D<long>(inputValues);
+            using var output = Accelerator.Allocate1D<short>(input.Length);
+            Execute(Length, input.View, output.View);
+            Verify(output.View, expected);
+        }
+    }
+}

--- a/Src/ILGPU.Tests/ILGPU.Tests.csproj
+++ b/Src/ILGPU.Tests/ILGPU.Tests.csproj
@@ -86,10 +86,10 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>ConvertFloatOperations.tt</DependentUpon>
     </None>
-    <None Include="ConvertIntOperations.cs">
+    <None Include="ConvertIntOperations.Generated.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
-      <DependentUpon>ConvertIntOperations.tt</DependentUpon>
+      <DependentUpon>ConvertIntOperations.Generated.tt</DependentUpon>
     </None>
     <None Include="FixedBuffers.cs">
       <DesignTime>True</DesignTime>
@@ -225,9 +225,9 @@
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>ConvertFloatOperations.cs</LastGenOutput>
     </None>
-    <None Update="ConvertIntOperations.tt">
+    <None Update="ConvertIntOperations.Generated.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
-      <LastGenOutput>ConvertIntOperations.cs</LastGenOutput>
+      <LastGenOutput>ConvertIntOperations.Generated.cs</LastGenOutput>
     </None>
     <None Update="FixedBuffers.tt">
       <Generator>TextTemplatingFileGenerator</Generator>


### PR DESCRIPTION
Fixes #470.

For #470, we were converting from Int64 to Int32, then to Int64 (in the debug assertions). However, the conversion was incorrectly simplified into Int64 to Int64, without the truncation to Int32 in the middle.
