### PR TITLE
Fixed invalid copies from and to sub views.

### DIFF
--- a/Src/ILGPU.Tests/MemoryBufferOperations.tt
+++ b/Src/ILGPU.Tests/MemoryBufferOperations.tt
@@ -252,6 +252,26 @@ namespace ILGPU.Tests
 
             Verify2D(denseY2.View, expected);
             Verify2D(denseX2.GetAsArray2D(), expected);
+
+            // Test subview copies
+            var expectedSub = InitializeArray2D(length / 2, converter);
+            denseX.MemSetToZero();
+            denseY.MemSetToZero();
+            var subViewX = denseX.View.SubView(
+                (1, 1),
+                (length / 2, length / 2));
+            var subViewY = denseY.View.SubView(
+                (1, 1),
+                (length / 2, length / 2));
+            var subViewYGeneral = subViewY.AsGeneral();
+            subViewX.CopyFromCPU(expectedSub);
+            Assert.Throws<NotSupportedException>(() =>
+                subViewY.CopyFromCPU(expectedSub));
+            subViewYGeneral.CopyFromCPU(expectedSub);
+            Verify2D(expectedSub, subViewX.GetAsArray2D());
+            Assert.Throws<NotSupportedException>(() =>
+                Verify2D(expectedSub, subViewY.GetAsArray2D()));
+            Verify2D(expectedSub, subViewYGeneral.GetAsArray2D());
         }
 
 <#  } #>
@@ -305,6 +325,26 @@ namespace ILGPU.Tests
 
             Verify3D(denseY2.View, expected);
             Verify3D(denseX2.GetAsArray3D(), expected);
+
+            // Test subview copies
+            var expectedSub = InitializeArray3D(length / 2, converter);
+            denseX.MemSetToZero();
+            denseY.MemSetToZero();
+            var subViewX = denseX.View.SubView(
+                (1, 1, 1),
+                (length / 2, length / 2, length / 2));
+            var subViewY = denseY.View.SubView(
+                (1, 1, 1),
+                (length / 2, length / 2, length / 2));
+            var subViewYGeneral = subViewY.AsGeneral();
+            subViewX.CopyFromCPU(expectedSub);
+            Assert.Throws<NotSupportedException>(() =>
+                subViewY.CopyFromCPU(expectedSub));
+            subViewYGeneral.CopyFromCPU(expectedSub);
+            Verify3D(expectedSub, subViewX.GetAsArray3D());
+            Assert.Throws<NotSupportedException>(() =>
+                Verify3D(expectedSub, subViewY.GetAsArray3D()));
+            Verify3D(expectedSub, subViewYGeneral.GetAsArray3D());
         }
 
 <#  } #>

--- a/Src/ILGPU/Resources/RuntimeErrorMessages.Designer.cs
+++ b/Src/ILGPU/Resources/RuntimeErrorMessages.Designer.cs
@@ -241,6 +241,15 @@ namespace ILGPU.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The stride information does not allow to perform an efficient copy operation without reordering. Use AsGeneral to convert the view to a general view with a CPU-based reordering operation..
+        /// </summary>
+        internal static string NotSupportedEfficientStrideCopy {
+            get {
+                return ResourceManager.GetString("NotSupportedEfficientStrideCopy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Not supported explicitly-grouped kernel.
         /// </summary>
         internal static string NotSupportedExplicitlyGroupedKernel {

--- a/Src/ILGPU/Resources/RuntimeErrorMessages.resx
+++ b/Src/ILGPU/Resources/RuntimeErrorMessages.resx
@@ -177,6 +177,9 @@
   <data name="NotSupportedDriverVersion" xml:space="preserve">
     <value>Not supported driver version '{0}' (&gt;= {1} required)</value>
   </data>
+  <data name="NotSupportedEfficientStrideCopy" xml:space="preserve">
+    <value>The stride information does not allow to perform an efficient copy operation without reordering. Use AsGeneral to convert the view to a general view with a CPU-based reordering operation.</value>
+  </data>
   <data name="NotSupportedExplicitlyGroupedKernel" xml:space="preserve">
     <value>Not supported explicitly-grouped kernel</value>
   </data>

--- a/Src/ILGPU/Runtime/ArrayViewExtensions.Generated.tt
+++ b/Src/ILGPU/Runtime/ArrayViewExtensions.Generated.tt
@@ -57,6 +57,7 @@ var castFunctions = new (string, string)[]
     ("ArrayView3D", "Stride3D.DenseZY"),
 };
 #>
+using ILGPU.Resources;
 using System;
 using System.Runtime.CompilerServices;
 
@@ -482,11 +483,26 @@ namespace ILGPU.Runtime
             AcceleratorStream stream,
             <#= arrayType #> data)
             where T : unmanaged
+<#      if (needsTranspose) { #>
+            => view.AsGeneral().CopyToCPU(stream, data);
+<#      } else { #>
         {
             if (data is null)
                 throw new ArgumentNullException(nameof(data));
             if (data.Length < 1)
                 return;
+<#      if (dimension > 1) { #>
+            // Check if we need to transpose the output on the CPU
+            if (view.Extent.Y % view.Stride.XStride != 0
+<#          if (dimension > 2) { #>
+                && view.Extent.Z % (view.Stride.XStride / view.Stride.YStride) != 0
+<#          } #>
+                )
+            {
+                throw new NotSupportedException(
+                    RuntimeErrorMessages.NotSupportedEfficientStrideCopy);
+            }
+<#      } #>
 <#      for (int i = 0; i < dimension; ++i) { #>
 <#          var propertyName = IndexDimensions[i].PropertyName; #>
             if (data.GetLength(<#= i #>) <
@@ -544,11 +560,26 @@ namespace ILGPU.Runtime
             AcceleratorStream stream,
             <#= arrayType #> data)
             where T : unmanaged
+<#      if (needsTranspose) { #>
+            => view.AsGeneral().CopyFromCPU(stream, data);
+<#      } else { #>
         {
             if (data is null)
                 throw new ArgumentNullException(nameof(data));
             if (view.HasNoData())
                 return;
+<#      if (dimension > 1) { #>
+            // Check if we need to transpose the output on the CPU
+            if (view.Extent.Y % view.Stride.XStride != 0
+<#          if (dimension > 2) { #>
+                && view.Extent.Z % (view.Stride.XStride / view.Stride.YStride) != 0
+<#          } #>
+                )
+            {
+                throw new NotSupportedException(
+                    RuntimeErrorMessages.NotSupportedEfficientStrideCopy);
+            }
+<#      } #>
 <#      for (int i = 0; i < dimension; ++i) { #>
 <#          var propertyName = IndexDimensions[i].PropertyName; #>
             if (data.GetLength(<#= i #>) <

--- a/Src/ILGPU/Runtime/ArrayViewExtensions.Generated.tt
+++ b/Src/ILGPU/Runtime/ArrayViewExtensions.Generated.tt
@@ -37,10 +37,11 @@ var threeDStrides = new (string, bool)[]
 var dimensionStrides =
     twoDStrides.Select(t => (2, t.Item1, t.Item2)).Concat(
     threeDStrides.Select(t => (3, t.Item1, t.Item2)));
+var extendedDimensionStrides =
+    dimensionStrides.Concat(new [] { (1, "Dense", false) });
 var generalDimensionStrides =
-    dimensionStrides.Concat(
+    extendedDimensionStrides.Concat(
         new [] {
-            (1, "Dense", false),
             (1, "General", true),
             (2, "General", true),
             (3, "General", true) });
@@ -436,7 +437,7 @@ namespace ILGPU.Runtime
 
         #region Copy to/from arrays
 
-<# foreach (var (dimension, strideName, needsTranspose) in generalDimensionStrides) { #>
+<# foreach (var (dimension, strideName, needsTranspose) in extendedDimensionStrides) { #>
 <#      var typeName = $"ArrayView{dimension}D"; #>
 <#      var strideTypeName = $"Stride{dimension}D"; #>
 <#      var arrayDimExpr = string.Join(",",
@@ -495,89 +496,14 @@ namespace ILGPU.Runtime
             }
 <#      } #>
 
-<#      if (!needsTranspose) { #>
             fixed (T* ptr = data)
             {
                 view.BaseView.CopyToCPU(
                     stream,
                     new Span<T>(ptr, data.Length));
             }
-<#      } else { #>
-            var tempBuffer = new T[view.BaseView.Length];
-            fixed (T* ptr = tempBuffer)
-            {
-                var span = new Span<T>(ptr, tempBuffer.Length);
-                view.BaseView.CopyToCPU(stream, span);
-
-                // Transpose the input elements and store them in the result buffer
-                var extent = (Index<#= dimension #>D)view.Extent;
-                var stride = view.Stride;
-<#      for (int i = 0; i < dimension; ++i) { #>
-<#          var fieldName = IndexDimensions[i].FieldName; #>
-                for (
-                    int <#= fieldName #> = 0;
-                    <#= fieldName #> < extent.<#= IndexDimensions[i].PropertyName #>;
-                    ++<#= fieldName #>)
-                {
-<#      } #>
-                    var multiDimIndex = new Index<#= dimension #>D(<#= string.Join(
-                        ", ",
-                        IndexDimensions.Take(dimension).Select(t => t.FieldName)) #>);
-                    int elementIndex = stride.ComputeElementIndex(multiDimIndex);
-                    data[<#= string.Join(", ",
-                        Enumerable.Range(0, dimension)
-                        .Select(t => IndexDimensions[t].FieldName)) #>] =
-                        span[elementIndex];
-<#      for (int i = 0; i < dimension; ++i) { #>
-                }
-<#      } #>
-            }
-<#      } #>
         }
-
-        /// <summary>
-        /// Copies the contents of the <#= dimension #>D view into the given
-        /// <#= dimension #>D array using the default accelerator stream.
-        /// </summary>
-        /// <param name="buffer">The source buffer.</param>
-        /// <param name="data">The target data array.</param>
-        /// <remarks>
-<#      if (needsTranspose) { #>
-        /// CAUTION: this method transposes the data on the CPU.
 <#      } #>
-        /// This method is not supported on accelerators.
-        /// </remarks>
-        [NotInsideKernel]
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void CopyToCPU<T>(
-            this MemoryBuffer<
-                <#= typeName #><T, <#= strideTypeName #>.<#= strideName #>>> buffer,
-            <#= arrayType #> data)
-            where T : unmanaged =>
-            buffer.View.CopyToCPU(data);
-
-        /// <summary>
-        /// Copies the contents of the <#= dimension #>D view into the given
-        /// <#= dimension #>D array using the given accelerator stream.
-        /// </summary>
-        /// <param name="buffer">The source buffer.</param>
-        /// <param name="stream">The used accelerator stream.</param>
-        /// <param name="data">The target data array.</param>
-        /// <remarks>
-<#      if (needsTranspose) { #>
-        /// CAUTION: this method transposes the data on the CPU.
-<#      } #>
-        /// This method is not supported on accelerators.
-        /// </remarks>
-        [NotInsideKernel]
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void CopyToCPU<T>(
-            this MemoryBuffer<
-                <#= typeName #><T, <#= strideTypeName #>.<#= strideName #>>> buffer,
-            AcceleratorStream stream,
-            <#= arrayType #> data)
-            where T : unmanaged =>
-            buffer.View.CopyToCPU(stream, data);
 
         /// <summary>
         /// Copies the contents of the <#= dimension #>D array into the given
@@ -632,42 +558,7 @@ namespace ILGPU.Runtime
             }
 <#      } #>
 
-<#      if (needsTranspose) { #>
-            var tempBuffer = new T[view.Length];
-            fixed (T* ptr = data)
-            {
-                var span = new ReadOnlySpan<T>(ptr, data.Length);
-
-                // Transpose the input elements and store them in the result buffer
-                var extent = (Index<#= dimension #>D)view.Extent;
-                var stride = view.Stride;
-<#      for (int i = 0; i < dimension; ++i) { #>
-<#          var fieldName = IndexDimensions[i].FieldName; #>
-                for (
-                    int <#= fieldName #> = 0;
-                    <#= fieldName #> < extent.<#= IndexDimensions[i].PropertyName #>;
-                    ++<#= fieldName #>)
-                {
-<#      } #>
-                    int targetElementIndex = view.Stride.ComputeElementIndex(
-                        new Index<#= dimension #>D(<#= string.Join(
-                        ", ",
-                        IndexDimensions.Take(dimension).Select(t => t.FieldName)) #>));
-                    int sourceElementIndex = <#= IndexDimensions[0].FieldName #>;
-<#      for (int i = 1; i < dimension; ++i) { #>
-<#          var dim = IndexDimensions[i]; #>
-                    sourceElementIndex *= (int)view.Extent.<#= dim.PropertyName #>;
-                    sourceElementIndex += <#= dim.FieldName #>;
-
-<#      } #>
-                    tempBuffer[targetElementIndex] = span[sourceElementIndex];
-<#      for (int i = 0; i < dimension; ++i) { #>
-                }
-<#      } #>
-            }
-<#      } else { #>
             var tempBuffer = data;
-<#      } #>
             fixed (T* ptr = tempBuffer)
             {
                 view.BaseView.CopyFromCPU(
@@ -675,6 +566,60 @@ namespace ILGPU.Runtime
                     new ReadOnlySpan<T>(ptr, tempBuffer.Length));
             }
         }
+<#      } #>
+
+<# } #>
+
+<# foreach (var (dimension, strideName, needsTranspose) in generalDimensionStrides) { #>
+<#      var typeName = $"ArrayView{dimension}D"; #>
+<#      var strideTypeName = $"Stride{dimension}D"; #>
+<#      var arrayDimExpr = string.Join(",",
+            Enumerable.Repeat(string.Empty, dimension)); #>
+<#      var arrayType = $"T[{arrayDimExpr}]"; #>
+
+        /// <summary>
+        /// Copies the contents of the <#= dimension #>D view into the given
+        /// <#= dimension #>D array using the default accelerator stream.
+        /// </summary>
+        /// <param name="buffer">The source buffer.</param>
+        /// <param name="data">The target data array.</param>
+        /// <remarks>
+<#      if (needsTranspose) { #>
+        /// CAUTION: this method transposes the data on the CPU.
+<#      } #>
+        /// This method is not supported on accelerators.
+        /// </remarks>
+        [NotInsideKernel]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void CopyToCPU<T>(
+            this MemoryBuffer<
+                <#= typeName #><T, <#= strideTypeName #>.<#= strideName #>>> buffer,
+            <#= arrayType #> data)
+            where T : unmanaged =>
+            buffer.View.CopyToCPU(data);
+
+        /// <summary>
+        /// Copies the contents of the <#= dimension #>D view into the given
+        /// <#= dimension #>D array using the given accelerator stream.
+        /// </summary>
+        /// <param name="buffer">The source buffer.</param>
+        /// <param name="stream">The used accelerator stream.</param>
+        /// <param name="data">The target data array.</param>
+        /// <remarks>
+<#      if (needsTranspose) { #>
+        /// CAUTION: this method transposes the data on the CPU.
+<#      } #>
+        /// This method is not supported on accelerators.
+        /// </remarks>
+        [NotInsideKernel]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void CopyToCPU<T>(
+            this MemoryBuffer<
+                <#= typeName #><T, <#= strideTypeName #>.<#= strideName #>>> buffer,
+            AcceleratorStream stream,
+            <#= arrayType #> data)
+            where T : unmanaged =>
+            buffer.View.CopyToCPU(stream, data);
 
         /// <summary>
         /// Copies the contents of the <#= dimension #>D array into the given


### PR DESCRIPTION
The current implementation of `CopyFromCPU` and `CopyToCPU`, which do not require reorder operations, perform invalid data copy operations on partial sub views. This PR fixes invalid copies from and to CPU memory operating on partial sub views by adding additional checks.