### PR TITLE
changed Index parameter check to include LongIndices

### DIFF
--- a/Src/ILGPU/Backends/EntryPoints/EntryPointDescription.cs
+++ b/Src/ILGPU/Backends/EntryPoints/EntryPointDescription.cs
@@ -56,7 +56,7 @@ namespace ILGPU.Backends.EntryPoints
             // Try to get index type from first parameter
             var firstParamType = parameters[0].ParameterType;
             var indexType = firstParamType.GetIndexType();
-            if (indexType == IndexType.None || indexType > IndexType.Index3D)
+            if (indexType == IndexType.None || indexType > IndexType.LongIndex3D)
             {
                 throw new NotSupportedException(
                     ErrorMessages.InvalidEntryPointIndexParameterOfWrongType);


### PR DESCRIPTION
```c#
using System;
using ILGPU;
using ILGPU.Runtime;
using ILGPU.Runtime.CPU;
public static class Program
{
    static void Kernel(LongIndex1D i, ArrayView<int> data, ArrayView<int> output)
    {
        output[i] = data[i % data.Length];
    }

    static void Main()
    {
        Context context = Context.CreateDefault();
        Accelerator accelerator = context.CreateCPUAccelerator(0);

        MemoryBuffer1D<int, Stride1D.Dense> deviceData = accelerator.Allocate1D<int>(new int[] { 0, 1, 2, 4, 5, 6, 7, 8, 9 });
        MemoryBuffer1D<int, Stride1D.Dense> deviceOutput = accelerator.Allocate1D<int>(10_000);

        Action<LongIndex1D, ArrayView<int>, ArrayView<int>> loadedKernel =
            accelerator.LoadAutoGroupedStreamKernel<LongIndex1D, ArrayView<int>, ArrayView<int>>(Kernel);

        loadedKernel((int)deviceOutput.Length, deviceData.View, deviceOutput.View);
        accelerator.Synchronize();

        int[] hostOutput = deviceOutput.View.GetAs1DArray();

        deviceData.Dispose();
        deviceOutput.Dispose();
        accelerator.Dispose();
        context.Dispose();
    }
}
```

This code fails at runtime with a NotSupportedException(ErrorMessages.InvalidEntryPointIndexParameterOfWrongType);

It is due to this check failing to allow LongIndex1D, 2D, and 3D
if (indexType == IndexType.None || indexType > IndexType.LongIndex3D)