### PR TITLE
Added GetPreferredDevice and GetPreferredDevices to Context

### DIFF
--- a/Src/ILGPU/Context.cs
+++ b/Src/ILGPU/Context.cs
@@ -390,19 +390,8 @@ namespace ILGPU
         /// </summary>
         /// <param name="preferCPU">Always returns CPU device 0.</param>
         /// <returns>Selected device.</returns>
-        public Device GetPreferredDevice(bool preferCPU)
-        {
-            if (preferCPU)
-            {
-                return GetDevice<CPUDevice>(0);
-            }
-
-            var sorted = Devices
-                .OrderByDescending(d => d.MemorySize)
-                .Where(d => d.AcceleratorType != AcceleratorType.CPU);
-
-            return sorted.FirstOrDefault() ?? GetDevice<CPUDevice>(0);
-        }
+        public Device GetPreferredDevice(bool preferCPU) =>
+            GetPreferredDevices(preferCPU, matchingDevicesOnly: false).First();
 
         /// <summary>
         /// Attempts to return the most optimal set of devices.

--- a/Src/ILGPU/Context.cs
+++ b/Src/ILGPU/Context.cs
@@ -400,7 +400,8 @@ namespace ILGPU
         /// <param name="matchingDevicesOnly">Only returns matching devices.</param>
         /// <returns>Selected devices.</returns>
         public IEnumerable<Device> GetPreferredDevices(
-            bool preferCPU, bool matchingDevicesOnly)
+            bool preferCPU, 
+            bool matchingDevicesOnly)
         {
             if (preferCPU)
             {

--- a/Src/ILGPU/Context.cs
+++ b/Src/ILGPU/Context.cs
@@ -414,21 +414,6 @@ namespace ILGPU
                 .OrderByDescending(d => d.MemorySize)
                 .Where(d => d.AcceleratorType != AcceleratorType.CPU);
 
-            //var firstItem = sorted.First();
-            //if (firstItem != null)
-            //{
-            //    if (matchingDevicesOnly)
-            //    {
-            //        return sorted.Where(
-            //            d =>
-            //            d.AcceleratorType == firstItem.AcceleratorType &&
-            //            d.MemorySize == firstItem.MemorySize);
-            //    }
-            //    else
-            //    {
-            //        return sorted;
-            //    }
-            //}
             if (sorted.Any())
             {
                 if (matchingDevicesOnly)

--- a/Src/ILGPU/Context.cs
+++ b/Src/ILGPU/Context.cs
@@ -399,7 +399,8 @@ namespace ILGPU
         /// <param name="preferCPU">Always returns first CPU device.</param>
         /// <param name="matchingDevicesOnly">Only returns matching devices.</param>
         /// <returns>Selected devices.</returns>
-        public IEnumerable<Device> GetPreferredDevices(bool preferCPU, bool matchingDevicesOnly)
+        public IEnumerable<Device> GetPreferredDevices(
+            bool preferCPU, bool matchingDevicesOnly)
         {
             if (preferCPU)
             {
@@ -413,12 +414,26 @@ namespace ILGPU
                 .OrderByDescending(d => d.MemorySize)
                 .Where(d => d.AcceleratorType != AcceleratorType.CPU);
 
+            //var firstItem = sorted.First();
+            //if (firstItem != null)
+            //{
+            //    if (matchingDevicesOnly)
+            //    {
+            //        return sorted.Where(
+            //            d =>
+            //            d.AcceleratorType == firstItem.AcceleratorType &&
+            //            d.MemorySize == firstItem.MemorySize);
+            //    }
+            //    else
+            //    {
+            //        return sorted;
+            //    }
+            //}
             if (sorted.Any())
             {
                 if (matchingDevicesOnly)
                 {
                     Device toMatch = sorted.First();
-
                     return sorted.Where(
                         d =>
                         d.AcceleratorType == toMatch.AcceleratorType &&


### PR DESCRIPTION
This adds 2 functions to Context which provide a simple method for getting the "best" device.

I currently select the best device based on memory size, ignoring the CPU devices. 

There are 3 scenarios I can think of for the possible hardware config:

- 1 GPU computers (like mine)
- 1 dGPU and 1 iGPU (laptops)
- N dGPU and possibly 1iGPU (servers)

and 4 scenarios I can think of for Device usage

- 1 CPU for debugging. (for all hardware configs)
- 1 GPU in use (for all hardware configs)
- N matched GPUs (for the N dGPU and possibly 1iGPU hardware config)
- N unmatched GPUs in use (for 1 dGPU and 1 iGPU or the N dGPU and possibly 1iGPU hardware config)

I think this could be done with 2 or 3 functions, I implemented the 2 function method.
 
- Device GetBestDevice(bool PreferCPU = false)
- List<Device> GetBestDevices(bool PreferCPU = false, bool MatchingDevicesOnly = false)

or

- Device GetBestDevice(bool PreferCPU = false)
- List<Device> GetBestMatchingDevices(bool PreferCPU = false)
- List<Device> GetBestDevices(bool PreferCPU = false)

I am interested in peoples input on both how to pick the best device and other sets of devices that people may want to be returned.