### PR TITLE
Run clean tests on push to master or tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,9 +98,13 @@ jobs:
       - name: CPU Tests
         if: matrix.os != 'cuda'
         run: dotnet test --logger GitHubActions --no-build --configuration=Release Src/${{ matrix.library }}.Tests.CPU
+        env:
+          ILGPU_CLEAN_TESTS: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) }}
       - name: CUDA Tests
         if: matrix.os == 'cuda'
         run: dotnet test --logger GitHubActions --no-build --configuration=Release Src/${{ matrix.library }}.Tests.Cuda
+        env:
+          ILGPU_CLEAN_TESTS: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) }}
 
   package:
     runs-on: windows-latest

--- a/Src/ILGPU.Tests/Generic/TestBase.cs
+++ b/Src/ILGPU.Tests/Generic/TestBase.cs
@@ -30,8 +30,11 @@ namespace ILGPU.Tests
         {
             get
             {
-                var env = Environment.GetEnvironmentVariable(CleanTestsEnvironmentVariable);
-                return !string.IsNullOrWhiteSpace(env) && env.ToLower() != "false" && env != "0";
+                var env = Environment.GetEnvironmentVariable(
+                    CleanTestsEnvironmentVariable);
+                return !string.IsNullOrWhiteSpace(env)
+                       && env.ToLower() != "false"
+                       && env != "0";
             }
         }
 

--- a/Src/ILGPU.Tests/Generic/TestBase.cs
+++ b/Src/ILGPU.Tests/Generic/TestBase.cs
@@ -26,9 +26,14 @@ namespace ILGPU.Tests
         /// <summary>
         /// Returns true if all tests should be executed in a clean environment.
         /// </summary>
-        public static bool CleanTests { get; } =
-            !string.IsNullOrWhiteSpace(
-                Environment.GetEnvironmentVariable(CleanTestsEnvironmentVariable));
+        public static bool CleanTests
+        {
+            get
+            {
+                var env = Environment.GetEnvironmentVariable(CleanTestsEnvironmentVariable);
+                return !string.IsNullOrWhiteSpace(env) && env.ToLower() != "false" && env != "0";
+            }
+        }
 
         /// <summary>
         /// Resolves a kernel method.


### PR DESCRIPTION
This PR builds on top of the new cached tests introduced in #522.
It will run clean tests when a push to `master` or a release tag happens, by setting the `ILGPU_CLEAN_TESTS` environment variable to `"true"`.
It introduces an additional way to disable clean tests, by setting the `ILGPU_CLEAN_TESTS` environment variable to `"false"` (case-insensitive) or `"0"`.