### PR TITLE
Updated Cuda API binding used to destroy events.

### DIFF
--- a/Src/ILGPU/Runtime/Cuda/CudaAPI.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaAPI.cs
@@ -814,7 +814,7 @@ namespace ILGPU.Runtime.Cuda
         /// <param name="event">The accelerator event.</param>
         /// <returns>The error status.</returns>
         public CudaError DestroyEvent(IntPtr @event) =>
-            cuEventDestroy(@event);
+            cuEventDestroy_v2(@event);
 
         /// <summary>
         /// Queries the status of the given event.

--- a/Src/ILGPU/Runtime/Cuda/CudaAPI.xml
+++ b/Src/ILGPU/Runtime/Cuda/CudaAPI.xml
@@ -192,7 +192,7 @@
         <Parameter Name="@event" Type="IntPtr" Flags="Out" />
         <Parameter Name="flags" Type="CudaEventFlags" />
     </Import>
-    <Import Name="cuEventDestroy">
+    <Import Name="cuEventDestroy_v2">
         <Parameter Name="@event" Type="IntPtr" />
     </Import>
     <Import Name="cuEventQuery">


### PR DESCRIPTION
As discovered in https://github.com/m4rs-mt/ILGPU/pull/480, the v2 bindings can sometimes lead to issues.

This PR updates `cuEventDestroy` to `cuEventDestroy_v2` just in case.