### PR TITLE
Fixed issue with check styles when rebuilding entire project.

### DIFF
--- a/Src/ILGPU/Properties/ILGPU.CheckStyles.targets
+++ b/Src/ILGPU/Properties/ILGPU.CheckStyles.targets
@@ -51,11 +51,6 @@ foreach (var file in Files)
     if (parentDirName == "Resources")
         continue;
 
-    // Ignore files that disable line length checking.
-    var lines = File.ReadAllLines(filePath);
-    if (lines.Any(line => line.StartsWith("// disable: max_line_length")))
-        continue;
-
     // Ignore generated C# files.
     var ext = Path.GetExtension(filePath);
     if (ext == ".cs")
@@ -64,6 +59,11 @@ foreach (var file in Files)
         if (File.Exists(templatePath))
             continue;
     }
+
+    // Ignore files that disable line length checking.
+    var lines = File.ReadAllLines(filePath);
+    if (lines.Any(line => line.StartsWith("// disable: max_line_length")))
+        continue;
 
     for (var i = 0; i < lines.Length; i++)
     {


### PR DESCRIPTION
When using `Rebuild All` in Visual Studio, the generated C# files occasionally fail with `FileNotFoundException`. Changed the order of checks so that the check for generated C# files is performed before reading the file contents.