### PR TITLE
Added stream profiling markers.

### DIFF
--- a/Src/ILGPU.Tests/Configurations.txt
+++ b/Src/ILGPU.Tests/Configurations.txt
@@ -9,6 +9,7 @@ Indices: Debug, Release, O2
 KernelEntryPoints: Debug, Release, O2
 MemoryBufferOperations : Debug, Release, O2
 MemoryCacheOperations : Debug, Release, O2
+ProfilingMarkers: Debug, Release, O2
 SharedMemory: Debug, Release, O2
 SizeOfValues: Debug, Release, O2
 SpecializedKernels: Debug, Release, O2

--- a/Src/ILGPU.Tests/Generic/TestContext.cs
+++ b/Src/ILGPU.Tests/Generic/TestContext.cs
@@ -29,7 +29,8 @@ namespace ILGPU.Tests
                     .Assertions()
                     .Arrays(ArrayMode.InlineMutableStaticArrays)
                     .Verify()
-                    .Optimize(level)));
+                    .Optimize(level)
+                    .Profiling()));
             Accelerator = createAccelerator(Context);
         }
 

--- a/Src/ILGPU.Tests/ILGPU.Tests.csproj
+++ b/Src/ILGPU.Tests/ILGPU.Tests.csproj
@@ -159,6 +159,11 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>ConvertIntOperations.tt</DependentUpon>
     </Compile>
+    <Compile Update="ConvertIntOperations.Generated.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ConvertIntOperations.Generated.tt</DependentUpon>
+    </Compile>
     <Compile Update="FixedBuffers.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>

--- a/Src/ILGPU.Tests/ProfilingMarkers.cs
+++ b/Src/ILGPU.Tests/ProfilingMarkers.cs
@@ -1,0 +1,67 @@
+﻿using ILGPU.Runtime;
+using System;
+using System.Linq;
+using System.Threading;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ILGPU.Tests
+{
+    public abstract class ProfilingMarkers : TestBase
+    {
+        protected ProfilingMarkers(ITestOutputHelper output, TestContext testContext)
+            : base(output, testContext)
+        { }
+
+        private const int Length = 1024;
+
+        internal static void ProfilingMarkerKernel(
+            Index1D index,
+            ArrayView1D<int, Stride1D.Dense> data)
+        {
+            data[index] = index;
+        }
+
+        [Fact]
+        [KernelMethod(nameof(ProfilingMarkerKernel))]
+        public void MeasureProfilingMarker()
+        {
+            var expected = Enumerable.Range(0, Length).ToArray();
+            using var buffer = Accelerator.Allocate1D<int>(Length);
+
+            using var start = Accelerator.DefaultStream.AddProfilingMarker();
+            Accelerator.LaunchAutoGrouped<Index1D, ArrayView1D<int, Stride1D.Dense>>(
+                ProfilingMarkerKernel,
+                Accelerator.DefaultStream,
+                (int)buffer.Length,
+                buffer.View);
+            using var end = Accelerator.DefaultStream.AddProfilingMarker();
+
+            Verify(buffer.View, expected);
+
+            var elapsedTime = end - start;
+            Assert.True(elapsedTime.Ticks >= 0);
+        }
+
+        [Fact]
+        [KernelMethod(nameof(ProfilingMarkerKernel))]
+        public void MeasureReverseProfilingMarker()
+        {
+            var expected = Enumerable.Range(0, Length).ToArray();
+            using var buffer = Accelerator.Allocate1D<int>(Length);
+
+            using var start = Accelerator.DefaultStream.AddProfilingMarker();
+            Accelerator.LaunchAutoGrouped<Index1D, ArrayView1D<int, Stride1D.Dense>>(
+                ProfilingMarkerKernel,
+                Accelerator.DefaultStream,
+               (int)buffer.Length,
+                buffer.View);
+            using var end = Accelerator.DefaultStream.AddProfilingMarker();
+
+            Verify(buffer.View, expected);
+
+            var elapsedTime = start - end;
+            Assert.True(elapsedTime.Ticks <= 0);
+        }
+    }
+}

--- a/Src/ILGPU/Context.Builder.cs
+++ b/Src/ILGPU/Context.Builder.cs
@@ -229,6 +229,16 @@ namespace ILGPU
             }
 
             /// <summary>
+            /// Turns on profiling of all streams.
+            /// </summary>
+            /// <returns>The current builder instance.</returns>
+            public Builder Profiling()
+            {
+                EnableProfiling = true;
+                return this;
+            }
+
+            /// <summary>
             /// Converts this builder instance into a context instance.
             /// </summary>
             /// <returns>The created context instance.</returns>

--- a/Src/ILGPU/ContextProperties.cs
+++ b/Src/ILGPU/ContextProperties.cs
@@ -335,6 +335,12 @@ namespace ILGPU
         public CachingMode CachingMode { get; protected set; } =
             CachingMode.Default;
 
+        /// <summary>
+        /// Returns true if profiling is enabled on all streams.
+        /// </summary>
+        /// <remarks>Disabled by default.</remarks>
+        public bool EnableProfiling { get; protected set; }
+
         #endregion
 
         #region Methods
@@ -387,6 +393,7 @@ namespace ILGPU
                 StaticFieldMode = StaticFieldMode,
                 ArrayMode = ArrayMode,
                 CachingMode = CachingMode,
+                EnableProfiling = EnableProfiling,
             };
 
         #endregion

--- a/Src/ILGPU/Resources/RuntimeErrorMessages.Designer.cs
+++ b/Src/ILGPU/Resources/RuntimeErrorMessages.Designer.cs
@@ -205,6 +205,15 @@ namespace ILGPU.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Profiling marker &apos;{0}&apos; is not compatible with &apos;{1}&apos;.
+        /// </summary>
+        internal static string InvalidProfilingMarker {
+            get {
+                return ResourceManager.GetString("InvalidProfilingMarker", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Shared-memory size cannot be &lt; 0.
         /// </summary>
         internal static string InvalidSharedMemorySize {
@@ -291,6 +300,15 @@ namespace ILGPU.Resources {
         internal static string NotSupportedPitchedAllocation {
             get {
                 return ResourceManager.GetString("NotSupportedPitchedAllocation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot add profiling marker. Ensure that profiling is enabled from the ContextBuilder..
+        /// </summary>
+        internal static string NotSupportedProfilingMarker {
+            get {
+                return ResourceManager.GetString("NotSupportedProfilingMarker", resourceCulture);
             }
         }
         

--- a/Src/ILGPU/Resources/RuntimeErrorMessages.resx
+++ b/Src/ILGPU/Resources/RuntimeErrorMessages.resx
@@ -165,6 +165,9 @@
   <data name="InvalidNumberOfUniformArgs" xml:space="preserve">
     <value>The number of provided arguments does not match the required length</value>
   </data>
+  <data name="InvalidProfilingMarker" xml:space="preserve">
+    <value>Profiling marker '{0}' is not compatible with '{1}'</value>
+  </data>
   <data name="InvalidSharedMemorySize" xml:space="preserve">
     <value>Shared-memory size cannot be &lt; 0</value>
   </data>
@@ -194,6 +197,9 @@
   </data>
   <data name="NotSupportedPitchedAllocation" xml:space="preserve">
     <value>Not supported pitched allocation for type '{0}' and byte pitch {1}</value>
+  </data>
+  <data name="NotSupportedProfilingMarker" xml:space="preserve">
+    <value>Cannot add profiling marker. Ensure that profiling is enabled from the ContextBuilder.</value>
   </data>
   <data name="NotSupportedPTXArchitecture" xml:space="preserve">
     <value>Not supported PTX architecture</value>

--- a/Src/ILGPU/Runtime/AcceleratorStream.cs
+++ b/Src/ILGPU/Runtime/AcceleratorStream.cs
@@ -9,8 +9,10 @@
 // Source License. See LICENSE.txt for details
 // ---------------------------------------------------------------------------------------
 
+using ILGPU.Resources;
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 namespace ILGPU.Runtime
@@ -68,6 +70,23 @@ namespace ILGPU.Runtime
         /// </summary>
         /// <returns>A scoped binding object.</returns>
         public ScopedAcceleratorBinding BindScoped() => Accelerator.BindScoped();
+
+        /// <summary>
+        /// Adds a profiling marker into the stream.
+        /// </summary>
+        /// <returns>The profiling marker.</returns>
+        public ProfilingMarker AddProfilingMarker() =>
+            Accelerator.Context.Properties.EnableProfiling
+            ? AddProfilingMarkerInternal()
+            : throw new NotSupportedException(
+                RuntimeErrorMessages.NotSupportedProfilingMarker);
+
+        /// <summary>
+        /// Adds a profiling marker into the stream.
+        /// </summary>
+        /// <returns>The profiling marker.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected abstract ProfilingMarker AddProfilingMarkerInternal();
 
         #endregion
     }

--- a/Src/ILGPU/Runtime/CPU/CPUProfilingMarker.cs
+++ b/Src/ILGPU/Runtime/CPU/CPUProfilingMarker.cs
@@ -1,0 +1,61 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                        Copyright (c) 2016-2020 Marcel Koester
+//                                    www.ilgpu.net
+//
+// File: CPUProfilingMarker.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+
+using ILGPU.Resources;
+using System;
+
+namespace ILGPU.Runtime.CPU
+{
+    /// <summary>
+    /// Represents a point-in-time marker used in CPU profiling.
+    /// </summary>
+    internal sealed class CPUProfilingMarker : ProfilingMarker
+    {
+        #region Instance
+
+        internal CPUProfilingMarker()
+        {
+            Timestamp = DateTime.UtcNow;
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// The timestamp this profiling marker was created.
+        /// </summary>
+        public DateTime Timestamp { get; private set; }
+
+        #endregion
+
+        #region Methods
+
+        /// <inheritdoc/>
+        public override void Synchronize() { }
+
+        /// <inheritdoc/>
+        public override TimeSpan MeasureFrom(ProfilingMarker marker) =>
+            (marker is CPUProfilingMarker startMarker)
+                ? Timestamp - startMarker.Timestamp
+                : throw new ArgumentException(
+                    string.Format(
+                        RuntimeErrorMessages.InvalidProfilingMarker,
+                        GetType().Name,
+                        marker.GetType().Name),
+                    nameof(marker));
+
+        /// <inheritdoc/>
+        protected override void DisposeAcceleratorObject(bool disposing) { }
+
+        #endregion
+    }
+}

--- a/Src/ILGPU/Runtime/CPU/CPUStream.cs
+++ b/Src/ILGPU/Runtime/CPU/CPUStream.cs
@@ -49,6 +49,10 @@ namespace ILGPU.Runtime.CPU
         /// </summary>
         public override void Synchronize() { }
 
+        /// <inheritdoc/>
+        protected unsafe override ProfilingMarker AddProfilingMarkerInternal() =>
+            new CPUProfilingMarker();
+
         #endregion
 
         #region IDisposable

--- a/Src/ILGPU/Runtime/Cuda/CudaAPI.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaAPI.cs
@@ -796,5 +796,61 @@ namespace ILGPU.Runtime.Cuda
                 blockSizeLimit);
 
         #endregion
+
+        #region Event Methods
+
+        /// <summary>
+        /// Creates a new accelerator event.
+        /// </summary>
+        /// <param name="event">The created event.</param>
+        /// <param name="flags">The event creation flags.</param>
+        /// <returns>The error status.</returns>
+        public CudaError CreateEvent(out IntPtr @event, CudaEventFlags flags) =>
+            cuEventCreate(out @event, flags);
+
+        /// <summary>
+        /// Destroys the given event.
+        /// </summary>
+        /// <param name="event">The accelerator event.</param>
+        /// <returns>The error status.</returns>
+        public CudaError DestroyEvent(IntPtr @event) =>
+            cuEventDestroy(@event);
+
+        /// <summary>
+        /// Queries the status of the given event.
+        /// </summary>
+        /// <param name="event">The accelerator event.</param>
+        /// <returns>The error status.</returns>
+        public CudaError QueryEvent(IntPtr @event) =>
+            cuEventQuery(@event);
+
+        /// <summary>
+        /// Computes the elapsed time between two events.
+        /// </summary>
+        /// <param name="milliseconds">The elapsed time in milliseconds.</param>
+        /// <param name="start">The starting event.</param>
+        /// <param name="end">The ending event.</param>
+        /// <returns>The error status.</returns>
+        public CudaError ElapsedTime(out float milliseconds, IntPtr start, IntPtr end) =>
+            cuEventElapsedTime(out milliseconds, start, end);
+
+        /// <summary>
+        /// Records an event on a stream.
+        /// </summary>
+        /// <param name="event">The event.</param>
+        /// <param name="stream">The accelerator stream.</param>
+        /// <returns>The error status.</returns>
+        public CudaError RecordEvent(IntPtr @event, IntPtr stream) =>
+            cuEventRecord(@event, stream);
+
+        /// <summary>
+        /// Synchronizes the current event.
+        /// </summary>
+        /// <param name="event">The event.</param>
+        /// <returns>The error status.</returns>
+        public CudaError SynchronizeEvent(IntPtr @event) =>
+            cuEventSynchronize(@event);
+
+        #endregion
     }
 }

--- a/Src/ILGPU/Runtime/Cuda/CudaAPI.xml
+++ b/Src/ILGPU/Runtime/Cuda/CudaAPI.xml
@@ -188,4 +188,26 @@
         <Parameter Name="dynamicSMemSize" Type="IntPtr" />
         <Parameter Name="blockSizeLimit" Type="int" />
     </Import>
+    <Import Name="cuEventCreate">
+        <Parameter Name="@event" Type="IntPtr" Flags="Out" />
+        <Parameter Name="flags" Type="CudaEventFlags" />
+    </Import>
+    <Import Name="cuEventDestroy">
+        <Parameter Name="@event" Type="IntPtr" />
+    </Import>
+    <Import Name="cuEventQuery">
+        <Parameter Name="@event" Type="IntPtr" />
+    </Import>
+    <Import Name="cuEventElapsedTime">
+        <Parameter Name="milliseconds" Type="float" Flags="Out" />
+        <Parameter Name="start" Type="IntPtr" />
+        <Parameter Name="end" Type="IntPtr" />
+    </Import>
+    <Import Name="cuEventRecord">
+        <Parameter Name="@event" Type="IntPtr" />
+        <Parameter Name="stream" Type="IntPtr" />
+    </Import>
+    <Import Name="cuEventSynchronize">
+        <Parameter Name="@event" Type="IntPtr" />
+    </Import>
 </Imports>

--- a/Src/ILGPU/Runtime/Cuda/CudaNativeMethods.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaNativeMethods.cs
@@ -248,6 +248,30 @@ namespace ILGPU.Runtime.Cuda
         CU_DEVICE_P2P_ATTRIBUTE_NATIVE_ATOMIC_SUPPORTED = 3
     }
 
+    [Flags]
+    public enum CudaEventFlags
+    {
+        /// <summary>
+        /// Default event creation flag.
+        /// </summary>
+        CU_EVENT_DEFAULT = 0,
+
+        /// <summary>
+        /// The created event should use blocking synchronization.
+        /// </summary>
+        CU_EVENT_BLOCKING_SYNC = 1,
+
+        /// <summary>
+        /// The created event does not need to record timing data.
+        /// </summary>
+        CU_EVENT_DISABLE_TIMING = 2,
+
+        /// <summary>
+        /// The created event may be used as an interprocess event.
+        /// </summary>
+        CU_EVENT_INTERPROCESS = 4,
+    }
+
     #endregion
 }
 

--- a/Src/ILGPU/Runtime/Cuda/CudaProfilingMarker.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaProfilingMarker.cs
@@ -1,0 +1,93 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                        Copyright (c) 2016-2020 Marcel Koester
+//                                    www.ilgpu.net
+//
+// File: CudaProfilingMarker.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+
+using ILGPU.Resources;
+using System;
+using static ILGPU.Runtime.Cuda.CudaAPI;
+
+namespace ILGPU.Runtime.Cuda
+{
+    /// <summary>
+    /// Represents a point-in-time marker used in CUDA profiling.
+    /// </summary>
+    internal sealed class CudaProfilingMarker : ProfilingMarker
+    {
+        #region Instance
+
+        internal CudaProfilingMarker()
+        {
+            CudaException.ThrowIfFailed(
+                CurrentAPI.CreateEvent(
+                    out var eventPtr,
+                    CudaEventFlags.CU_EVENT_DEFAULT));
+            EventPtr = eventPtr;
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// The native event pointer.
+        /// </summary>
+        public IntPtr EventPtr { get; private set; }
+
+        #endregion
+
+        #region Methods
+
+        /// <inheritdoc/>
+        public override void Synchronize()
+        {
+            var errorStatus = CurrentAPI.QueryEvent(EventPtr);
+            if (errorStatus == CudaError.CUDA_ERROR_NOT_READY)
+                CudaException.ThrowIfFailed(CurrentAPI.SynchronizeEvent(EventPtr));
+            else
+                CudaException.ThrowIfFailed(errorStatus);
+        }
+
+        /// <inheritdoc/>
+        public override TimeSpan MeasureFrom(ProfilingMarker marker)
+        {
+            if (!(marker is CudaProfilingMarker startMarker))
+            {
+                throw new ArgumentException(
+                    string.Format(
+                        RuntimeErrorMessages.InvalidProfilingMarker,
+                        GetType().Name,
+                        marker.GetType().Name),
+                    nameof(marker));
+            }
+
+            // Wait for the markers to complete, then calculate the duration.
+            startMarker.Synchronize();
+            Synchronize();
+
+            CudaException.ThrowIfFailed(
+                CurrentAPI.ElapsedTime(
+                    out float milliseconds,
+                    startMarker.EventPtr,
+                    EventPtr));
+            return TimeSpan.FromMilliseconds(milliseconds);
+        }
+
+        /// <inheritdoc/>
+        protected override void DisposeAcceleratorObject(bool disposing)
+        {
+            CudaException.VerifyDisposed(
+                disposing,
+                CurrentAPI.DestroyEvent(EventPtr));
+            EventPtr = IntPtr.Zero;
+        }
+
+        #endregion
+    }
+}

--- a/Src/ILGPU/Runtime/Cuda/CudaStream.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaStream.cs
@@ -84,6 +84,16 @@ namespace ILGPU.Runtime.Cuda
             binding.Recover();
         }
 
+        /// <inheritdoc/>
+        protected override ProfilingMarker AddProfilingMarkerInternal()
+        {
+            var profilingMarker = new CudaProfilingMarker();
+
+            CudaException.ThrowIfFailed(
+                CurrentAPI.RecordEvent(profilingMarker.EventPtr, StreamPtr));
+            return profilingMarker;
+        }
+
         #endregion
 
         #region IDisposable

--- a/Src/ILGPU/Runtime/OpenCL/CLAPI.xml
+++ b/Src/ILGPU/Runtime/OpenCL/CLAPI.xml
@@ -65,7 +65,7 @@
             ReturnType="IntPtr">
         <Parameter Name="context" Type="IntPtr" />
         <Parameter Name="device" Type="IntPtr" />
-        <Parameter Name="properties" Type="IntPtr" />
+        <Parameter Name="properties" Type="CLCommandQueueProperties" />
         <Parameter Name="errorCode" Type="CLError" Flags="Out" />
     </Import>
     <Import Name="clCreateCommandQueueWithProperties"
@@ -223,6 +223,13 @@
         <Parameter Name="numEvents" Type="int" />
         <Parameter Name="events" Type="IntPtr*" />
     </Import>
+    <Import Name="clGetEventInfo">
+        <Parameter Name="@event" Type="IntPtr" />
+        <Parameter Name="param_name" Type="CLEventInfo" />
+        <Parameter Name="param_value_size" Type="IntPtr" />
+        <Parameter Name="param_value" Type="void*" DllFlags="Out" />
+        <Parameter Name="param_value_size_ret" Type="IntPtr" DllFlags="Out" />
+    </Import>
 
     <!-- Markers -->
     <Import Name="clEnqueueBarrierWithWaitList">
@@ -230,5 +237,14 @@
         <Parameter Name="numEvents" Type="int" />
         <Parameter Name="events" Type="IntPtr*" />
         <Parameter Name="resultEvent" Type="IntPtr*" DllFlags="InOut" />
+    </Import>
+
+    <!-- Profiling -->
+    <Import Name="clGetEventProfilingInfo">
+        <Parameter Name="@event" Type="IntPtr" />
+        <Parameter Name="param_name" Type="CLProfilingInfo" />
+        <Parameter Name="param_value_size" Type="IntPtr" />
+        <Parameter Name="param_value" Type="void*" DllFlags="Out" />
+        <Parameter Name="param_value_size_ret" Type="IntPtr" DllFlags="Out" />
     </Import>
 </Imports>

--- a/Src/ILGPU/Runtime/OpenCL/CLNativeMethods.cs
+++ b/Src/ILGPU/Runtime/OpenCL/CLNativeMethods.cs
@@ -297,6 +297,62 @@ namespace ILGPU.Runtime.OpenCL
         CL_PROGRAM_BINARY_TYPE = 0x1184,
         CL_PROGRAM_BUILD_GLOBAL_VARIABLE_TOTAL_SIZE = 0x1185
     }
+
+    public enum CLCommandQueueInfo : int
+    {
+        CL_QUEUE_CONTEXT = 0x1090,
+        CL_QUEUE_DEVICE = 0x1091,
+        CL_QUEUE_REFERENCE_COUNT = 0x1092,
+        CL_QUEUE_PROPERTIES = 0x1093,
+
+        // OpenCL >= 2.0
+        CL_QUEUE_SIZE = 0x1094,
+
+        // OpenCL >= 2.1
+        CL_QUEUE_DEVICE_DEFAULT = 0x1095,
+
+        // OpenCL >= 3.0
+        CL_QUEUE_PROPERTIES_ARRAY = 0x1098,
+    }
+
+    [Flags]
+    public enum CLCommandQueueProperties : int
+    {
+        CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE = 1 << 0,
+        CL_QUEUE_PROFILING_ENABLE = 1 << 1,
+
+        // OpenCL >= 2.0
+        CL_QUEUE_ON_DEVICE = 1 << 2,
+        CL_QUEUE_ON_DEVICE_DEFAULT = 1 << 3,
+    }
+
+    public enum CLEventInfo : int
+    {
+        CL_EVENT_COMMAND_QUEUE = 0x11D0,
+        CL_EVENT_COMMAND_TYPE = 0x11D1,
+        CL_EVENT_REFERENCE_COUNT = 0x11D2,
+        CL_EVENT_COMMAND_EXECUTION_STATUS = 0x11D3,
+        CL_EVENT_CONTEXT = 0x11D4,
+    }
+
+    public enum CLCommandExecutionStatus : int
+    {
+        CL_COMPLETE = 0x0,
+        CL_RUNNING = 0x1,
+        CL_SUBMITTED = 0x2,
+        CL_QUEUED = 0x3,
+    }
+
+    public enum CLProfilingInfo : int
+    {
+        CL_PROFILING_COMMAND_QUEUED = 0x1280,
+        CL_PROFILING_COMMAND_SUBMIT = 0x1281,
+        CL_PROFILING_COMMAND_START = 0x1282,
+        CL_PROFILING_COMMAND_END = 0x1283,
+
+        // OpenCL >= 2.0
+        CL_PROFILING_COMMAND_COMPLETE = 0x1284,
+    }
 }
 
 #pragma warning restore CA1069 // Enums values should not be duplicated

--- a/Src/ILGPU/Runtime/OpenCL/CLProfilingMarker.cs
+++ b/Src/ILGPU/Runtime/OpenCL/CLProfilingMarker.cs
@@ -1,0 +1,110 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                        Copyright (c) 2016-2020 Marcel Koester
+//                                    www.ilgpu.net
+//
+// File: CLProfilingMarker.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+
+using ILGPU.Resources;
+using ILGPU.Util;
+using System;
+using static ILGPU.Runtime.OpenCL.CLAPI;
+
+namespace ILGPU.Runtime.OpenCL
+{
+    /// <summary>
+    /// Represents a point-in-time marker used in OpenCL profiling.
+    /// </summary>
+    internal sealed class CLProfilingMarker : ProfilingMarker
+    {
+        #region Instance
+
+        internal CLProfilingMarker(IntPtr eventPtr)
+        {
+            EventPtr = eventPtr;
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// The native event pointer.
+        /// </summary>
+        public IntPtr EventPtr { get; private set; }
+
+        #endregion
+
+        #region Methods
+
+        /// <inheritdoc/>
+        public unsafe override void Synchronize()
+        {
+            ReadOnlySpan<IntPtr> events = stackalloc[] { EventPtr };
+            CLException.ThrowIfFailed(
+                CurrentAPI.WaitForEvents(events));
+        }
+
+        /// <inheritdoc/>
+        public override TimeSpan MeasureFrom(ProfilingMarker marker)
+        {
+            if (!(marker is CLProfilingMarker startMarker))
+            {
+                throw new ArgumentException(
+                    string.Format(
+                        RuntimeErrorMessages.InvalidProfilingMarker,
+                        GetType().Name,
+                        marker.GetType().Name),
+                    nameof(marker));
+            }
+
+            // Wait for the markers to complete, then calculate the duration.
+            startMarker.Synchronize();
+            Synchronize();
+
+            CLException.ThrowIfFailed(
+                CurrentAPI.GetEventProfilingInfo(
+                    EventPtr,
+                    CLProfilingInfo.CL_PROFILING_COMMAND_END,
+                    out var endNanoseconds));
+            CLException.ThrowIfFailed(
+                CurrentAPI.GetEventProfilingInfo(
+                    startMarker.EventPtr,
+                    CLProfilingInfo.CL_PROFILING_COMMAND_END,
+                    out var startNanoseconds));
+
+            // TimeSpan tracks time in ticks, where a single tick represents one hundred
+            // nanoseconds, so we need to convert our elasped nanoseconds into ticks.
+            //
+            // NB: If the start time is later than the end time, reverse the calculation,
+            // and then restore the correct signed result.
+            bool swapped = false;
+            if (endNanoseconds < startNanoseconds)
+            {
+                Utilities.Swap(ref startNanoseconds, ref endNanoseconds);
+                swapped = true;
+            }
+            var elapsedNanoseconds = endNanoseconds - startNanoseconds;
+            var ticks = (long)(elapsedNanoseconds / 100UL);
+            if (swapped)
+                ticks = -ticks;
+
+            return new TimeSpan(ticks);
+        }
+
+        /// <inheritdoc/>
+        protected override void DisposeAcceleratorObject(bool disposing)
+        {
+            CLException.VerifyDisposed(
+                disposing,
+                CurrentAPI.clReleaseEvent(EventPtr));
+            EventPtr = IntPtr.Zero;
+        }
+
+        #endregion
+    }
+}

--- a/Src/ILGPU/Runtime/ProfilingMarker.cs
+++ b/Src/ILGPU/Runtime/ProfilingMarker.cs
@@ -1,0 +1,56 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                        Copyright (c) 2016-2020 Marcel Koester
+//                                    www.ilgpu.net
+//
+// File: ProfilingMarker.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+
+using System;
+
+namespace ILGPU.Runtime
+{
+    /// <summary>
+    /// Represents a point-in-time marker used in profiling.
+    /// </summary>
+    public abstract class ProfilingMarker : AcceleratorObject
+    {
+        /// <summary>
+        /// Waits for the profiling marker to complete.
+        /// </summary>
+        public abstract void Synchronize();
+
+        /// <summary>
+        /// Returns the elapsed time from this profiling marker to the given marker.
+        /// </summary>
+        /// <param name="marker">The comparison profiing marker.</param>
+        /// <returns>The elapsed time.</returns>
+        /// <remarks>Will block until the profiling markers have completed.</remarks>
+        public abstract TimeSpan MeasureFrom(ProfilingMarker marker);
+
+        /// <summary>
+        /// Returns the elapsed time between two profiling markers.
+        /// </summary>
+        /// <param name="end">The end profiing marker.</param>
+        /// <param name="start">The start profiing marker.</param>
+        /// <returns>The elapsed time.</returns>
+        /// <remarks>Will block until the profiling markers has completed.</remarks>
+        public static TimeSpan operator -(ProfilingMarker end, ProfilingMarker start) =>
+            end.MeasureFrom(start);
+    }
+
+    /// <summary>
+    /// Profiling marker extensions for accelerators.
+    /// </summary>
+    public static class ProfilingMarkers
+    {
+        /// <summary>
+        /// Adds a profiling marker to the accelerator default stream.
+        /// </summary>
+        public static void AddProfilingMarker(this Accelerator accelerator) =>
+            accelerator.DefaultStream.AddProfilingMarker();
+    }
+}


### PR DESCRIPTION
Fixes #399.

This is a proposed PR to add high resolution timers for Cuda and OpenCL accelerators.

It introduces the concept of a `ProfilingMarker` that can be added to an `AcceleratorStream`.
For OpenCL, the user is required to enable profiling - `contextBuilder.Profiling()`.

Example usage:
```CSharp
using var start = accelerator.DefaultStream.AddProfilingMarker();
launchKernelToBeProfiled();
using var end = accelerator.DefaultStream.AddProfilingMarker();

TimeSpan elapsedTime = end - start; // or end.MeasureFrom(start);
```

NOTE: On the CPU accelerator, it currently uses `DateTime.UtcNow`, which apparently has approximately 15 millisecond accuracy. If this is not acceptable, we will need to investigate a cross-platform high-resolution timer.

NOTE: There appears to be an issue with OpenCL. A workaround was required where the OpenCL event had to be awaited immediately, otherwise the clock timer did not appear to start. Unsure if this is a driver bug on my Intel HD 630.
