### PR TITLE
Explicitly use ordinal comparison when parsing inline PTX instructions.

### DIFF
--- a/Src/ILGPU/Frontend/Intrinsic/LanguageIntrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/LanguageIntrinsics.cs
@@ -179,11 +179,11 @@ namespace ILGPU.Frontend.Intrinsic
 
             foreach (var part in parts)
             {
-                if (part == "%%")
+                if (part.Equals("%%", StringComparison.Ordinal))
                 {
                     result.Add(new FormatExpression("%"));
                 }
-                else if (part.StartsWith("%"))
+                else if (part.StartsWith("%", StringComparison.Ordinal))
                 {
                     // Check whether the argument can be resolved to an integer.
                     if (int.TryParse(part.Substring(1), out int argument))


### PR DESCRIPTION
Fixes compiler warning CA1310 `The behavior of 'string.StartsWith(string)' could vary based on the current user's locale settings` when using `net5.0`.