### PR TITLE
Changed T4 DllImportSearchPath to LegacyBehavior.

### DIFF
--- a/Src/ILGPU/Static/DllImports.tt
+++ b/Src/ILGPU/Static/DllImports.tt
@@ -93,7 +93,7 @@ namespace <#= imports.Namespace #>
             , ThrowOnUnmappableChar = true
 <#          } #>
         )]
-        [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         internal static extern <#= imports.GetReturnType(entryPoint) #>
             <#= entryPoint.Name #>_Import(
 <#          foreach (var (param, suffix) in entryPoint.ParamExpressions) { #>


### PR DESCRIPTION
A community member reported that on some systems (e.g. various flavors of Linux), that the Cuda DLLs are not located in "safe directories".