### PR TITLE
Support for multi-dimensional and static constant arrays.

### DIFF
--- a/Src/ILGPU.Tests/Generic/TestContext.cs
+++ b/Src/ILGPU.Tests/Generic/TestContext.cs
@@ -24,7 +24,12 @@ namespace ILGPU.Tests
             Func<Context, Accelerator> createAccelerator)
         {
             Context = Context.Create(builder =>
-                prepareContext(builder.Assertions().Verify().Optimize(level)));
+                prepareContext(
+                    builder
+                    .Assertions()
+                    .Arrays(ArrayMode.InlineMutableStaticArrays)
+                    .Verify()
+                    .Optimize(level)));
             Accelerator = createAccelerator(Context);
         }
 

--- a/Src/ILGPU/Context.Builder.cs
+++ b/Src/ILGPU/Context.Builder.cs
@@ -166,6 +166,17 @@ namespace ILGPU
             }
 
             /// <summary>
+            /// Specifies how to deal with arrays.
+            /// </summary>
+            /// <param name="arrayMode">The array mode to use.</param>
+            /// <returns>The current builder instance.</returns>
+            public Builder Arrays(ArrayMode arrayMode)
+            {
+                ArrayMode = arrayMode;
+                return this;
+            }
+
+            /// <summary>
             /// Specifies the caching mode for the context instance.
             /// </summary>
             /// <param name="cachingMode">The caching mode to use.</param>

--- a/Src/ILGPU/ContextProperties.cs
+++ b/Src/ILGPU/ContextProperties.cs
@@ -172,6 +172,25 @@ namespace ILGPU
     }
 
     /// <summary>
+    /// Internal flags to specify the behavior in the presence of static arrays. Note
+    /// that static array fields are also affected by the <see cref="StaticFieldMode"/>
+    /// settings.
+    /// </summary>
+    public enum ArrayMode
+    {
+        /// <summary>
+        /// Loads from static array values are rejected by default.
+        /// </summary>
+        Default,
+
+        /// <summary>
+        /// Loads from static arrays are supported and realized by inlining static
+        /// array values.
+        /// </summary>
+        InlineMutableStaticArrays,
+    }
+
+    /// <summary>
     /// Internal flags to specify the caching behavior.
     /// </summary>
     public enum CachingMode
@@ -303,6 +322,13 @@ namespace ILGPU
             StaticFieldMode.Default;
 
         /// <summary>
+        /// Defines how to deal with arrays.
+        /// </summary>
+        /// <remarks><see cref="ArrayMode.Default"/> by default.</remarks>
+        public ArrayMode ArrayMode { get; protected set; } =
+            ArrayMode.Default;
+
+        /// <summary>
         /// Defines which functions/kernels/modules should be cached.
         /// </summary>
         /// <remarks><see cref="CachingMode.Default"/> by default.</remarks>
@@ -359,6 +385,7 @@ namespace ILGPU
                 InliningMode = InliningMode,
                 MathMode = MathMode,
                 StaticFieldMode = StaticFieldMode,
+                ArrayMode = ArrayMode,
                 CachingMode = CachingMode,
             };
 

--- a/Src/ILGPU/Frontend/CodeGenerator/Fields.cs
+++ b/Src/ILGPU/Frontend/CodeGenerator/Fields.cs
@@ -37,7 +37,12 @@ namespace ILGPU.Frontend
                 fieldIndex = structureType.RemapFieldIndex(fieldIndex);
             }
 
-            return new FieldSpan(fieldIndex, typeInfo.NumFlattendedFields);
+            // Compute the actual span based on the intrinsic mapping of .Net arrays
+            // to ILGPU structure values
+            int span = typeInfo.NumFlattendedFields;
+            if (typeInfo.ManagedType.IsArray)
+                span += typeInfo.ManagedType.GetArrayRank();
+            return new FieldSpan(fieldIndex, span);
         }
 
         /// <summary>

--- a/Src/ILGPU/Frontend/Intrinsic/ArrayIntrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/ArrayIntrinsics.cs
@@ -1,0 +1,210 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                        Copyright (c) 2016-2020 Marcel Koester
+//                                    www.ilgpu.net
+//
+// File: ArrayIntrinsics.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+
+using ILGPU.IR;
+using ILGPU.IR.Values;
+using ILGPU.Resources;
+using ILGPU.Util;
+using System;
+
+namespace ILGPU.Frontend.Intrinsic
+{
+    partial class Intrinsics
+    {
+        #region Managed Arrays
+
+        /// <summary>
+        /// Determines whether the given type is an intrinsic array type.
+        /// </summary>
+        /// <param name="type">The type to test.</param>
+        /// <returns>True, if the given type is an intrinsic array type.</returns>
+        internal static bool IsIntrinsicArrayType(Type type) =>
+            type == typeof(Array) || type.IsArray;
+
+        /// <summary>
+        /// Handles array operations.
+        /// </summary>
+        /// <param name="context">The current invocation context.</param>
+        /// <returns>The resulting value.</returns>
+        private static ValueReference HandleArrays(ref InvocationContext context)
+        {
+            var builder = context.Builder;
+            var location = context.Location;
+            return context.Method.Name switch
+            {
+                ".ctor" => CreateNewArray(ref context),
+                "Get" => CreateGetArrayElement(ref context),
+                "Set" => CreateSetArrayElement(ref context),
+                "get_Length" => builder.CreateGetArrayLength(
+                    location,
+                    context[0]),
+                "get_LongLength" => builder.CreateGetArrayLongLength(
+                    location,
+                    context[0]),
+                nameof(Array.GetLowerBound) => CreateGetArrayLowerBound(ref context),
+                nameof(Array.GetUpperBound) => CreateGetArrayUpperBound(ref context),
+                nameof(Array.GetLength) => CreateGetArrayLength(ref context),
+                nameof(Array.GetLongLength) => CreateGetArrayLongLength(ref context),
+                nameof(Array.Empty) => CreateEmptyArray(ref context),
+                _ => throw location.GetNotSupportedException(
+                    ErrorMessages.NotSupportedIntrinsic,
+                    context.Method.Name),
+            };
+        }
+
+        /// <summary>
+        /// Creates a new nD array instance.
+        /// </summary>
+        /// <param name="context">The current invocation context.</param>
+        /// <returns>The resulting value.</returns>
+        private static ValueReference CreateNewArray(ref InvocationContext context)
+        {
+            var location = context.Location;
+            var builder = context.Builder;
+
+            int dimension = context.NumArguments - 1;
+            if (dimension < 1)
+            {
+                throw context.Location.GetNotSupportedException(
+                    ErrorMessages.NotSupportedArrayDimension,
+                    dimension.ToString());
+            }
+
+            // Create an array view type of the appropriate dimension
+            var managedElementType = context.Method.DeclaringType.GetElementType();
+            var elementType = builder.CreateType(
+                managedElementType,
+                MemoryAddressSpace.Generic);
+            var dimensionLengths = context.Arguments.Slice(1, dimension);
+
+            // Create and store array instance
+            var newArray = builder.CreateNewArray(
+                location,
+                elementType,
+                ref dimensionLengths);
+
+            // Clear array data
+            var callArguments = InlineList<ValueReference>.Create(
+                builder.CreateGetViewFromArray(
+                    location,
+                    newArray));
+            builder.CreateCall(
+                location,
+                context.DeclareMethod(
+                    LocalMemory.GetClearMethod(managedElementType)),
+                ref callArguments);
+
+            // Store instance
+            builder.CreateStore(location, context[0], newArray);
+            return default;
+        }
+
+        /// <summary>
+        /// Creates a new empty 1D array instance.
+        /// </summary>
+        /// <param name="context">The current invocation context.</param>
+        /// <returns>The resulting value.</returns>
+        private static Value CreateEmptyArray(ref InvocationContext context)
+        {
+            var location = context.Location;
+            var builder = context.Builder;
+
+            var elementType = builder.CreateType(context.GetMethodGenericArguments()[0]);
+            return builder.CreateEmptyArray(location, elementType, 1);
+        }
+
+        /// <summary>
+        /// Gets an array element.
+        /// </summary>
+        /// <param name="context">The current invocation context.</param>
+        /// <returns>The resulting value.</returns>
+        private static Value CreateGetArrayElement(ref InvocationContext context)
+        {
+            var location = context.Location;
+            var builder = context.Builder;
+
+            var arguments = context.Arguments.Slice(1, context.NumArguments - 1);
+            return builder.CreateLoad(
+                location,
+                builder.CreateGetArrayElementAddress(
+                    location,
+                    context[0],
+                    ref arguments));
+        }
+
+        /// <summary>
+        /// Sets an array element.
+        /// </summary>
+        /// <param name="context">The current invocation context.</param>
+        /// <returns>The resulting value.</returns>
+        private static Value CreateSetArrayElement(ref InvocationContext context)
+        {
+            var location = context.Location;
+            var builder = context.Builder;
+
+            var arguments = context.Arguments.Slice(1, context.NumArguments - 2);
+            return builder.CreateStore(
+                location,
+                builder.CreateGetArrayElementAddress(
+                    location,
+                    context[0],
+                    ref arguments),
+                context[context.NumArguments - 1]);
+        }
+
+        /// <summary>
+        /// Gets an array lower bound.
+        /// </summary>
+        /// <param name="context">The current invocation context.</param>
+        /// <returns>The resulting value.</returns>
+        private static Value CreateGetArrayLowerBound(ref InvocationContext context) =>
+            context.Builder.CreatePrimitiveValue(
+                context.Location,
+                0);
+
+        /// <summary>
+        /// Gets an array upper bound.
+        /// </summary>
+        /// <param name="context">The current invocation context.</param>
+        /// <returns>The resulting value.</returns>
+        private static Value CreateGetArrayUpperBound(ref InvocationContext context) =>
+            context.Builder.CreateArithmetic(
+                context.Location,
+                CreateGetArrayLength(ref context),
+                context.Builder.CreatePrimitiveValue(
+                    context.Location,
+                    1),
+                BinaryArithmeticKind.Sub);
+
+        /// <summary>
+        /// Gets an array length.
+        /// </summary>
+        /// <param name="context">The current invocation context.</param>
+        /// <returns>The resulting value.</returns>
+        private static Value CreateGetArrayLength(ref InvocationContext context) =>
+            context.Builder.CreateGetArrayLength(
+                context.Location,
+                context[0],
+                context[1]);
+
+        /// <summary>
+        /// Gets an array long length.
+        /// </summary>
+        /// <param name="context">The current invocation context.</param>
+        /// <returns>The resulting value.</returns>
+        private static Value CreateGetArrayLongLength(ref InvocationContext context) =>
+            context.Builder.CreateConvertToInt64(
+                context.Location,
+                CreateGetArrayLength(ref context));
+
+        #endregion
+    }
+}

--- a/Src/ILGPU/IR/Transformations/InferAddressSpaces.cs
+++ b/Src/ILGPU/IR/Transformations/InferAddressSpaces.cs
@@ -229,6 +229,7 @@ namespace ILGPU.IR.Transformations
                     // We are not allowed to remove field or array stores to tuples
                     // with different field types
                     return false;
+                case NewView _:
                 case SubViewValue _:
                 case PointerCast _:
                 case LoadElementAddress _:

--- a/Src/ILGPU/IR/Types/IRTypeContext.cs
+++ b/Src/ILGPU/IR/Types/IRTypeContext.cs
@@ -279,8 +279,8 @@ namespace ILGPU.IR.Types
         /// <returns>The created array type.</returns>
         public TypeNode CreateArrayType(TypeNode elementType, int dimensions)
         {
-            // Check for not supported array dimensions
-            if (dimensions != 1)
+            // Map arbitrary array dimensions
+            if (dimensions < 1)
             {
                 throw new NotSupportedException(
                     string.Format(
@@ -288,8 +288,15 @@ namespace ILGPU.IR.Types
                         dimensions.ToString()));
             }
 
-            // Create a 1D view type for now
-            return CreateViewType(elementType, MemoryAddressSpace.Generic);
+            // We need one element to store the base view type and an extent in each
+            // dimension
+            var builder = CreateStructureType(1 + dimensions);
+            // Attach the data view
+            builder.Add(CreateViewType(elementType, MemoryAddressSpace.Generic));
+            // Add each dimension
+            for (int i = 0; i < dimensions; ++i)
+                builder.Add(GetPrimitiveType(BasicValueType.Int32));
+            return builder.Seal();
         }
 
         /// <summary>

--- a/Src/ILGPU/LocalMemory.cs
+++ b/Src/ILGPU/LocalMemory.cs
@@ -24,36 +24,34 @@ namespace ILGPU
     public static partial class LocalMemory
     {
         /// <summary>
-        /// A readonly reference to the <see cref="AllocateZero{T}(int)"/> method.
+        /// A readonly reference to the <see cref="Clear{T}(ArrayView{T})"/> method.
         /// </summary>
-        private static readonly MethodInfo AllocateZeroMethod =
+        private static readonly MethodInfo ClearMethod =
             typeof(LocalMemory).GetMethod(
-                nameof(AllocateZero),
+                nameof(Clear),
                 BindingFlags.NonPublic | BindingFlags.Static);
 
         /// <summary>
-        /// Creates a typed <see cref="AllocateZero{T}(int)"/> method instance to invoke.
+        /// Creates a typed <see cref="Clear{T}(ArrayView{T})"/> method instance to
+        /// invoke.
         /// </summary>
         /// <param name="elementType">The array element type.</param>
         /// <returns>The typed method instance.</returns>
-        internal static MethodInfo GetAllocateZeroMethod(Type elementType) =>
-            AllocateZeroMethod.MakeGenericMethod(elementType);
+        internal static MethodInfo GetClearMethod(Type elementType) =>
+            ClearMethod.MakeGenericMethod(elementType);
 
         /// <summary>
-        /// Allocates a chunk of local memory with the specified number of elements.
+        /// Clears a chunk of local memory with the specified number of elements.
         /// </summary>
         /// <typeparam name="T">The element type.</typeparam>
-        /// <param name="extent">The extent (number of elements to allocate).</param>
+        /// <param name="view">The extent (number of elements to allocate).</param>
         /// <returns>An allocated region of local memory.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static ArrayView<T> AllocateZero<T>(int extent)
+        private static void Clear<T>(ArrayView<T> view)
             where T : unmanaged
         {
-            Trace.Assert(extent >= 0, "Invalid extent");
-            var view = Allocate<T>(extent);
-            for (long i = 0; i < extent; ++i)
+            for (int i = 0, e = view.IntLength; i < e; ++i)
                 view[i] = default;
-            return view;
         }
 
         /// <summary>

--- a/Src/ILGPU/Resources/ErrorMessages.Designer.cs
+++ b/Src/ILGPU/Resources/ErrorMessages.Designer.cs
@@ -592,6 +592,15 @@ namespace ILGPU.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot load from the static array &apos;{0} since it is mutable..
+        /// </summary>
+        internal static string NotSupportedLoadFromStaticArray {
+            get {
+                return ResourceManager.GetString("NotSupportedLoadFromStaticArray", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot load from the static field &apos;{0}&apos; since it is not read only.
         /// </summary>
         internal static string NotSupportedLoadOfStaticField {
@@ -804,6 +813,15 @@ namespace ILGPU.Resources {
         internal static string NotSupportedWriteFormatConstant {
             get {
                 return ResourceManager.GetString("NotSupportedWriteFormatConstant", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The array dimension &apos;{0}&apos; must be a compile-time constant and within the range of the array..
+        /// </summary>
+        internal static string NotSupportNonConstArrayDimension {
+            get {
+                return ResourceManager.GetString("NotSupportNonConstArrayDimension", resourceCulture);
             }
         }
         

--- a/Src/ILGPU/Resources/ErrorMessages.Designer.cs
+++ b/Src/ILGPU/Resources/ErrorMessages.Designer.cs
@@ -349,7 +349,7 @@ namespace ILGPU.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The array dimension &apos;{0}&apos; is multidimensional. Currently only liner arrays are supported.
+        ///   Looks up a localized string similar to The array dimension &apos;{0}&apos; is out of the supported array dimensions..
         /// </summary>
         internal static string NotSupportedArrayDimension {
             get {

--- a/Src/ILGPU/Resources/ErrorMessages.resx
+++ b/Src/ILGPU/Resources/ErrorMessages.resx
@@ -369,4 +369,10 @@
   <data name="NotSupportedInlinePTXFormatConstant" xml:space="preserve">
     <value>Not supported inline PTX format '{0}; must be a constant string reference</value>
   </data>
+  <data name="NotSupportedLoadFromStaticArray" xml:space="preserve">
+    <value>Cannot load from the static array '{0} since it is mutable.</value>
+  </data>
+  <data name="NotSupportNonConstArrayDimension" xml:space="preserve">
+    <value>The array dimension '{0}' must be a compile-time constant and within the range of the array.</value>
+  </data>
 </root>

--- a/Src/ILGPU/Resources/ErrorMessages.resx
+++ b/Src/ILGPU/Resources/ErrorMessages.resx
@@ -139,7 +139,7 @@
     <value>Cannot create a dynamically sized array on an accelerator</value>
   </data>
   <data name="NotSupportedArrayDimension" xml:space="preserve">
-    <value>The array dimension '{0}' is multidimensional. Currently only liner arrays are supported</value>
+    <value>The array dimension '{0}' is out of the supported array dimensions.</value>
   </data>
   <data name="NotSupportedClassType" xml:space="preserve">
     <value>Class type '{0}' is not supported</value>

--- a/Src/ILGPU/Util/TypeExtensions.cs
+++ b/Src/ILGPU/Util/TypeExtensions.cs
@@ -12,6 +12,7 @@
 using ILGPU.IR.Values;
 using ILGPU.Runtime;
 using System;
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text;
@@ -88,6 +89,25 @@ namespace ILGPU.Util
             }
             var args = type.GetGenericArguments();
             nestedType = args[0];
+            return true;
+        }
+
+        /// <summary>
+        /// Checks whether the given type is an immutable array.
+        /// </summary>
+        /// <param name="type">The source type.</param>
+        /// <param name="elementType">The element type (if any).</param>
+        /// <returns>True, if the given type is an immutable array.</returns>
+        public static bool IsImmutableArray(this Type type, out Type elementType)
+        {
+            elementType = null;
+            if (!type.IsGenericType ||
+                type.GetGenericTypeDefinition() != typeof(ImmutableArray<>))
+            {
+                return false;
+            }
+
+            elementType = type.GetGenericArguments()[0];
             return true;
         }
 


### PR DESCRIPTION
This PR adds full support for multi-dimensional arrays in the context of ILGPU kernels (previously only 1D arrays were supported). It also adds support for accessing constant arrays from static fields (closes #419). Note that the memory layout of .Net and the newly built-in ILGPU arrays is identical.

~This PR requires #478 to run.~

The following code snippet demonstrates the new support for multi-dimensional arrays within a kernel:
```c#
static void Kernel(Index1D index, ArrayView<int> output)
{
    var data = new int[,] { { 0, 1 }, { 2, 3 } };

    output[index] = data[0, 0]; // Will be resolved at kernel compile time by the ILGPU optimizer
}
```

Please note that arrays are not inlined into kernels by default, since .Net arrays themselves are not immutable and could be changed by the CPU after kernel compilation. The following example is not compiled with the default ILGPU context settings:
```c#
readonly static int[] Data = ...
...
static void Kernel(...)
{
    ... Data[index] // Compile error
}
```

However, there are two ways to deal with this "problem":
- Specify `ArrayMode.InlineMutableStaticArrays` using `ContextBuilder.Arrays(ArrayMode....)` to turn on inlining of mutable static arrays.
- Use `ImmutableArray<T>` structures to tell ILGPU that the array itself will not be modified by the CPU:
```c#
readonly static ImmutableArray<int> Data = ...
...
static void Kernel(...)
{
    ... Data[index] // Works fine with default compiler settings
}
```

This PR changes the internal implementation of array types to be mapped to structure values. Each array is converted to a structure consisting of a `View` and an `Int32` field (extent) for each array dimension:
```asm
int[,,] => Structure<View<int, Generic>, Int32, Int32, Int32>
```
This in turn adds the constraint that calls to `GetLength(i)` (to get the length in a given dimension) must resolved to one of the fields at compile time. In other words, `i` must be a compile-time known constant.

Note that the type change of array types plays nicely with the internal optimizer to ensure compile-time folding of even multi-dimensional arrays. However, a slight extension of the `InferAddressSpaces` pass (also included in this PR) was necessary.