### PR TITLE
Added page locking on pinned memory.

### DIFF
--- a/Src/ILGPU.Tests/Configurations.txt
+++ b/Src/ILGPU.Tests/Configurations.txt
@@ -9,6 +9,7 @@ Indices: Debug, Release, O2
 KernelEntryPoints: Debug, Release, O2
 MemoryBufferOperations : Debug, Release, O2
 MemoryCacheOperations : Debug, Release, O2
+PageLockedMemory: Debug, Release, O2
 ProfilingMarkers: Debug, Release, O2
 SharedMemory: Debug, Release, O2
 SizeOfValues: Debug, Release, O2

--- a/Src/ILGPU.Tests/Generic/TestBase.cs
+++ b/Src/ILGPU.Tests/Generic/TestBase.cs
@@ -227,7 +227,7 @@ namespace ILGPU.Tests
         {
             Assert.Equal(source.Length, expected.Length);
             for (int i = 0; i < expected.Length; ++i)
-                    Assert.Equal(expected[i], source[i]);
+                Assert.Equal(expected[i], source[i]);
         }
 
         /// <summary>

--- a/Src/ILGPU.Tests/PageLockedMemory.cs
+++ b/Src/ILGPU.Tests/PageLockedMemory.cs
@@ -1,0 +1,75 @@
+﻿using ILGPU.Runtime;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ILGPU.Tests
+{
+    public abstract class PageLockedMemory : TestBase
+    {
+        protected PageLockedMemory(ITestOutputHelper output, TestContext testContext)
+            : base(output, testContext)
+        { }
+
+        private const int Length = 1024;
+
+        internal static void PinnedMemoryKernel(
+            Index1D index,
+            ArrayView1D<int, Stride1D.Dense> data)
+        {
+            if (data[index] == 0)
+            {
+                data[index] = 42;
+            }
+            else
+            {
+                data[index] = 24;
+            }
+        }
+
+        [Fact]
+        [KernelMethod(nameof(PinnedMemoryKernel))]
+        public unsafe void PinnedUsingGCHandle()
+        {
+            var expected = Enumerable.Repeat(42, Length).ToArray();
+            var array = new int[Length];
+            var handle = GCHandle.Alloc(array, GCHandleType.Pinned);
+            try
+            {
+                using var buffer = Accelerator.Allocate1D<int>(array.Length);
+                using var scope = Accelerator.CreatePageLockFromPinned(array);
+
+                buffer.View.CopyFromPageLockedAsync(scope);
+                Execute(buffer.Length, buffer.View);
+
+                buffer.View.CopyToPageLockedAsync(scope);
+                Accelerator.Synchronize();
+                Verify1D(array, expected);
+            }
+            finally
+            {
+                handle.Free();
+            }
+        }
+
+#if NET5_0
+        [Fact]
+        [KernelMethod(nameof(PinnedMemoryKernel))]
+        public void PinnedUsingGCAllocateArray()
+        {
+            var expected = Enumerable.Repeat(42, Length).ToArray();
+            var array = System.GC.AllocateArray<int>(Length, pinned: true);
+            using var buffer = Accelerator.Allocate1D<int>(array.Length);
+            using var scope = Accelerator.CreatePageLockFromPinned(array);
+
+            buffer.View.CopyFromPageLockedAsync(scope);
+            Execute(buffer.Length, buffer.View);
+
+            buffer.View.CopyToPageLockedAsync(scope);
+            Accelerator.Synchronize();
+            Verify1D(array, expected);
+        }
+#endif
+    }
+}

--- a/Src/ILGPU/Resources/RuntimeErrorMessages.Designer.cs
+++ b/Src/ILGPU/Resources/RuntimeErrorMessages.Designer.cs
@@ -295,6 +295,15 @@ namespace ILGPU.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Creating a page lock is not supported on the current accelerator..
+        /// </summary>
+        internal static string NotSupportedPageLock {
+            get {
+                return ResourceManager.GetString("NotSupportedPageLock", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Not supported pitched allocation for type &apos;{0}&apos; and byte pitch {1}.
         /// </summary>
         internal static string NotSupportedPitchedAllocation {

--- a/Src/ILGPU/Resources/RuntimeErrorMessages.resx
+++ b/Src/ILGPU/Resources/RuntimeErrorMessages.resx
@@ -195,6 +195,9 @@
   <data name="NotSupportedOpenCLCVersion" xml:space="preserve">
     <value>Not supported OpenCL C version (&gt;= {0} required)</value>
   </data>
+  <data name="NotSupportedPageLock" xml:space="preserve">
+    <value>Creating a page lock is not supported on the current accelerator.</value>
+  </data>
   <data name="NotSupportedPitchedAllocation" xml:space="preserve">
     <value>Not supported pitched allocation for type '{0}' and byte pitch {1}</value>
   </data>

--- a/Src/ILGPU/Runtime/Accelerator.cs
+++ b/Src/ILGPU/Runtime/Accelerator.cs
@@ -778,6 +778,65 @@ namespace ILGPU.Runtime
 
         #endregion
 
+        #region Page Lock Scope
+
+        /// <summary>
+        /// Creates a page lock on the already pinned array.
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <param name="pinned">The already pinned array.</param>
+        /// <param name="numElements">The number of elements in the array.</param>
+        /// <returns>A page lock scope.</returns>
+        /// <remarks>
+        /// The array must already be pinned, otherwise the behaviour is undefined.
+        /// </remarks>
+        public unsafe PageLockScope<T> CreatePageLockFromPinned<T>(
+            IntPtr pinned,
+            long numElements)
+            where T : unmanaged
+        {
+            EnsureBlittable<T>();
+            return CreatePageLockFromPinnedInternal<T>(pinned, numElements);
+        }
+
+        /// <summary>
+        /// Creates a page lock on the already pinned array.
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <param name="pinned">The already pinned array.</param>
+        /// <returns>A page lock scope.</returns>
+        /// <remarks>
+        /// The array must already be pinned, otherwise the behaviour is undefined.
+        /// </remarks>
+        public unsafe PageLockScope<T> CreatePageLockFromPinned<T>(T[] pinned)
+            where T : unmanaged
+        {
+            // The array is already pinned - "fixing" it to obtain the memory address.
+            fixed (T* ptr = pinned)
+            {
+                return CreatePageLockFromPinned<T>(
+                    new IntPtr(ptr),
+                    pinned.Length);
+            }
+        }
+
+        /// <summary>
+        /// Creates a page lock on the already pinned array.
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <param name="pinned">The already pinned array.</param>
+        /// <param name="numElements">The number of elements in the array.</param>
+        /// <returns>A page lock scope.</returns>
+        /// <remarks>
+        /// The array must already be pinned, otherwise the behaviour is undefined.
+        /// </remarks>
+        protected abstract PageLockScope<T> CreatePageLockFromPinnedInternal<T>(
+            IntPtr pinned,
+            long numElements)
+            where T : unmanaged;
+
+        #endregion
+
         #region IDisposable
 
         /// <summary cref="DisposeBase.Dispose(bool)"/>

--- a/Src/ILGPU/Runtime/ArrayViewExtensions.Generated.tt
+++ b/Src/ILGPU/Runtime/ArrayViewExtensions.Generated.tt
@@ -715,6 +715,76 @@ namespace ILGPU.Runtime
 
         #endregion
 
+        #region Copy to/from Page Locked
+
+<# foreach (var viewName in basicFunctions) { #>
+        /// <summary>
+        /// Copies from the source view into the given page locked memory without
+        /// synchronizing the current accelerator stream.
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <param name="source">The source view instance.</param>
+        /// <param name="pageLockScope">The page locked memory.</param>
+        /// <remarks>This method is not supported on accelerators.</remarks>
+        [NotInsideKernel]
+        public static void CopyToPageLockedAsync<T>(
+            this <#= viewName #> source,
+            PageLockScope<T> pageLockScope)
+            where T : unmanaged =>
+            source.BaseView.CopyToPageLockedAsync(pageLockScope);
+
+        /// <summary>
+        /// Copies from the source view into the given page locked memory without
+        /// synchronizing the current accelerator stream.
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <param name="source">The source view instance.</param>
+        /// <param name="stream">The used accelerator stream.</param>
+        /// <param name="pageLockScope">The page locked memory.</param>
+        /// <remarks>This method is not supported on accelerators.</remarks>
+        [NotInsideKernel]
+        public static void CopyToPageLockedAsync<T>(
+            this <#= viewName #> source,
+            AcceleratorStream stream,
+            PageLockScope<T> pageLockScope)
+            where T : unmanaged =>
+            source.BaseView.CopyToPageLockedAsync(stream, pageLockScope);
+
+        /// <summary>
+        /// Copies from the page locked memory into the given target view without
+        /// synchronizing the current accelerator stream.
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <param name="target">The target view instance.</param>
+        /// <param name="pageLockScope">The page locked memory.</param>
+        /// <remarks>This method is not supported on accelerators.</remarks>
+        [NotInsideKernel]
+        public static void CopyFromPageLockedAsync<T>(
+            this <#= viewName #> target,
+            PageLockScope<T> pageLockScope)
+            where T : unmanaged =>
+            target.BaseView.CopyFromPageLockedAsync(pageLockScope);
+
+        /// <summary>
+        /// Copies from the page locked memory into the given target view without
+        /// synchronizing the current accelerator stream.
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <param name="target">The target view instance.</param>
+        /// <param name="stream">The used accelerator stream.</param>
+        /// <param name="pageLockScope">The page locked memory.</param>
+        /// <remarks>This method is not supported on accelerators.</remarks>
+        [NotInsideKernel]
+        public static void CopyFromPageLockedAsync<T>(
+            this <#= viewName #> target,
+            AcceleratorStream stream,
+            PageLockScope<T> pageLockScope)
+            where T : unmanaged =>
+            target.BaseView.CopyFromPageLockedAsync(stream, pageLockScope);
+
+<# } #>
+        #endregion
+
         #region GetAsArray
 
 <# foreach (var (dimension, strideName, needsTranspose) in generalDimensionStrides) { #>

--- a/Src/ILGPU/Runtime/ArrayViewExtensions.cs
+++ b/Src/ILGPU/Runtime/ArrayViewExtensions.cs
@@ -703,6 +703,8 @@ namespace ILGPU.Runtime
                 stream,
                 source.IndexInBytes,
                 buffer.AsRawArrayView());
+            if (pageLockScope is NullPageLockScope<T>)
+                stream.Synchronize();
         }
 
         /// <summary>
@@ -736,6 +738,8 @@ namespace ILGPU.Runtime
                 stream,
                 buffer.AsRawArrayView(),
                 target.IndexInBytes);
+            if (pageLockScope is NullPageLockScope<T>)
+                stream.Synchronize();
         }
 
         /// <summary>

--- a/Src/ILGPU/Runtime/ArrayViewExtensions.cs
+++ b/Src/ILGPU/Runtime/ArrayViewExtensions.cs
@@ -670,6 +670,116 @@ namespace ILGPU.Runtime
 
         #endregion
 
+        #region Copy to/from Page Lock async
+
+        /// <summary>
+        /// Copies from the source view into the given page locked memory without
+        /// synchronizing the current accelerator stream.
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <typeparam name="TView">The view type.</typeparam>
+        /// <param name="source">The source view instance.</param>
+        /// <param name="stream">The used accelerator stream.</param>
+        /// <param name="pageLockScope">The page locked memory.</param>
+        /// <remarks>This method is not supported on accelerators.</remarks>
+        [NotInsideKernel]
+        public static void CopyToPageLockedAsync<T, TView>(
+            this TView source,
+            AcceleratorStream stream,
+            PageLockScope<T> pageLockScope)
+            where TView : IContiguousArrayView<T>
+            where T : unmanaged
+        {
+            if (pageLockScope == null)
+                throw new ArgumentNullException(nameof(pageLockScope));
+            if (pageLockScope.LengthInBytes < 1)
+                return;
+
+            using var buffer = CPUMemoryBuffer.Create(
+                pageLockScope.AddrOfLockedObject,
+                pageLockScope.LengthInBytes,
+                Interop.SizeOf<byte>());
+            source.Buffer.CopyTo(
+                stream,
+                source.IndexInBytes,
+                buffer.AsRawArrayView());
+        }
+
+        /// <summary>
+        /// Copies from the page locked memory into the given target view without
+        /// synchronizing the current accelerator stream.
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <typeparam name="TView">The view type.</typeparam>
+        /// <param name="target">The target view instance.</param>
+        /// <param name="stream">The used accelerator stream.</param>
+        /// <param name="pageLockScope">The page locked memory.</param>
+        /// <remarks>This method is not supported on accelerators.</remarks>
+        [NotInsideKernel]
+        public static void CopyFromPageLockedAsync<T, TView>(
+            this TView target,
+            AcceleratorStream stream,
+            PageLockScope<T> pageLockScope)
+            where TView : IContiguousArrayView<T>
+            where T : unmanaged
+        {
+            if (pageLockScope == null)
+                throw new ArgumentNullException(nameof(pageLockScope));
+            if (pageLockScope.LengthInBytes < 1)
+                return;
+
+            using var buffer = CPUMemoryBuffer.Create(
+                pageLockScope.AddrOfLockedObject,
+                pageLockScope.LengthInBytes,
+                Interop.SizeOf<byte>());
+            target.Buffer.CopyFrom(
+                stream,
+                buffer.AsRawArrayView(),
+                target.IndexInBytes);
+        }
+
+        /// <summary>
+        /// Copies from the source view into the given page locked memory without
+        /// synchronizing the current accelerator stream.
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <typeparam name="TView">The view type.</typeparam>
+        /// <param name="source">The source view instance.</param>
+        /// <param name="pageLockScope">The page locked memory.</param>
+        /// <remarks>This method is not supported on accelerators.</remarks>
+        [NotInsideKernel]
+        public static void CopyToPageLockedAsync<T, TView>(
+            this TView source,
+            PageLockScope<T> pageLockScope)
+            where TView : IContiguousArrayView<T>
+            where T : unmanaged =>
+            CopyToPageLockedAsync<T, TView>(
+                source,
+                source.GetDefaultStream(),
+                pageLockScope);
+
+        /// <summary>
+        /// Copies from the page locked memory into the given target view without
+        /// synchronizing the current accelerator stream.
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <typeparam name="TView">The view type.</typeparam>
+        /// <param name="target">The target view instance.</param>
+        /// <param name="pageLockScope">The page locked memory.</param>
+        /// <remarks>This method is not supported on accelerators.</remarks>
+        [NotInsideKernel]
+        public static void CopyFromPageLockedAsync<T, TView>(
+            this TView target,
+            PageLockScope<T> pageLockScope)
+            where TView : IContiguousArrayView<T>
+            where T : unmanaged =>
+            CopyFromPageLockedAsync<T, TView>(
+                target,
+                target.GetDefaultStream(),
+                pageLockScope);
+
+        #endregion
+
         #region Array Methods
 
         /// <summary>

--- a/Src/ILGPU/Runtime/CPU/CPUAccelerator.cs
+++ b/Src/ILGPU/Runtime/CPU/CPUAccelerator.cs
@@ -468,6 +468,16 @@ namespace ILGPU.Runtime.CPU
 
         #endregion
 
+        #region Page Lock Scope
+
+        /// <inheritdoc/>
+        protected unsafe override PageLockScope<T> CreatePageLockFromPinnedInternal<T>(
+            IntPtr pinned,
+            long numElements) =>
+            throw new NotSupportedException(RuntimeErrorMessages.NotSupportedPageLock);
+
+        #endregion
+
         #region IDisposable
 
         /// <summary>

--- a/Src/ILGPU/Runtime/CPU/CPUAccelerator.cs
+++ b/Src/ILGPU/Runtime/CPU/CPUAccelerator.cs
@@ -473,8 +473,11 @@ namespace ILGPU.Runtime.CPU
         /// <inheritdoc/>
         protected unsafe override PageLockScope<T> CreatePageLockFromPinnedInternal<T>(
             IntPtr pinned,
-            long numElements) =>
-            throw new NotSupportedException(RuntimeErrorMessages.NotSupportedPageLock);
+            long numElements)
+        {
+            Trace.WriteLine(RuntimeErrorMessages.NotSupportedPageLock);
+            return new NullPageLockScope<T>(this, pinned, numElements);
+        }
 
         #endregion
 

--- a/Src/ILGPU/Runtime/Cuda/CudaAPI.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaAPI.cs
@@ -449,6 +449,40 @@ namespace ILGPU.Runtime.Cuda
                 attribute,
                 devicePtr);
 
+        /// <summary>
+        /// Registers an existing host memory range for use by CUDA.
+        /// </summary>
+        /// <param name="hostPtr">The host pointer.</param>
+        /// <param name="bytesize ">The size of the buffer, in bytes.</param>
+        /// <param name="flags">The flags to use.</param>
+        /// <returns>The error status.</returns>
+        public CudaError MemHostRegister(
+            IntPtr hostPtr,
+            IntPtr bytesize,
+            MemHostRegisterFlags flags) =>
+            cuMemHostRegister_v2(hostPtr, bytesize, flags);
+
+        /// <summary>
+        /// Unregisters a memory range that was registered with cuMemHostRegister.
+        /// </summary>
+        /// <param name="hostPtr">The host pointer.</param>
+        /// <returns>The error status.</returns>
+        public CudaError MemHostUnregister(IntPtr hostPtr) =>
+            cuMemHostUnregister(hostPtr);
+
+        /// <summary>
+        /// Unregisters a memory range that was registered with cuMemHostRegister.
+        /// </summary>
+        /// <param name="devicePtr">The size of the buffer, in bytes.</param>
+        /// <param name="hostPtr">The host pointer.</param>
+        /// <param name="flags">The flags to use.</param>
+        /// <returns>The error status.</returns>
+        public CudaError MemHostGetDevicePointer(
+            out IntPtr devicePtr,
+            IntPtr hostPtr,
+            int flags) =>
+            cuMemHostGetDevicePointer_v2(out devicePtr, hostPtr, flags);
+
         #endregion
 
         #region Stream Methods

--- a/Src/ILGPU/Runtime/Cuda/CudaAPI.xml
+++ b/Src/ILGPU/Runtime/Cuda/CudaAPI.xml
@@ -113,6 +113,19 @@
         <Parameter Name="length" Type="IntPtr" />
         <Parameter Name="stream" Type="IntPtr" />
     </Import>
+    <Import Name="cuMemHostRegister_v2">
+        <Parameter Name="hostPtr" Type="IntPtr" />
+        <Parameter Name="bytesize" Type="IntPtr" />
+        <Parameter Name="flags" Type="MemHostRegisterFlags" />
+    </Import>
+    <Import Name="cuMemHostUnregister">
+        <Parameter Name="hostPtr" Type="IntPtr" />
+    </Import>
+    <Import Name="cuMemHostGetDevicePointer_v2">
+        <Parameter Name="devicePtr" Type="IntPtr" Flags="Out"/>
+        <Parameter Name="hostPtr" Type="IntPtr" />
+        <Parameter Name="flags" Type="int" />
+    </Import>
     <Import Name="cuStreamCreate">
         <Parameter Name="stream" Type="IntPtr" Flags="Out" />
         <Parameter Name="flags" Type="StreamFlags" />

--- a/Src/ILGPU/Runtime/Cuda/CudaAccelerator.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaAccelerator.cs
@@ -666,6 +666,19 @@ namespace ILGPU.Runtime.Cuda
 
         #endregion
 
+        #region Page Lock Scope
+
+        /// <inheritdoc/>
+        protected unsafe override PageLockScope<T> CreatePageLockFromPinnedInternal<T>(
+            IntPtr pinned,
+            long numElements) =>
+            new CudaPageLockScope<T>(
+                this,
+                pinned,
+                numElements);
+
+        #endregion
+
         #region IDisposable
 
         /// <summary>

--- a/Src/ILGPU/Runtime/Cuda/CudaAccelerator.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaAccelerator.cs
@@ -672,10 +672,9 @@ namespace ILGPU.Runtime.Cuda
         protected unsafe override PageLockScope<T> CreatePageLockFromPinnedInternal<T>(
             IntPtr pinned,
             long numElements) =>
-            new CudaPageLockScope<T>(
-                this,
-                pinned,
-                numElements);
+            Device.SupportsMappingHostMemory
+            ? new CudaPageLockScope<T>(this, pinned, numElements)
+            : (PageLockScope<T>)new NullPageLockScope<T>(this, pinned, numElements);
 
         #endregion
 

--- a/Src/ILGPU/Runtime/Cuda/CudaDevice.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaDevice.cs
@@ -324,6 +324,11 @@ namespace ILGPU.Runtime.Cuda
             SupportsComputePreemption = CurrentAPI.GetDeviceAttribute(
                 DeviceAttributeKind.CU_DEVICE_ATTRIBUTE_COMPUTE_PREEMPTION_SUPPORTED,
                 DeviceId) != 0;
+
+            // Resolve whether this device supports using host memory
+            SupportsMappingHostMemory = CurrentAPI.GetDeviceAttribute(
+                DeviceAttributeKind.CU_DEVICE_ATTRIBUTE_CAN_MAP_HOST_MEMORY,
+                DeviceId) != 0;
         }
 
         /// <summary>
@@ -427,9 +432,14 @@ namespace ILGPU.Runtime.Cuda
         public bool SupportsManagedMemory { get; private set; }
 
         /// <summary>
-        /// Returns true if this device support compute preemption.
+        /// Returns true if this device supports compute preemption.
         /// </summary>
         public bool SupportsComputePreemption { get; private set; }
+
+        /// <summary>
+        /// Returns true if this device supports mapping host memory.
+        /// </summary>
+        public bool SupportsMappingHostMemory { get; private set; }
 
         /// <summary>
         /// Returns the current device driver mode.

--- a/Src/ILGPU/Runtime/Cuda/CudaDevice.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaDevice.cs
@@ -329,6 +329,10 @@ namespace ILGPU.Runtime.Cuda
             SupportsMappingHostMemory = CurrentAPI.GetDeviceAttribute(
                 DeviceAttributeKind.CU_DEVICE_ATTRIBUTE_CAN_MAP_HOST_MEMORY,
                 DeviceId) != 0;
+            SupportsUsingHostPointerForRegisteredMemory = CurrentAPI.GetDeviceAttribute(
+                DeviceAttributeKind.
+                    CU_DEVICE_ATTRIBUTE_CAN_USE_HOST_POINTER_FOR_REGISTERED_MEM,
+                DeviceId) != 0;
         }
 
         /// <summary>
@@ -440,6 +444,12 @@ namespace ILGPU.Runtime.Cuda
         /// Returns true if this device supports mapping host memory.
         /// </summary>
         public bool SupportsMappingHostMemory { get; private set; }
+
+        /// <summary>
+        /// Returns true if this device supports using the host pointer for registered
+        /// memory.
+        /// </summary>
+        public bool SupportsUsingHostPointerForRegisteredMemory { get; private set; }
 
         /// <summary>
         /// Returns the current device driver mode.

--- a/Src/ILGPU/Runtime/Cuda/CudaNativeMethods.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaNativeMethods.cs
@@ -272,6 +272,33 @@ namespace ILGPU.Runtime.Cuda
         CU_EVENT_INTERPROCESS = 4,
     }
 
+    /// <summary>
+    /// Represents flags used to register host memory with the CUDA.
+    /// </summary>
+    [Flags]
+    public enum MemHostRegisterFlags
+    {
+        /// <summary>
+        /// Host memory is portable between CUDA contexts.
+        /// </summary>
+        CU_MEMHOSTREGISTER_PORTABLE = 1,
+
+        /// <summary>
+        /// Host memory is mapped into CUDA address space.
+        /// </summary>
+        CU_MEMHOSTREGISTER_DEVICEMAP = 2,
+
+        /// <summary>
+        /// Memory pointer is treated as pointing to some memory-mapped I/O space.
+        /// </summary>
+        CU_MEMHOSTREGISTER_IOMEMORY = 4,
+
+        /// <summary>
+        /// Memory pointer is treated as pointing to memory that is considered read-only.
+        /// </summary>
+        CU_MEMHOSTREGISTER_READ_ONLY = 8,
+    }
+
     #endregion
 }
 

--- a/Src/ILGPU/Runtime/Cuda/CudaPageLockScope.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaPageLockScope.cs
@@ -1,0 +1,66 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                        Copyright (c) 2016-2020 Marcel Koester
+//                                    www.ilgpu.net
+//
+// File: CudaPageLockScope.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+
+using ILGPU.Resources;
+using ILGPU.Runtime.Cuda;
+using System;
+using static ILGPU.Runtime.Cuda.CudaAPI;
+
+namespace ILGPU.Runtime
+{
+    /// <summary>
+    /// Represents a CUDA page lock scope.
+    /// </summary>
+    public sealed class CudaPageLockScope<T> : PageLockScope<T>
+        where T : unmanaged
+    {
+        /// <summary>
+        /// Constructs a page lock scope for the accelerator.
+        /// </summary>
+        /// <param name="accelerator">The associated accelerator.</param>
+        /// <param name="hostPtr">The host buffer pointer to page lock.</param>
+        /// <param name="numElements">The number of elements in the buffer.</param>
+        internal CudaPageLockScope(
+            CudaAccelerator accelerator,
+            IntPtr hostPtr,
+            long numElements)
+            : base(accelerator)
+        {
+            var flags = MemHostRegisterFlags.CU_MEMHOSTREGISTER_PORTABLE;
+            if (!accelerator.Device.SupportsMappingHostMemory)
+            {
+                throw new NotSupportedException(
+                    RuntimeErrorMessages.NotSupportedPageLock);
+            }
+
+            AddrOfLockedObject = hostPtr;
+            Length = numElements;
+
+            CudaException.ThrowIfFailed(
+                CurrentAPI.MemHostRegister(
+                    hostPtr,
+                    new IntPtr(LengthInBytes),
+                    flags));
+        }
+
+        /// <inheritdoc/>
+        protected override void DisposeAcceleratorObject(bool disposing) =>
+            CudaException.VerifyDisposed(
+                disposing,
+                CurrentAPI.MemHostUnregister(AddrOfLockedObject));
+
+        /// <inheritdoc/>
+        public override IntPtr AddrOfLockedObject { get; }
+
+        /// <inheritdoc/>
+        public override long Length { get; }
+    }
+}

--- a/Src/ILGPU/Runtime/OpenCL/CLAccelerator.cs
+++ b/Src/ILGPU/Runtime/OpenCL/CLAccelerator.cs
@@ -541,6 +541,16 @@ namespace ILGPU.Runtime.OpenCL
 
         #endregion
 
+        #region Page Lock Scope
+
+        /// <inheritdoc/>
+        protected unsafe override PageLockScope<T> CreatePageLockFromPinnedInternal<T>(
+            IntPtr pinned,
+            long numElements) =>
+            throw new NotSupportedException(RuntimeErrorMessages.NotSupportedPageLock);
+
+        #endregion
+
         #region IDisposable
 
         /// <summary>

--- a/Src/ILGPU/Runtime/OpenCL/CLAccelerator.cs
+++ b/Src/ILGPU/Runtime/OpenCL/CLAccelerator.cs
@@ -15,6 +15,7 @@ using ILGPU.Resources;
 using ILGPU.Util;
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Reflection;
 using System.Reflection.Emit;
 using static ILGPU.Runtime.OpenCL.CLAPI;
@@ -546,8 +547,11 @@ namespace ILGPU.Runtime.OpenCL
         /// <inheritdoc/>
         protected unsafe override PageLockScope<T> CreatePageLockFromPinnedInternal<T>(
             IntPtr pinned,
-            long numElements) =>
-            throw new NotSupportedException(RuntimeErrorMessages.NotSupportedPageLock);
+            long numElements)
+        {
+            Trace.WriteLine(RuntimeErrorMessages.NotSupportedPageLock);
+            return new NullPageLockScope<T>(this, pinned, numElements);
+        }
 
         #endregion
 

--- a/Src/ILGPU/Runtime/PageLockScope.cs
+++ b/Src/ILGPU/Runtime/PageLockScope.cs
@@ -42,4 +42,37 @@ namespace ILGPU.Runtime
         /// </summary>
         public long LengthInBytes => Length * Interop.SizeOf<T>();
     }
+
+    /// <summary>
+    /// A null/no-op page lock scope.
+    /// </summary>
+    internal sealed class NullPageLockScope<T> : PageLockScope<T>
+        where T : unmanaged
+    {
+        /// <summary>
+        /// Constructs a page lock scope for the accelerator.
+        /// </summary>
+        /// <param name="accelerator">The associated accelerator.</param>
+        /// <param name="hostPtr">The host buffer pointer to page lock.</param>
+        /// <param name="numElements">The number of elements in the buffer.</param>
+        public NullPageLockScope(
+            Accelerator accelerator,
+            IntPtr hostPtr,
+            long numElements)
+            : base(accelerator)
+        {
+            AddrOfLockedObject = hostPtr;
+            Length = numElements;
+        }
+
+        /// <inheritdoc/>
+        public override IntPtr AddrOfLockedObject { get; }
+
+        /// <inheritdoc/>
+        public override long Length { get; }
+
+        /// <inheritdoc/>
+        protected override void DisposeAcceleratorObject(bool disposing)
+        { }
+    }
 }

--- a/Src/ILGPU/Runtime/PageLockScope.cs
+++ b/Src/ILGPU/Runtime/PageLockScope.cs
@@ -1,0 +1,45 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                        Copyright (c) 2016-2020 Marcel Koester
+//                                    www.ilgpu.net
+//
+// File: PageLockScope.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+
+using System;
+
+namespace ILGPU.Runtime
+{
+    /// <summary>
+    /// Represents the scope/duration of a page lock.
+    /// </summary>
+    public abstract class PageLockScope<T> : AcceleratorObject
+        where T : unmanaged
+    {
+        /// <summary>
+        /// Constructs a page lock scope for the accelerator.
+        /// </summary>
+        /// <param name="accelerator">The associated accelerator.</param>
+        protected PageLockScope(Accelerator accelerator)
+            : base(accelerator)
+        { }
+
+        /// <summary>
+        /// Returns the address of page locked object.
+        /// </summary>
+        public abstract IntPtr AddrOfLockedObject { get; }
+
+        /// <summary>
+        /// Returns the number of elements.
+        /// </summary>
+        public abstract long Length { get; }
+
+        /// <summary>
+        /// Returns the length of the page locked memory in bytes.
+        /// </summary>
+        public long LengthInBytes => Length * Interop.SizeOf<T>();
+    }
+}


### PR DESCRIPTION
Fixes #472.

This is a proposed API for dealing with page-locking memory on Cuda. On other accelerators, the page locking functionality throws a not supported exception.
QUESTION: Should this be a no-op instead?

Added a new `accelerator.CreatePageLockFromPinned` function that returns a `PageLockScope`. This currently accepts 1D arrays, or an `IntPtr` with `long` length. Pinning memory could take time, so the scope can be created once and retained. It should be disposed when no longer required.

Also added new `CopyFromPageLockedAsync` and `CopyToPageLockedAsync` methods that copy from `PageLockScope` without synchronising with the stream.

QUESTION: My device returns `false` for `CU_DEVICE_ATTRIBUTE_CAN_USE_HOST_POINTER_FOR_REGISTERED_MEM`. So, I registered the host memory using `CU_MEMHOSTREGISTER_DEVICEMAP`, and then retrieved the device pointer using `cuMemHostGetDevicePointer`. Unfortunately, that fails with `invalid device context`. However, using the host pointer works just fine.. any thoughts?