### PR TITLE
Fixed regression copying from/to OpenCL accelerators.

### DIFF
--- a/Src/ILGPU/Runtime/CPU/CPUMemoryBuffer.cs
+++ b/Src/ILGPU/Runtime/CPU/CPUMemoryBuffer.cs
@@ -495,7 +495,7 @@ namespace ILGPU.Runtime.CPU
             long length,
             int elementSize) =>
             new PointerSourceBuffer(
-                accelerator,
+                GetCPUAccelerator(accelerator),
                 ptr,
                 length,
                 elementSize);

--- a/Src/ILGPU/Runtime/OpenCL/CLMemoryBuffer.cs
+++ b/Src/ILGPU/Runtime/OpenCL/CLMemoryBuffer.cs
@@ -92,7 +92,7 @@ namespace ILGPU.Runtime.OpenCL
                         stream,
                         target.NativePtr,
                         false,
-                        new IntPtr(targetView.Index * target.ElementSize),
+                        new IntPtr(targetView.Index * ArrayView<T>.ElementSize),
                         new IntPtr(target.LengthInBytes),
                         sourceView.LoadEffectiveAddressAsPtr()));
                 return;
@@ -108,7 +108,7 @@ namespace ILGPU.Runtime.OpenCL
                                 stream,
                                 source.NativePtr,
                                 false,
-                                new IntPtr(sourceView.Index * source.ElementSize),
+                                new IntPtr(sourceView.Index * ArrayView<T>.ElementSize),
                                 new IntPtr(target.LengthInBytes),
                                 targetView.LoadEffectiveAddressAsPtr()));
                         return;
@@ -119,8 +119,8 @@ namespace ILGPU.Runtime.OpenCL
                                 stream,
                                 source.NativePtr,
                                 target.NativePtr,
-                                new IntPtr(sourceView.Index * source.ElementSize),
-                                new IntPtr(targetView.Index * target.ElementSize),
+                                new IntPtr(sourceView.Index * ArrayView<T>.ElementSize),
+                                new IntPtr(targetView.Index * ArrayView<T>.ElementSize),
                                 new IntPtr(targetView.LengthInBytes)));
                         return;
                 }


### PR DESCRIPTION
Bug introduced as part of https://github.com/m4rs-mt/ILGPU/pull/498.

When copying between CPU and Cuda, the code is the same regardless of the type of the source and target buffers. However, OpenCL has different code paths, depending on if the source/target buffers are CPU or OpenCL. The issue that is occurring is that both the source and target buffers are being treated as OpenCL, rather than one being CPU.