### PR TITLE
Fixed missing file location information when using debug assertion.

### DIFF
--- a/Src/ILGPU/IR/Location.cs
+++ b/Src/ILGPU/IR/Location.cs
@@ -14,6 +14,7 @@ using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 
@@ -335,6 +336,28 @@ namespace ILGPU.IR
         /// <returns>The merged location.</returns>
         public CompilationStackLocation Append(Location other) =>
             new CompilationStackLocation(Stack.Push(other));
+
+        /// <summary>
+        /// Returns the most recent location of the given type from the compilation
+        /// stack, if any.
+        /// </summary>
+        /// <param name="location">Filled in with the location found.</param>
+        /// <returns>True if this compilation stack has the location type.</returns>
+        public bool TryGetLocation<T>(out T location)
+            where T : Location
+        {
+            foreach (var loc in Stack.Reverse())
+            {
+                if (loc is T typedLocation)
+                {
+                    location = typedLocation;
+                    return true;
+                }
+            }
+
+            location = null;
+            return false;
+        }
 
         #endregion
 

--- a/Src/ILGPU/IR/Values/Debug.cs
+++ b/Src/ILGPU/IR/Values/Debug.cs
@@ -65,7 +65,10 @@ namespace ILGPU.IR.Values
         public (string FileName, int Line, string Method) GetLocationInfo()
         {
             const string KernelName = "Kernel";
-            if (Location.IsKnown && Location is FileLocation fileLocation)
+            if (Location.IsKnown &&
+                (Location is FileLocation fileLocation ||
+                Location is CompilationStackLocation compilationStackLocation &&
+                compilationStackLocation.TryGetLocation(out fileLocation)))
             {
                 // Return information based on the current file location
                 return (


### PR DESCRIPTION
After changing to use `CompilationStackLocation`, debug asserts no longer reported file location information.