### PR TITLE
Display version mismatch during CI as a proper error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
             $tag = "${{ github.ref }}".SubString(11)
             $version = (Select-Xml -path Src/ILGPU/ILGPU.csproj -XPath "/Project/PropertyGroup/VersionPrefix/text()").node.Value
             if (-not ($tag -eq $version)) {
-              echo "There is a mismatch between the project version ($version) and the tag ($tag)"
+              echo "::error ::There is a mismatch between the project version ($version) and the tag ($tag)"
               exit 1
             }
           } else {


### PR DESCRIPTION
This should allow the maintainer to spot more quickly when there is a version mismatch 😅 

Here is what it looks like with this PR:
<img width="664" alt="image" src="https://user-images.githubusercontent.com/3692455/119547035-833fce00-bd8c-11eb-8884-ce9d5b398c4a.png">
 