### PR TITLE
Selective builds on macOS, master and tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,18 @@ jobs:
       - name: Setup OS matrix
         id: setup-os-matrix
         run: |
-          os='["ubuntu-latest","windows-latest","macos-latest"'
+          os='["ubuntu-latest","windows-latest"'
+
+          # runs on macOS only if there is a push to master, or a tag is 
+          # pushed, we do this since macOS builds last too long and ILGPU 
+          # is rarely used on a macOS
+          [ "${{ github.ref }}" == "refs/heads/master" ] ||
+          [[ "${{ github.ref }}" =~ "refs/tags/v" ]] && 
+          [ "${{ github.event_name }}" == "push" ] &&
+          os="$os,\"macos-latest\""
+
           [ "${{ github.event.repository.fork }}" == "false" ] && os="$os,\"cuda\""
+
           os="$os]"
           echo "::set-output name=os::$os"
     outputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,20 +69,22 @@ jobs:
       - name: Setup OS matrix
         id: setup-os-matrix
         run: |
-          os='["ubuntu-latest","windows-latest"'
+          os=("ubuntu-latest" "windows-latest")
 
           # runs on macOS only if there is a push to master, or a tag is 
           # pushed, we do this since macOS builds last too long and ILGPU 
           # is rarely used on a macOS
-          [ "${{ github.ref }}" == "refs/heads/master" ] ||
-          [[ "${{ github.ref }}" =~ "refs/tags/v" ]] && 
-          [ "${{ github.event_name }}" == "push" ] &&
-          os="$os,\"macos-latest\""
+          (
+            [ "${{ github.event_name }}" == "push" ] &&
+            (
+              [ "${{ github.ref }}" == "refs/heads/master" ] ||
+              [[ "${{ github.ref }}" =~ "refs/tags/v" ]]  
+            )
+          ) && os+=("macos-latest")
 
-          [ "${{ github.event.repository.fork }}" == "false" ] && os="$os,\"cuda\""
+          [ "${{ github.event.repository.fork }}" == "false" ] && os+=("cuda")
 
-          os="$os]"
-          echo "::set-output name=os::$os"
+          echo "::set-output name=os::$(jq -cn '$ARGS.positional' --args ${os[@]})"
     outputs:
       os: ${{ steps.setup-os-matrix.outputs.os }}
 


### PR DESCRIPTION
## Preface
MacOS ILGPU builds are taking bit too long to complete, since we suspect there is a little to no one using ILGPU on MacOS we want to limit these builds to tags/master branch when doing a push.