### PR TITLE
Fixed and enhanced Strides and ArrayViews.

### DIFF
--- a/Src/ILGPU.Tests/ArrayViews.cs
+++ b/Src/ILGPU.Tests/ArrayViews.cs
@@ -812,10 +812,10 @@ namespace ILGPU.Tests
             Assert.Equal(linearLength, oneDView2.Length);
 
             var oneDGeneral = oneDView2.AsGeneral(new Stride1D.General(2));
-            Assert.Equal(linearLength * 2, oneDGeneral.Length);
+            Assert.Equal(linearLength * 2 - 1, oneDGeneral.Length);
 
             var oneDView3 = oneDGeneral.To1DView();
-            Assert.Equal(linearLength * 2, oneDView3.Length);
+            Assert.Equal(linearLength * 2 - 1, oneDView3.Length);
 
             // Verify 2D views
             var twoDView = oneDView.As2DView(
@@ -829,6 +829,17 @@ namespace ILGPU.Tests
             Assert.Equal(
                 twoDView.Stride.StrideExtent.Size,
                 length1);
+            var twoDViewTransposed = twoDView.AsTransposed();
+            Assert.Equal(
+                twoDViewTransposed.Extent,
+                new LongIndex2D(twoDView.Extent.Y, twoDView.Extent.X));
+            Assert.Equal(twoDViewTransposed.Length, twoDView.Length);
+            Assert.Equal(
+                twoDViewTransposed.AsTransposed().Extent,
+                twoDView.Extent);
+            Assert.Equal(
+                twoDViewTransposed.AsTransposed().Length,
+                twoDView.Length);
 
             var oneD2DView = twoDView.To1DView();
             Assert.Equal(length1 * length2, oneD2DView.Extent.Size);
@@ -842,6 +853,17 @@ namespace ILGPU.Tests
             Assert.Equal(length2, twoDViewY.Extent.Y);
             Assert.Equal(1, twoDViewY.Stride.YStride);
             Assert.Equal(length2, twoDViewY.Stride.XStride);
+            var twoDViewYTransposed = twoDViewY.AsTransposed();
+            Assert.Equal(twoDViewYTransposed.Length, twoDViewY.Length);
+            Assert.Equal(
+                twoDViewYTransposed.Extent,
+                new LongIndex2D(twoDViewY.Extent.Y, twoDViewY.Extent.X));
+            Assert.Equal(
+                twoDViewYTransposed.AsTransposed().Length,
+                twoDViewY.Length);
+            Assert.Equal(
+                twoDViewYTransposed.AsTransposed().Extent,
+                twoDView.Extent);
 
             // Verify 3D views
             var threeDView = oneDView.As3DView(
@@ -854,21 +876,35 @@ namespace ILGPU.Tests
             Assert.Equal(1, threeDView.Stride.XStride);
             Assert.Equal(length1, threeDView.Stride.YStride);
             Assert.Equal(length1 * length2, threeDView.Stride.ZStride);
+            var threeDViewTransposed = threeDView.AsTransposed();
+            Assert.Equal(threeDViewTransposed.Length, threeDView.Length);
+            Assert.Equal(
+                threeDViewTransposed.Extent,
+                new LongIndex3D(
+                    threeDView.Extent.Z,
+                    threeDView.Extent.Y,
+                    threeDView.Extent.X));
+            Assert.Equal(
+                threeDViewTransposed.AsTransposed().Length,
+                threeDView.Length);
+            Assert.Equal(
+                threeDViewTransposed.AsTransposed().Extent,
+                threeDView.Extent);
 
             var oneD3DView = threeDView.To1DView();
             Assert.Equal(length1 * length2 * length3, oneD3DView.Extent.Size);
             Assert.Equal(1, oneD3DView.Stride.XStride);
 
             var threeDViewZ = oneD3DView.As3DView(
-                new LongIndex3D(length1, length2, length3),
-                new Stride3D.DenseZY(length2 * length3, length2));
+                new LongIndex3D(length3, length2, length1),
+                new Stride3D.DenseZY(length2 * length1, length2));
             Assert.Equal(length1 * length2 * length3, threeDViewZ.Length);
-            Assert.Equal(length1, threeDViewZ.Extent.X);
+            Assert.Equal(length3, threeDViewZ.Extent.X);
             Assert.Equal(length2, threeDViewZ.Extent.Y);
-            Assert.Equal(length3, threeDViewZ.Extent.Z);
+            Assert.Equal(length1, threeDViewZ.Extent.Z);
             Assert.Equal(1, threeDViewZ.Stride.ZStride);
             Assert.Equal(length2, threeDViewZ.Stride.YStride);
-            Assert.Equal(length2 * length3, threeDViewZ.Stride.XStride);
+            Assert.Equal(length2 * length1, threeDViewZ.Stride.XStride);
         }
     }
 }

--- a/Src/ILGPU.Tests/MemoryBufferOperations.tt
+++ b/Src/ILGPU.Tests/MemoryBufferOperations.tt
@@ -33,7 +33,8 @@ namespace ILGPU.Tests
         {
             int counter = 0;
             int strideCounter = 0;
-            length *= stride;
+            if (stride > 1)
+                length = (length - 1) * stride + 1;
             var src = new T[length];
             for (int i = 0; i < length; i++)
                 src[i] = (strideCounter++) % stride == 0 ? builder(counter++) : default;

--- a/Src/ILGPU/Runtime/ArrayViewExtensions.Generated.tt
+++ b/Src/ILGPU/Runtime/ArrayViewExtensions.Generated.tt
@@ -503,10 +503,7 @@ namespace ILGPU.Runtime
                     new Span<T>(ptr, data.Length));
             }
 <#      } else { #>
-            var tempBuffer = new T[
-                <#= string.Join(", ",
-                    Enumerable.Range(0, dimension)
-                    .Select(t => $"data.GetLength({t})")) #>];
+            var tempBuffer = new T[view.BaseView.Length];
             fixed (T* ptr = tempBuffer)
             {
                 var span = new Span<T>(ptr, tempBuffer.Length);

--- a/Src/ILGPU/Runtime/ArrayViewExtensions.cs
+++ b/Src/ILGPU/Runtime/ArrayViewExtensions.cs
@@ -242,6 +242,97 @@ namespace ILGPU.Runtime
 
         #endregion
 
+        #region Transpose
+
+        /// <summary>
+        /// Reinterpets the given view as a transposed dense view.
+        /// </summary>
+        /// <typeparam name="T">The view element type.</typeparam>
+        /// <param name="view">The view instance.</param>
+        /// <returns>The transposed array view.</returns>
+        public static ArrayView2D<T, Stride2D.DenseY> AsTransposed<T>(
+            this ArrayView2D<T, Stride2D.DenseX> view)
+            where T : unmanaged =>
+            new ArrayView2D<T, Stride2D.DenseY>(
+                view.BaseView,
+                new LongIndex2D(view.Extent.Y, view.Extent.X),
+                new Stride2D.DenseY(view.Stride.YStride));
+
+        /// <summary>
+        /// Reinterpets the given view as a transposed dense view.
+        /// </summary>
+        /// <typeparam name="T">The view element type.</typeparam>
+        /// <param name="view">The view instance.</param>
+        /// <returns>The transposed array view.</returns>
+        public static ArrayView2D<T, Stride2D.DenseX> AsTransposed<T>(
+            this ArrayView2D<T, Stride2D.DenseY> view)
+            where T : unmanaged =>
+            new ArrayView2D<T, Stride2D.DenseX>(
+                view.BaseView,
+                new LongIndex2D(view.Extent.Y, view.Extent.X),
+                new Stride2D.DenseX(view.Stride.XStride));
+
+        /// <summary>
+        /// Reinterpets the given view as a transposed view.
+        /// </summary>
+        /// <typeparam name="T">The view element type.</typeparam>
+        /// <param name="view">The view instance.</param>
+        /// <returns>The transposed array view.</returns>
+        public static ArrayView2D<T, Stride2D.General> AsTransposed<T>(
+            this ArrayView2D<T, Stride2D.General> view)
+            where T : unmanaged =>
+            new ArrayView2D<T, Stride2D.General>(
+                view.BaseView,
+                new LongIndex2D(view.Extent.Y, view.Extent.X),
+                new Stride2D.General((view.Stride.YStride, view.Stride.XStride)));
+
+        /// <summary>
+        /// Reinterpets the given view as a transposed dense view.
+        /// </summary>
+        /// <typeparam name="T">The view element type.</typeparam>
+        /// <param name="view">The view instance.</param>
+        /// <returns>The transposed array view.</returns>
+        public static ArrayView3D<T, Stride3D.DenseZY> AsTransposed<T>(
+            this ArrayView3D<T, Stride3D.DenseXY> view)
+            where T : unmanaged =>
+            new ArrayView3D<T, Stride3D.DenseZY>(
+                view.BaseView,
+                new LongIndex3D(view.Extent.Z, view.Extent.Y, view.Extent.X),
+                new Stride3D.DenseZY(view.Stride.ZStride, view.Stride.YStride));
+
+        /// <summary>
+        /// Reinterpets the given view as a transposed dense view.
+        /// </summary>
+        /// <typeparam name="T">The view element type.</typeparam>
+        /// <param name="view">The view instance.</param>
+        /// <returns>The transposed array view.</returns>
+        public static ArrayView3D<T, Stride3D.DenseXY> AsTransposed<T>(
+            this ArrayView3D<T, Stride3D.DenseZY> view)
+            where T : unmanaged =>
+            new ArrayView3D<T, Stride3D.DenseXY>(
+                view.BaseView,
+                new LongIndex3D(view.Extent.Z, view.Extent.Y, view.Extent.X),
+                new Stride3D.DenseXY(view.Stride.YStride, view.Stride.XStride));
+
+        /// <summary>
+        /// Reinterpets the given view as a transposed view.
+        /// </summary>
+        /// <typeparam name="T">The view element type.</typeparam>
+        /// <param name="view">The view instance.</param>
+        /// <returns>The transposed array view.</returns>
+        public static ArrayView3D<T, Stride3D.General> AsTransposed<T>(
+            this ArrayView3D<T, Stride3D.General> view)
+            where T : unmanaged =>
+            new ArrayView3D<T, Stride3D.General>(
+                view.BaseView,
+                new LongIndex3D(view.Extent.Z, view.Extent.Y, view.Extent.X),
+                new Stride3D.General(
+                    (view.Stride.ZStride,
+                    view.Stride.YStride,
+                    view.Stride.XStride)));
+
+        #endregion
+
         #region MemSet
 
         /// <summary>

--- a/Src/ILGPU/Runtime/ArrayViews.tt
+++ b/Src/ILGPU/Runtime/ArrayViews.tt
@@ -275,7 +275,8 @@ namespace ILGPU.Runtime
                 "Index/Extent <#= iName #> out of bounds");
 <#      } #>
             <#= baseType #> offset = ComputeLinearIndex(index);
-            var view = BaseView.SubView(offset, extent.Size);
+            <#= baseType #> length = Stride.ComputeBufferLength(extent);
+            var view = BaseView.SubView(offset, length);
             return new <#= typeName #><T, TStride>(
                 view,
                 extent,

--- a/Src/ILGPU/Stride.cs
+++ b/Src/ILGPU/Stride.cs
@@ -11,7 +11,6 @@
 
 using ILGPU.IR.Types;
 using ILGPU.Resources;
-using ILGPU.Runtime;
 using ILGPU.Util;
 using System;
 using System.Diagnostics;
@@ -61,6 +60,13 @@ namespace ILGPU
         /// <param name="index">The dimension for index computation.</param>
         /// <returns>The computed linear element address.</returns>
         long ComputeElementIndex(TLongIndex index);
+
+        /// <summary>
+        /// Computes the 32-bit length of a required allocation.
+        /// </summary>
+        /// <param name="extent">The extent to allocate.</param>
+        /// <returns>The 32-bit length of a required allocation.</returns>
+        int ComputeBufferLength(TIndex extent);
 
         /// <summary>
         /// Computes the 64-bit length of a required allocation.
@@ -307,16 +313,22 @@ namespace ILGPU
                 Stride2D.ComputeElementIndex(this, index);
 
             /// <summary>
+            /// Computes the 32-bit length of a required allocation.
+            /// </summary>
+            /// <param name="extent">The extent to allocate.</param>
+            /// <returns>The 32-bit length of a required allocation.</returns>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public readonly int ComputeBufferLength(Index2D extent) =>
+                ComputeElementIndex(extent - Index2D.One) + 1;
+
+            /// <summary>
             /// Computes the 64-bit length of a required allocation.
             /// </summary>
             /// <param name="extent">The extent to allocate.</param>
             /// <returns>The 64-bit length of a required allocation.</returns>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public readonly long ComputeBufferLength(LongIndex2D extent)
-            {
-                Trace.Assert(extent.X <= YStride, "X extent out of range");
-                return YStride * extent.Y;
-            }
+            public readonly long ComputeBufferLength(LongIndex2D extent) =>
+                ComputeElementIndex(extent - LongIndex2D.One) + 1L;
 
             /// <summary>
             /// Computes a new extent and stride based on the given cast context.
@@ -427,17 +439,24 @@ namespace ILGPU
                 Stride2D.ComputeElementIndex(this, index);
 
             /// <summary>
+            /// Computes the 32-bit length of a required allocation.
+            /// </summary>
+            /// <param name="extent">The extent to allocate.</param>
+            /// <returns>The 32-bit length of a required allocation.</returns>
+            /// <remarks>This method is not supported on accelerators.</remarks>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public readonly int ComputeBufferLength(Index2D extent) =>
+                Stride2D.ComputeBufferLength(this, extent);
+
+            /// <summary>
             /// Computes the 64-bit length of a required allocation.
             /// </summary>
             /// <param name="extent">The extent to allocate.</param>
             /// <returns>The 64-bit length of a required allocation.</returns>
             /// <remarks>This method is not supported on accelerators.</remarks>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public readonly long ComputeBufferLength(LongIndex2D extent)
-            {
-                Trace.Assert(extent.Y <= XStride, "Y extent out of range");
-                return XStride * extent.X;
-            }
+            public readonly long ComputeBufferLength(LongIndex2D extent) =>
+                Stride2D.ComputeBufferLength(this, extent);
 
             /// <summary>
             /// Computes a new extent and stride based on the given cast context.
@@ -561,18 +580,24 @@ namespace ILGPU
                 Stride3D.ComputeElementIndex(this, index);
 
             /// <summary>
+            /// Computes the 32-bit length of a required allocation.
+            /// </summary>
+            /// <param name="extent">The extent to allocate.</param>
+            /// <returns>The 3264-bit length of a required allocation.</returns>
+            /// <remarks>This method is not supported on accelerators.</remarks>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public readonly int ComputeBufferLength(Index3D extent) =>
+                Stride3D.ComputeBufferLength(this, extent);
+
+            /// <summary>
             /// Computes the 64-bit length of a required allocation.
             /// </summary>
             /// <param name="extent">The extent to allocate.</param>
             /// <returns>The 64-bit length of a required allocation.</returns>
             /// <remarks>This method is not supported on accelerators.</remarks>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public readonly long ComputeBufferLength(LongIndex3D extent)
-            {
-                Trace.Assert(extent.X <= YStride, "X extent out of range");
-                Trace.Assert(extent.X * extent.Y <= ZStride, "Y extent out of range");
-                return ZStride * extent.Z;
-            }
+            public readonly long ComputeBufferLength(LongIndex3D extent) =>
+                Stride3D.ComputeBufferLength(this, extent);
 
             /// <summary>
             /// Computes a new extent and stride based on the given cast context.
@@ -694,18 +719,24 @@ namespace ILGPU
                 Stride3D.ComputeElementIndex(this, index);
 
             /// <summary>
+            /// Computes the 32-bit length of a required allocation.
+            /// </summary>
+            /// <param name="extent">The extent to allocate.</param>
+            /// <returns>The 32-bit length of a required allocation.</returns>
+            /// <remarks>This method is not supported on accelerators.</remarks>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public readonly int ComputeBufferLength(Index3D extent) =>
+                Stride3D.ComputeBufferLength(this, extent);
+
+            /// <summary>
             /// Computes the 64-bit length of a required allocation.
             /// </summary>
             /// <param name="extent">The extent to allocate.</param>
             /// <returns>The 64-bit length of a required allocation.</returns>
             /// <remarks>This method is not supported on accelerators.</remarks>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public readonly long ComputeBufferLength(LongIndex3D extent)
-            {
-                Trace.Assert(extent.Z <= YStride, "Y extent out of range");
-                Trace.Assert(extent.Z * extent.Y <= XStride, "Z extent out of range");
-                return XStride * extent.X;
-            }
+            public readonly long ComputeBufferLength(LongIndex3D extent) =>
+                Stride3D.ComputeBufferLength(this, extent);
 
             /// <summary>
             /// Computes a new extent and stride based on the given cast context.

--- a/Src/ILGPU/StrideTypes.tt
+++ b/Src/ILGPU/StrideTypes.tt
@@ -39,7 +39,6 @@ namespace ILGPU
         int <#= IndexDimensions[i] #>Stride { get; }
 
 <#      } #>
-
         /// <summary>
         /// Returns this stride as general <#= def.Dimension #>D stride.
         /// </summary>
@@ -89,6 +88,14 @@ namespace ILGPU
             /// <returns>The computed linear element address.</returns>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public readonly long ComputeElementIndex(<#= longIndexName #> index) => 0L;
+
+            /// <summary>
+            /// Computes the 32-bit length of a required allocation.
+            /// </summary>
+            /// <param name="extent">The extent to allocate.</param>
+            /// <returns>The 32-bit length of a required allocation.</returns>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public readonly int ComputeBufferLength(<#= indexName #> extent) => 1;
 
             /// <summary>
             /// Computes the 64-bit length of a required allocation.
@@ -165,6 +172,14 @@ namespace ILGPU
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public readonly long ComputeElementIndex(<#= longIndexName #> index) =>
                 index;
+
+            /// <summary>
+            /// Computes the 32-bit length of a required allocation.
+            /// </summary>
+            /// <param name="extent">The extent to allocate.</param>
+            /// <returns>The 32-bit length of a required allocation.</returns>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public readonly int ComputeBufferLength(<#= indexName #> extent) => extent;
 
             /// <summary>
             /// Computes the 64-bit length of a required allocation.
@@ -280,25 +295,22 @@ namespace ILGPU
                 <#= className #>.ComputeElementIndex(this, index);
 
             /// <summary>
+            /// Computes the 32-bit length of a required allocation.
+            /// </summary>
+            /// <param name="extent">The extent to allocate.</param>
+            /// <returns>The 3264-bit length of a required allocation.</returns>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public readonly int ComputeBufferLength(<#= indexName #> extent) =>
+                <#= className #>.ComputeBufferLength(this, extent);
+
+            /// <summary>
             /// Computes the 64-bit length of a required allocation.
             /// </summary>
             /// <param name="extent">The extent to allocate.</param>
             /// <returns>The 64-bit length of a required allocation.</returns>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public readonly long ComputeBufferLength(<#= longIndexName #> extent)
-<#      if  (def.Dimension == 1) { #>
-                => extent * StrideExtent;
-<#      } else { #>
-            {
-                Trace.Assert(extent.X <= YStride, "X extent out of range");
-<#          if  (def.Dimension == 2) { #>
-                return YStride * extent.Y;
-<#          } else { #>
-                Trace.Assert(extent.X * extent.Y <= ZStride, "Y extent out of range");
-                return ZStride * extent.Z;
-<#          } #>
-            }
-<#      } #>
+            public readonly long ComputeBufferLength(<#= longIndexName #> extent) =>
+                <#= className #>.ComputeBufferLength(this, extent);
 
             /// <summary>
             /// Returns this stride as general <#= def.Dimension #>D stride.
@@ -360,6 +372,32 @@ namespace ILGPU
 <#          var separator = i + 1 < def.Dimension ? " +" : ";"; #>
             index.<#= iName #> * stride.<#= iName #>Stride<#= separator #>
 <#      } #>
+
+        /// <summary>
+        /// Computes the 32-bit length of a required allocation.
+        /// </summary>
+        /// <param name="stride">The stride to use.</param>
+        /// <param name="extent">The extent to allocate.</param>
+        /// <returns>The 3264-bit length of a required allocation.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int ComputeBufferLength<TStride>(
+            this TStride stride,
+            <#= indexName #> extent)
+            where TStride : <#= strideName #> =>
+            stride.ComputeElementIndex(extent - <#= indexName #>.One) + 1;
+
+        /// <summary>
+        /// Computes the 64-bit length of a required allocation.
+        /// </summary>
+        /// <param name="stride">The stride to use.</param>
+        /// <param name="extent">The extent to allocate.</param>
+        /// <returns>The 64-bit length of a required allocation.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static long ComputeBufferLength<TStride>(
+            this TStride stride,
+            <#= longIndexName #> extent)
+            where TStride : <#= strideName #> =>
+            stride.ComputeElementIndex(extent - <#= longIndexName #>.One) + 1L;
     }
 
 <#  } #>


### PR DESCRIPTION
This PR fixes several issues related to the newly added `Stride` types in `v1.0-beta`. It was found that the `length` information was not computed correctly in some cases due to invalid `over-approximations`. This PR fixes several of these problems and resolves a related issue that could occur when fetching strided buffers back into CPU memory.

It also adds a set of small helper methods called `AsTranspose` that can be used to reinterpret the memory layout of a given view as it would be transposed (without actually transposing the data elements stored in the view).