### PR TITLE
Fixed invalid CopyToCPU function that leads to program crashes.

### DIFF
--- a/Src/ILGPU.Tests/Generic/TestBase.cs
+++ b/Src/ILGPU.Tests/Generic/TestBase.cs
@@ -217,7 +217,21 @@ namespace ILGPU.Tests
         }
 
         /// <summary>
-        /// Verifies the contents of the given 2D memory buffer.
+        /// Verifies the contents of the given 1D arrays.
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <param name="source">The source array.</param>
+        /// <param name="expected">The expected values.</param>
+        public static void Verify1D<T>(T[] source, T[] expected)
+            where T : unmanaged
+        {
+            Assert.Equal(source.Length, expected.Length);
+            for (int i = 0; i < expected.Length; ++i)
+                    Assert.Equal(expected[i], source[i]);
+        }
+
+        /// <summary>
+        /// Verifies the contents of the given 2D view.
         /// </summary>
         /// <typeparam name="T">The element type.</typeparam>
         /// <param name="view">The target buffer.</param>
@@ -259,7 +273,7 @@ namespace ILGPU.Tests
         }
 
         /// <summary>
-        /// Verifies the contents of the given 3D memory buffer.
+        /// Verifies the contents of the given 3D view.
         /// </summary>
         /// <typeparam name="T">The element type.</typeparam>
         /// <param name="view">The target buffer.</param>

--- a/Src/ILGPU.Tests/MemoryBufferOperations.tt
+++ b/Src/ILGPU.Tests/MemoryBufferOperations.tt
@@ -5,6 +5,7 @@
 using ILGPU.Runtime;
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -140,6 +141,65 @@ namespace ILGPU.Tests
             Verify(sourceBuffer.View, expected);
             Verify(denseBuffer.View, expected);
             Verify(stridedBuffer.View.AsContiguous(), stridedExpected);
+        }
+
+        [Theory]
+<#      foreach (var length in lengths) { #>
+        [InlineData(<#= length #>)]
+<#      } #>
+        public unsafe void CopyFromToCPU_<#= type.Name #>(int length)
+        {
+            Func<int, <#= type.Type #>> converter = c => (<#= type.Type #>)(c + 1);
+            var expected = InitializeArray1D(length, 1, converter);
+            var temp = new <#= type.Type #>[length];
+            using var buffer = Accelerator.Allocate1D(expected);
+            var view = buffer.View;
+
+            // Copy to CPU
+            view.CopyToCPU(temp);
+            Verify1D(temp, expected);
+
+            // Copy each element to CPU
+            for (int i = 0; i < length; ++i)
+            {
+                view.SubView(i, 1).CopyToCPU(out <#= type.Type #> element, 1);
+                Assert.Equal(element, expected[i]);
+            }
+
+            // Copy unsafe to CPU
+            Array.Clear(temp, 0, length);
+            fixed (<#= type.Type #>* ptr = temp)
+            {
+                view.AsContiguous().CopyToCPUUnsafeAsync(
+                    out Unsafe.AsRef<<#= type.Type #>>(ptr),
+                    length);
+                Accelerator.Synchronize();
+                Verify1D(temp, expected);
+            }
+
+            // Copy from CPU
+            view.MemSetToZero();
+            view.CopyFromCPU(expected);
+            Verify(view, expected);
+
+            // Copy each element from CPU
+            view.MemSetToZero();
+            for (int i = 0; i < length; ++i)
+            {
+                var value = expected[i];
+                view.SubView(i, 1).CopyFromCPU(ref value, 1);
+            }
+            Verify(view, expected);
+
+            // Copy unsafe from CPU
+            fixed (<#= type.Type #>* ptr = temp)
+            {
+                view.AsContiguous().CopyFromCPUUnsafeAsync(
+                    ref Unsafe.AsRef<<#= type.Type #>>(ptr),
+                    length);
+                Accelerator.Synchronize();
+                Verify(view, expected);
+            }
         }
 
 <#  } #>

--- a/Src/ILGPU/Runtime/ArrayViewExtensions.cs
+++ b/Src/ILGPU/Runtime/ArrayViewExtensions.cs
@@ -478,7 +478,7 @@ namespace ILGPU.Runtime
             where TView : IContiguousArrayView<T>
             where T : unmanaged
         {
-            source.CopyToCPU(stream, out cpuData, length);
+            source.CopyToCPUUnsafeAsync(stream, out cpuData, length);
             stream.Synchronize();
         }
 


### PR DESCRIPTION
This PR fixes a `StackOverflowException` caused by a bug in one of the `CopyToCPU` functions that was not tested properly. It also includes a number of new test cases to cover additional parts of the new memory API that have been merged (see #421).