### PR TITLE
Applied general cleanup.

### DIFF
--- a/Src/.editorconfig
+++ b/Src/.editorconfig
@@ -5,6 +5,10 @@ tab_width = 4
 end_of_line = crlf
 trim_trailing_whitespace = true
 
+[*.csproj]
+indent_size = 2
+tab_width = 2
+
 [*.tt]
 
 ###############################

--- a/Src/ILGPU.Algorithms.Tests.CPU/Configurations.tt
+++ b/Src/ILGPU.Algorithms.Tests.CPU/Configurations.tt
@@ -6,6 +6,8 @@ using ILGPU.Tests.CPU;
 using Xunit;
 using Xunit.Abstractions;
 
+#pragma warning disable CA1707 // Identifiers should not contain underscores
+
 <#
 var configurationFile = Host.ResolvePath("../ILGPU.Algorithms.Tests/Configurations.txt");
 var configurations = TestConfig.Parse(configurationFile);
@@ -41,3 +43,5 @@ namespace ILGPU.Algorithms.Tests.CPU
 
 <# } #>
 }
+
+#pragma warning restore CA1707 // Identifiers should not contain underscores

--- a/Src/ILGPU.Algorithms.Tests.CPU/ILGPU.Algorithms.Tests.CPU.csproj
+++ b/Src/ILGPU.Algorithms.Tests.CPU/ILGPU.Algorithms.Tests.CPU.csproj
@@ -19,6 +19,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\ILGPU.Tests\Generic\AssemblyAttributes.cs" Link="Generic\AssemblyAttributes.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="..\ILGPU.Tests.CPU\TestContext.cs" Link="TestContext.cs" />
   </ItemGroup>
 

--- a/Src/ILGPU.Algorithms.Tests.Cuda/Configurations.tt
+++ b/Src/ILGPU.Algorithms.Tests.Cuda/Configurations.tt
@@ -6,6 +6,8 @@ using ILGPU.Tests.Cuda;
 using Xunit;
 using Xunit.Abstractions;
 
+#pragma warning disable CA1707 // Identifiers should not contain underscores
+
 <#
 var configurationFile = Host.ResolvePath("../ILGPU.Algorithms.Tests/Configurations.txt");
 var configurations = TestConfig.Parse(configurationFile);
@@ -41,3 +43,5 @@ namespace ILGPU.Algorithms.Tests.Cuda
 
 <# } #>
 }
+
+#pragma warning restore CA1707 // Identifiers should not contain underscores

--- a/Src/ILGPU.Algorithms.Tests.Cuda/ILGPU.Algorithms.Tests.Cuda.csproj
+++ b/Src/ILGPU.Algorithms.Tests.Cuda/ILGPU.Algorithms.Tests.Cuda.csproj
@@ -19,6 +19,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\ILGPU.Tests\Generic\AssemblyAttributes.cs" Link="Generic\AssemblyAttributes.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="..\ILGPU.Tests.Cuda\TestContext.cs" Link="TestContext.cs" />
   </ItemGroup>
 

--- a/Src/ILGPU.Algorithms.Tests.OpenCL/Configurations.tt
+++ b/Src/ILGPU.Algorithms.Tests.OpenCL/Configurations.tt
@@ -6,6 +6,8 @@ using ILGPU.Tests.OpenCL;
 using Xunit;
 using Xunit.Abstractions;
 
+#pragma warning disable CA1707 // Identifiers should not contain underscores
+
 <#
 var configurationFile = Host.ResolvePath("../ILGPU.Algorithms.Tests/Configurations.txt");
 var configurations = TestConfig.Parse(configurationFile);
@@ -41,3 +43,5 @@ namespace ILGPU.Algorithms.Tests.OpenCL
 
 <# } #>
 }
+
+#pragma warning restore CA1707 // Identifiers should not contain underscores

--- a/Src/ILGPU.Algorithms.Tests.OpenCL/ILGPU.Algorithms.Tests.OpenCL.csproj
+++ b/Src/ILGPU.Algorithms.Tests.OpenCL/ILGPU.Algorithms.Tests.OpenCL.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
@@ -17,6 +17,10 @@
   <PropertyGroup>
     <RunSettingsFilePath>$(MSBuildProjectDirectory)\..\ILGPU.Tests\.test.runsettings</RunSettingsFilePath>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\ILGPU.Tests\Generic\AssemblyAttributes.cs" Link="Generic\AssemblyAttributes.cs" />
+  </ItemGroup>
 
   <ItemGroup>
     <Compile Include="..\ILGPU.Tests.OpenCL\TestContext.cs" Link="TestContext.cs" />

--- a/Src/ILGPU.Algorithms.Tests/ILGPU.Algorithms.Tests.csproj
+++ b/Src/ILGPU.Algorithms.Tests/ILGPU.Algorithms.Tests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Unix'">netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
@@ -14,10 +13,6 @@
 
   <PropertyGroup Condition="'$(Channel)' == 'experimental'">
     <TargetFrameworks>$(TargetFrameworks);net5.0</TargetFrameworks>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -331,10 +326,6 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>XMathTests.Trig.tt</DependentUpon>
     </Compile>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Generic\" />
   </ItemGroup>
 
   <Import Project="..\ILGPU\Properties\ILGPU.CheckStyles.targets" />

--- a/Src/ILGPU.Algorithms.Tests/VectorTests.cs
+++ b/Src/ILGPU.Algorithms.Tests/VectorTests.cs
@@ -92,7 +92,7 @@ namespace ILGPU.Algorithms.Tests
                 new Vector2(1, -1),
                 size);
             targetBuffer.CopyFromCPU(stream, sequence);
-            
+
             Execute(targetBuffer.Length, targetBuffer.View, vector.GetVector());
 
             var expected = new Vector2[size];
@@ -169,9 +169,9 @@ namespace ILGPU.Algorithms.Tests
         }
 
         [Theory]
-        [InlineData(0,0,0)]
-        [InlineData(1,2,3)]
-        [InlineData(3,2,1)]
+        [InlineData(0, 0, 0)]
+        [InlineData(1, 2, 3)]
+        [InlineData(3, 2, 1)]
         public void Index3Vector3Conv(float x, float y, float z)
         {
             Vector3 initVector = new Vector3(x, y, z);

--- a/Src/ILGPU.Algorithms/ILGPU.Algorithms.csproj
+++ b/Src/ILGPU.Algorithms/ILGPU.Algorithms.csproj
@@ -3,10 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net47;netstandard2.1</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Unix'">netstandard2.1</TargetFrameworks>
-    <Platforms>AnyCPU</Platforms>
-    <!-- CAUTION: ILGPU supports a limited subset only - due to the .Net 4.7 backwards compatibility -->
-    <LangVersion>8.0</LangVersion>
-    <NeutralLanguage>en-US</NeutralLanguage>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Channel)' == 'experimental'">
@@ -19,16 +15,17 @@
     <FileVersion>1.0.0.0</FileVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+  <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DocumentationFile>..\..\Bin\Release\ILGPU.Algorithms.xml</DocumentationFile>
-    <OutputPath>..\..\Bin\Release\</OutputPath>
+    <NeutralLanguage>en-US</NeutralLanguage>
+    <!-- CAUTION: ILGPU supports a limited subset only - due to the .Net 4.7 backwards compatibility -->
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DocumentationFile>..\..\Bin\Debug\ILGPU.Algorithms.xml</DocumentationFile>
-    <OutputPath>..\..\Bin\Debug\</OutputPath>
+  <PropertyGroup>
+    <OutputPath>../../Bin/$(Configuration)/</OutputPath>
+    <DocumentationFile>../../Bin/$(Configuration)/ILGPU.Algorithms.xml</DocumentationFile>
+    <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/ILGPU.Algorithms/Runtime/Cuda/API/CuRandAPI.cs
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/API/CuRandAPI.cs
@@ -10,7 +10,6 @@
 // ---------------------------------------------------------------------------------------
 
 using System;
-using System.Runtime.InteropServices;
 
 namespace ILGPU.Runtime.Cuda.API
 {

--- a/Src/ILGPU.Algorithms/Runtime/Cuda/CuBlasEnums.cs
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/CuBlasEnums.cs
@@ -12,6 +12,8 @@
 #pragma warning disable CA1707 // Identifiers should not contain underscores
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace ILGPU.Runtime.Cuda
 {
     public enum CuBlasStatus : int
@@ -47,6 +49,10 @@ namespace ILGPU.Runtime.Cuda
         Unit = 1
     }
 
+    [SuppressMessage(
+        "Design",
+        "CA1027:Mark enums with FlagsAttribute",
+        Justification = "This is not a flag enumeration")]
     public enum CuBlasOperation : int
     {
         NonTranspose = 0,

--- a/Src/ILGPU.Algorithms/Runtime/Cuda/CuBlasException.cs
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/CuBlasException.cs
@@ -41,6 +41,20 @@ namespace ILGPU.Runtime.Cuda
             Error = errorCode;
         }
 
+        /// <summary cref="Exception(string)"/>
+        public CuBlasException(string message)
+            : base(message)
+        {
+            Error = CuBlasStatus.CUBLAS_STATUS_NOT_SUPPORTED;
+        }
+
+        /// <summary cref="Exception(string, Exception)"/>
+        public CuBlasException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+            Error = CuBlasStatus.CUBLAS_STATUS_NOT_SUPPORTED;
+        }
+
         /// <summary cref="Exception(SerializationInfo, StreamingContext)"/>
         private CuBlasException(SerializationInfo info, StreamingContext context)
             : base(info, context)

--- a/Src/ILGPU.Algorithms/Runtime/Cuda/CuRandEnums.cs
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/CuRandEnums.cs
@@ -9,6 +9,7 @@
 // Source License. See LICENSE.txt for details
 // ---------------------------------------------------------------------------------------
 
+#pragma warning disable CA1008 // Enums should have zero value
 #pragma warning disable CA1707 // Identifiers should not contain underscores
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
@@ -69,5 +70,6 @@ namespace ILGPU.Runtime.Cuda
     }
 }
 
+#pragma warning restore CA1008 // Enums should have zero value
 #pragma warning restore CA1707 // Identifiers should not contain underscores
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member

--- a/Src/ILGPU.Algorithms/Runtime/Cuda/CuRandEnums.cs
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/CuRandEnums.cs
@@ -12,8 +12,6 @@
 #pragma warning disable CA1707 // Identifiers should not contain underscores
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
-using System;
-
 namespace ILGPU.Runtime.Cuda
 {
     public enum CuRandStatus : int

--- a/Src/ILGPU.Algorithms/Runtime/Cuda/CuRandException.cs
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/CuRandException.cs
@@ -41,6 +41,20 @@ namespace ILGPU.Runtime.Cuda
             Error = errorCode;
         }
 
+        /// <summary cref="Exception(string)"/>
+        public CuRandException(string message)
+            : base(message)
+        {
+            Error = CuRandStatus.CURAND_STATUS_NOT_INITIALIZED;
+        }
+
+        /// <summary cref="Exception(string, Exception)"/>
+        public CuRandException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+            Error = CuRandStatus.CURAND_STATUS_NOT_INITIALIZED;
+        }
+
         /// <summary cref="Exception(SerializationInfo, StreamingContext)"/>
         private CuRandException(SerializationInfo info, StreamingContext context)
             : base(info, context)
@@ -62,7 +76,9 @@ namespace ILGPU.Runtime.Cuda
         #region Methods
 
         /// <summary cref="Exception.GetObjectData(SerializationInfo, StreamingContext)"/>
+#if !NET5_0
         [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
+#endif
         public override void GetObjectData(
             SerializationInfo info,
             StreamingContext context)

--- a/Src/ILGPU.Algorithms/ScanExtensions.cs
+++ b/Src/ILGPU.Algorithms/ScanExtensions.cs
@@ -290,7 +290,7 @@ namespace ILGPU.Algorithms
             where T : unmanaged
             where TScanOperation : struct, IScanReduceOperation<T>
             where TGroupScanImplementation
-                : struct,IScanImplementation<T, TScanOperation>
+                : struct, IScanImplementation<T, TScanOperation>
         {
             TScanOperation scanOperation = default;
             TGroupScanImplementation groupScan = default;

--- a/Src/ILGPU.Tests/Generic/AssemblyAttributes.cs
+++ b/Src/ILGPU.Tests/Generic/AssemblyAttributes.cs
@@ -1,4 +1,6 @@
 ﻿using ILGPU;
+using System;
 using System.Runtime.CompilerServices;
 
+[assembly: CLSCompliant(false)]
 [assembly: InternalsVisibleTo(Context.RuntimeAssemblyName)]

--- a/Src/ILGPU.Tests/ILGPU.Tests.csproj
+++ b/Src/ILGPU.Tests/ILGPU.Tests.csproj
@@ -14,12 +14,7 @@
     <TargetFrameworks>$(TargetFrameworks);net5.0</TargetFrameworks>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <LangVersion>latest</LangVersion>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+  <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/Src/ILGPU.Tests/ProfilingMarkers.cs
+++ b/Src/ILGPU.Tests/ProfilingMarkers.cs
@@ -1,7 +1,5 @@
 ﻿using ILGPU.Runtime;
-using System;
 using System.Linq;
-using System.Threading;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Src/ILGPU/Backends/InvalidCodeGenerationException.cs
+++ b/Src/ILGPU/Backends/InvalidCodeGenerationException.cs
@@ -19,7 +19,7 @@ namespace ILGPU.Backends
     /// An exception that is thrown in case of a fatal error in a backend.
     /// </summary>
     [Serializable]
-    public class InvalidCodeGenerationException : Exception
+    public sealed class InvalidCodeGenerationException : Exception
     {
         /// <summary>
         /// Constructs a new code generation exception.
@@ -46,19 +46,15 @@ namespace ILGPU.Backends
         /// <param name="innerException">The inner exception.</param>
         public InvalidCodeGenerationException(string message, Exception innerException)
             : base(message, innerException)
-        {
-            // Add any type-specific logic for inner exceptions.
-        }
+        { }
 
         /// <summary>
         /// Constructs a new code generation exception.
         /// </summary>
-        protected InvalidCodeGenerationException(
+        private InvalidCodeGenerationException(
             SerializationInfo info,
             StreamingContext context)
             : base(info, context)
-        {
-            // Implement type-specific serialization constructor logic.
-        }
+        { }
     }
 }

--- a/Src/ILGPU/Backends/NotSupportedIntrinsicException.cs
+++ b/Src/ILGPU/Backends/NotSupportedIntrinsicException.cs
@@ -20,7 +20,7 @@ namespace ILGPU.Backends
     /// An exception that is thrown in case of a not support intrinsic.
     /// </summary>
     [Serializable]
-    public class NotSupportedIntrinsicException : Exception
+    public sealed class NotSupportedIntrinsicException : Exception
     {
         /// <summary>
         /// Constructs a new intrinsic exception.
@@ -60,19 +60,15 @@ namespace ILGPU.Backends
         /// <param name="innerException">The inner exception.</param>
         public NotSupportedIntrinsicException(string message, Exception innerException)
             : base(message, innerException)
-        {
-            // Add any type-specific logic for inner exceptions.
-        }
+        { }
 
         /// <summary>
         /// Constructs a new intrinsic exception.
         /// </summary>
-        protected NotSupportedIntrinsicException(
+        private NotSupportedIntrinsicException(
             SerializationInfo info,
             StreamingContext context)
             : base(info, context)
-        {
-            // Implement type-specific serialization constructor logic.
-        }
+        { }
     }
 }

--- a/Src/ILGPU/Backends/OpenCL/CLCompiledKernel.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLCompiledKernel.cs
@@ -10,7 +10,6 @@
 // ---------------------------------------------------------------------------------------
 
 using ILGPU.Backends.EntryPoints;
-using System;
 
 namespace ILGPU.Backends.OpenCL
 {

--- a/Src/ILGPU/Backends/PTX/PTXCompiledKernel.cs
+++ b/Src/ILGPU/Backends/PTX/PTXCompiledKernel.cs
@@ -10,7 +10,6 @@
 // ---------------------------------------------------------------------------------------
 
 using ILGPU.Backends.EntryPoints;
-using System;
 
 namespace ILGPU.Backends.PTX
 {

--- a/Src/ILGPU/Context.cs
+++ b/Src/ILGPU/Context.cs
@@ -412,7 +412,7 @@ namespace ILGPU
         /// <param name="matchingDevicesOnly">Only returns matching devices.</param>
         /// <returns>Selected devices.</returns>
         public IEnumerable<Device> GetPreferredDevices(
-            bool preferCPU, 
+            bool preferCPU,
             bool matchingDevicesOnly)
         {
             if (preferCPU)

--- a/Src/ILGPU/Frontend/Intrinsic/LanguageIntrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/LanguageIntrinsics.cs
@@ -63,10 +63,8 @@ namespace ILGPU.Frontend.Intrinsic
         /// <returns>The resulting value.</returns>
         private static ValueReference HandleLanguageOperation(
             ref InvocationContext context,
-            LanguageIntrinsicAttribute attribute)
-        {
-            var builder = context.Builder;
-            return attribute.IntrinsicKind switch
+            LanguageIntrinsicAttribute attribute) =>
+            attribute.IntrinsicKind switch
             {
                 LanguageIntrinsicKind.EmitPTX =>
                     CreateLanguageEmitPTX(ref context),
@@ -74,7 +72,6 @@ namespace ILGPU.Frontend.Intrinsic
                     ErrorMessages.NotSupportedLanguageIntrinsic,
                     attribute.IntrinsicKind.ToString()),
             };
-        }
 
         /// <summary>
         /// Creates a new inline PTX instruction.

--- a/Src/ILGPU/Grid.cs
+++ b/Src/ILGPU/Grid.cs
@@ -12,7 +12,6 @@
 using ILGPU.Frontend.Intrinsic;
 using ILGPU.IR.Values;
 using ILGPU.Runtime.CPU;
-using System;
 using static ILGPU.IndexTypeExtensions;
 
 namespace ILGPU

--- a/Src/ILGPU/Group.cs
+++ b/Src/ILGPU/Group.cs
@@ -12,7 +12,6 @@
 using ILGPU.Frontend.Intrinsic;
 using ILGPU.IR.Values;
 using ILGPU.Runtime.CPU;
-using System;
 using System.Runtime.CompilerServices;
 
 namespace ILGPU

--- a/Src/ILGPU/ILGPU.csproj
+++ b/Src/ILGPU/ILGPU.csproj
@@ -1,403 +1,403 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net47;netstandard2.1</TargetFrameworks>
-        <TargetFrameworks Condition="'$(OS)' == 'Unix'">netstandard2.1</TargetFrameworks>
-        <OutputPath>../../Bin/$(Configuration)/</OutputPath>
-        <DocumentationFile>../../Bin/$(Configuration)/ILGPU.xml</DocumentationFile>
-        <Configurations>Debug;Release</Configurations>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net47;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Unix'">netstandard2.1</TargetFrameworks>
+    <OutputPath>../../Bin/$(Configuration)/</OutputPath>
+    <DocumentationFile>../../Bin/$(Configuration)/ILGPU.xml</DocumentationFile>
+    <Configurations>Debug;Release</Configurations>
+  </PropertyGroup>
 
-    <PropertyGroup Condition="'$(Channel)' == 'experimental'">
-        <TargetFrameworks>$(TargetFrameworks);net5.0</TargetFrameworks>
-    </PropertyGroup>
+  <PropertyGroup Condition="'$(Channel)' == 'experimental'">
+    <TargetFrameworks>$(TargetFrameworks);net5.0</TargetFrameworks>
+  </PropertyGroup>
 
-    <PropertyGroup>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <VersionPrefix>1.0.0-beta3</VersionPrefix>
-        <NeutralLanguage>en-US</NeutralLanguage>
-        <!-- CAUTION: ILGPU supports a limited subset only - due to the .Net 4.7 backwards compatibility -->
-        <LangVersion>8.0</LangVersion>
-        <AssemblyVersion>1.0.0.0</AssemblyVersion>
-        <FileVersion>1.0.0.0</FileVersion>
-    </PropertyGroup>
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <VersionPrefix>1.0.0-beta3</VersionPrefix>
+    <NeutralLanguage>en-US</NeutralLanguage>
+    <!-- CAUTION: ILGPU supports a limited subset only - due to the .Net 4.7 backwards compatibility -->
+    <LangVersion>8.0</LangVersion>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <FileVersion>1.0.0.0</FileVersion>
+  </PropertyGroup>
 
-    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net47|AnyCPU'">
-        <DebugType>full</DebugType>
-        <DebugSymbols>true</DebugSymbols>
-    </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net47|AnyCPU'">
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
 
-    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net47|AnyCPU'">
-        <DebugType>pdbonly</DebugType>
-        <DebugSymbols>true</DebugSymbols>
-    </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net47|AnyCPU'">
+    <DebugType>pdbonly</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
 
-    <PropertyGroup>
-        <EnableNETAnalyzers>true</EnableNETAnalyzers>
-        <AnalysisMode>AllEnabledByDefault</AnalysisMode>
-    </PropertyGroup>
+  <PropertyGroup>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
-        <PackageReference Include="System.Memory" Version="4.5.4" />
-        <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
-        <PackageReference Include="System.Reflection.Metadata" Version="1.8.0" />
-        <PackageReference Include="T4.Build" Version="0.2.0" PrivateAssets="All" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
+    <PackageReference Include="System.Reflection.Metadata" Version="1.8.0" />
+    <PackageReference Include="T4.Build" Version="0.2.0" PrivateAssets="All" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <None Include="AtomicFunctions.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>AtomicFunctions.tt</DependentUpon>
-        </None>
-        <None Include="Backends\PTX\PTXIntrinsics.Generated.cs">
-          <DesignTime>True</DesignTime>
-          <AutoGen>True</AutoGen>
-          <DependentUpon>PTXIntrinsics.Generated.tt</DependentUpon>
-        </None>
-        <None Include="Frontend\Intrinsic\RemappedIntrinsics.Generated.cs">
-          <DesignTime>True</DesignTime>
-          <AutoGen>True</AutoGen>
-          <DependentUpon>RemappedIntrinsics.Generated.tt</DependentUpon>
-        </None>
-        <None Include="IndexTypes.cs">
-          <DesignTime>True</DesignTime>
-          <AutoGen>True</AutoGen>
-          <DependentUpon>IndexTypes.tt</DependentUpon>
-        </None>
-        <None Include="Interop.Generated.cs">
-          <DesignTime>True</DesignTime>
-          <AutoGen>True</AutoGen>
-          <DependentUpon>Interop.Generated.tt</DependentUpon>
-        </None>
-        <None Include="IntrinsicMath.CPUOnly.cs">
-          <DesignTime>True</DesignTime>
-          <AutoGen>True</AutoGen>
-          <DependentUpon>IntrinsicMath.CPUOnly.tt</DependentUpon>
-        </None>
-        <None Include="HalfConversion.cs">
-          <DesignTime>True</DesignTime>
-          <AutoGen>True</AutoGen>
-          <DependentUpon>HalfConversion.tt</DependentUpon>
-        </None>
-        <None Include="IR\Intrinsics\IntrinsicMatchers.cs">
-          <DesignTime>True</DesignTime>
-          <AutoGen>True</AutoGen>
-          <DependentUpon>IntrinsicMatchers.tt</DependentUpon>
-        </None>
-        <None Include="Runtime\Cuda\CudaAsm.Generated.cs">
-          <DesignTime>True</DesignTime>
-          <AutoGen>True</AutoGen>
-          <DependentUpon>CudaAsm.Generated.tt</DependentUpon>
-        </None>
-        <None Include="Runtime\PageLockedArrays.Generated.cs">
-          <DesignTime>True</DesignTime>
-          <AutoGen>True</AutoGen>
-          <DependentUpon>PageLockedArrays.Generated.tt</DependentUpon>
-        </None>
-        <None Include="Static\ArithmeticEnums.cs">
-          <DesignTime>True</DesignTime>
-          <AutoGen>True</AutoGen>
-          <DependentUpon>ArithmeticEnums.tt</DependentUpon>
-        </None>
-        <None Include="Runtime\KernelLoaders.cs">
-          <DesignTime>True</DesignTime>
-          <AutoGen>True</AutoGen>
-          <DependentUpon>KernelLoaders.tt</DependentUpon>
-        </None>
-        <None Include="Runtime\MemoryBuffers.cs">
-          <DesignTime>True</DesignTime>
-          <AutoGen>True</AutoGen>
-          <DependentUpon>MemoryBuffers.tt</DependentUpon>
-        </None>
-        <None Include="IR\Construction\CompareOperations.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>CompareOperations.tt</DependentUpon>
-        </None>
-        <None Include="IR\Construction\ArithmeticOperations.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>ArithmeticOperations.tt</DependentUpon>
-        </None>
-        <None Include="Resources\ErrorMessages.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>ErrorMessages.resx</DependentUpon>
-        </None>
-        <None Include="Resources\RuntimeErrorMessages.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>RuntimeErrorMessages.resx</DependentUpon>
-        </None>
-        <None Include="Static\DllImports.cs">
-          <DesignTime>True</DesignTime>
-          <AutoGen>True</AutoGen>
-          <DependentUpon>DllImports.tt</DependentUpon>
-        </None>
-        <None Include="Util\DataBlocks.cs">
-          <DesignTime>True</DesignTime>
-          <AutoGen>True</AutoGen>
-          <DependentUpon>DataBlocks.tt</DependentUpon>
-        </None>
-        <None Include="Util\PrimitiveDataBlocks.cs">
-          <DesignTime>True</DesignTime>
-          <AutoGen>True</AutoGen>
-          <DependentUpon>PrimitiveDataBlocks.tt</DependentUpon>
-        </None>
-    </ItemGroup>
+  <ItemGroup>
+    <None Include="AtomicFunctions.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>AtomicFunctions.tt</DependentUpon>
+    </None>
+    <None Include="Backends\PTX\PTXIntrinsics.Generated.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>PTXIntrinsics.Generated.tt</DependentUpon>
+    </None>
+    <None Include="Frontend\Intrinsic\RemappedIntrinsics.Generated.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>RemappedIntrinsics.Generated.tt</DependentUpon>
+    </None>
+    <None Include="IndexTypes.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>IndexTypes.tt</DependentUpon>
+    </None>
+    <None Include="Interop.Generated.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Interop.Generated.tt</DependentUpon>
+    </None>
+    <None Include="IntrinsicMath.CPUOnly.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>IntrinsicMath.CPUOnly.tt</DependentUpon>
+    </None>
+    <None Include="HalfConversion.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>HalfConversion.tt</DependentUpon>
+    </None>
+    <None Include="IR\Intrinsics\IntrinsicMatchers.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>IntrinsicMatchers.tt</DependentUpon>
+    </None>
+    <None Include="Runtime\Cuda\CudaAsm.Generated.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>CudaAsm.Generated.tt</DependentUpon>
+    </None>
+    <None Include="Runtime\PageLockedArrays.Generated.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>PageLockedArrays.Generated.tt</DependentUpon>
+    </None>
+    <None Include="Static\ArithmeticEnums.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ArithmeticEnums.tt</DependentUpon>
+    </None>
+    <None Include="Runtime\KernelLoaders.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>KernelLoaders.tt</DependentUpon>
+    </None>
+    <None Include="Runtime\MemoryBuffers.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>MemoryBuffers.tt</DependentUpon>
+    </None>
+    <None Include="IR\Construction\CompareOperations.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>CompareOperations.tt</DependentUpon>
+    </None>
+    <None Include="IR\Construction\ArithmeticOperations.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ArithmeticOperations.tt</DependentUpon>
+    </None>
+    <None Include="Resources\ErrorMessages.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ErrorMessages.resx</DependentUpon>
+    </None>
+    <None Include="Resources\RuntimeErrorMessages.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>RuntimeErrorMessages.resx</DependentUpon>
+    </None>
+    <None Include="Static\DllImports.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>DllImports.tt</DependentUpon>
+    </None>
+    <None Include="Util\DataBlocks.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>DataBlocks.tt</DependentUpon>
+    </None>
+    <None Include="Util\PrimitiveDataBlocks.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>PrimitiveDataBlocks.tt</DependentUpon>
+    </None>
+  </ItemGroup>
 
-    <ItemGroup>
-        <Compile Update="Memory.cs">
-          <DesignTime>True</DesignTime>
-          <AutoGen>True</AutoGen>
-          <DependentUpon>Memory.tt</DependentUpon>
-        </Compile>
-        <Compile Update="Runtime\ArrayViews.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>ArrayViews.tt</DependentUpon>
-        </Compile>
-        <Compile Update="Runtime\ArrayViewExtensions.Generated.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>ArrayViewExtensions.Generated.tt</DependentUpon>
-        </Compile>
-        <Compile Update="AtomicFunctions.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>AtomicFunctions.tt</DependentUpon>
-        </Compile>
-        <Compile Update="Backends\PTX\PTXIntrinsics.Generated.cs">
-          <DesignTime>True</DesignTime>
-          <AutoGen>True</AutoGen>
-          <DependentUpon>PTXIntrinsics.Generated.tt</DependentUpon>
-        </Compile>
-        <Compile Update="Frontend\Intrinsic\RemappedIntrinsics.Generated.cs">
-          <DesignTime>True</DesignTime>
-          <AutoGen>True</AutoGen>
-          <DependentUpon>RemappedIntrinsics.Generated.tt</DependentUpon>
-        </Compile>
-        <Compile Update="IndexTypes.cs">
-          <DesignTime>True</DesignTime>
-          <AutoGen>True</AutoGen>
-          <DependentUpon>IndexTypes.tt</DependentUpon>
-        </Compile>
-        <Compile Update="Interop.Generated.cs">
-          <DesignTime>True</DesignTime>
-          <AutoGen>True</AutoGen>
-          <DependentUpon>Interop.Generated.tt</DependentUpon>
-        </Compile>
-        <Compile Update="IntrinsicMath.CPUOnly.cs">
-          <DesignTime>True</DesignTime>
-          <AutoGen>True</AutoGen>
-          <DependentUpon>IntrinsicMath.CPUOnly.tt</DependentUpon>
-        </Compile>
-        <Compile Update="HalfConversion.cs">
-          <DesignTime>True</DesignTime>
-          <AutoGen>True</AutoGen>
-          <DependentUpon>HalfConversion.tt</DependentUpon>
-        </Compile>
-        <Compile Update="IR\Intrinsics\IntrinsicMatchers.cs">
-          <DesignTime>True</DesignTime>
-          <AutoGen>True</AutoGen>
-          <DependentUpon>IntrinsicMatchers.tt</DependentUpon>
-        </Compile>
-        <Compile Update="IR\Types\ValueTuples.cs">
-          <DesignTime>True</DesignTime>
-          <AutoGen>True</AutoGen>
-          <DependentUpon>ValueTuples.tt</DependentUpon>
-        </Compile>
-        <Compile Update="Runtime\Cuda\CudaAsm.Generated.cs">
-          <DesignTime>True</DesignTime>
-          <AutoGen>True</AutoGen>
-          <DependentUpon>CudaAsm.Generated.tt</DependentUpon>
-        </Compile>
-        <Compile Update="Runtime\MemoryBuffers.cs">
-          <DesignTime>True</DesignTime>
-          <AutoGen>True</AutoGen>
-          <DependentUpon>MemoryBuffers.tt</DependentUpon>
-        </Compile>
-        <Compile Update="Runtime\PageLockedArrays.Generated.cs">
-          <DesignTime>True</DesignTime>
-          <AutoGen>True</AutoGen>
-          <DependentUpon>PageLockedArrays.Generated.tt</DependentUpon>
-        </Compile>
-        <Compile Update="Static\ArithmeticEnums.cs">
-          <DesignTime>True</DesignTime>
-          <AutoGen>True</AutoGen>
-          <DependentUpon>ArithmeticEnums.tt</DependentUpon>
-        </Compile>
-        <Compile Update="Runtime\KernelLoaders.cs">
-          <DesignTime>True</DesignTime>
-          <AutoGen>True</AutoGen>
-          <DependentUpon>KernelLoaders.tt</DependentUpon>
-        </Compile>
-        <Compile Update="IR\Construction\CompareOperations.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>CompareOperations.tt</DependentUpon>
-        </Compile>
-        <Compile Update="IR\Construction\ArithmeticOperations.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>ArithmeticOperations.tt</DependentUpon>
-        </Compile>
-        <Compile Update="Resources\ErrorMessages.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>ErrorMessages.resx</DependentUpon>
-        </Compile>
-        <Compile Update="Resources\RuntimeErrorMessages.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>RuntimeErrorMessages.resx</DependentUpon>
-        </Compile>
-        <Compile Update="Static\CapabilityContext.cs">
-          <DesignTime>True</DesignTime>
-          <AutoGen>True</AutoGen>
-          <DependentUpon>CapabilityContext.tt</DependentUpon>
-        </Compile>
-        <Compile Update="Static\DllImports.cs">
-          <DesignTime>True</DesignTime>
-          <AutoGen>True</AutoGen>
-          <DependentUpon>DllImports.tt</DependentUpon>
-        </Compile>
-        <Compile Update="StrideTypes.cs">
-          <DesignTime>True</DesignTime>
-          <AutoGen>True</AutoGen>
-          <DependentUpon>StrideTypes.tt</DependentUpon>
-        </Compile>
-        <Compile Update="Util\DataBlocks.cs">
-          <DesignTime>True</DesignTime>
-          <AutoGen>True</AutoGen>
-          <DependentUpon>DataBlocks.tt</DependentUpon>
-        </Compile>
-        <Compile Update="Util\PrimitiveDataBlocks.cs">
-          <DesignTime>True</DesignTime>
-          <AutoGen>True</AutoGen>
-          <DependentUpon>PrimitiveDataBlocks.tt</DependentUpon>
-        </Compile>
-    </ItemGroup>
-    <ItemGroup>
-        <None Update="Runtime\ArrayViews.tt">
-            <Generator>TextTemplatingFileGenerator</Generator>
-            <LastGenOutput>ArrayViews.cs</LastGenOutput>
-        </None>
-        <None Update="Runtime\ArrayViewExtensions.Generated.tt">
-            <Generator>TextTemplatingFileGenerator</Generator>
-            <LastGenOutput>ArrayViewExtensions.Generated.cs</LastGenOutput>
-        </None>
-        <None Update="AtomicFunctions.tt">
-            <Generator>TextTemplatingFileGenerator</Generator>
-            <LastGenOutput>AtomicFunctions.cs</LastGenOutput>
-        </None>
-        <None Update="Backends\PTX\PTXIntrinsics.Generated.tt">
-          <Generator>TextTemplatingFileGenerator</Generator>
-          <LastGenOutput>PTXIntrinsics.Generated.cs</LastGenOutput>
-        </None>
-        <None Update="Frontend\Intrinsic\RemappedIntrinsics.Generated.tt">
-          <Generator>TextTemplatingFileGenerator</Generator>
-          <LastGenOutput>RemappedIntrinsics.Generated.cs</LastGenOutput>
-        </None>
-        <None Update="IndexTypes.tt">
-          <Generator>TextTemplatingFileGenerator</Generator>
-          <LastGenOutput>IndexTypes.cs</LastGenOutput>
-        </None>
-        <None Update="Interop.Generated.tt">
-          <Generator>TextTemplatingFileGenerator</Generator>
-          <LastGenOutput>Interop.Generated.cs</LastGenOutput>
-        </None>
-        <None Update="IntrinsicMath.CPUOnly.tt">
-          <Generator>TextTemplatingFileGenerator</Generator>
-          <LastGenOutput>IntrinsicMath.CPUOnly.cs</LastGenOutput>
-        </None>
-        <None Update="HalfConversion.tt">
-          <Generator>TextTemplatingFileGenerator</Generator>
-          <LastGenOutput>HalfConversion.cs</LastGenOutput>
-        </None>
-        <None Update="IR\Construction\CompareOperations.tt">
-            <Generator>TextTemplatingFileGenerator</Generator>
-            <LastGenOutput>CompareOperations.cs</LastGenOutput>
-        </None>
-        <None Update="IR\Construction\ArithmeticOperations.tt">
-            <Generator>TextTemplatingFileGenerator</Generator>
-            <LastGenOutput>ArithmeticOperations.cs</LastGenOutput>
-        </None>
-        <None Update="IR\Intrinsics\IntrinsicMatchers.tt">
-          <Generator>TextTemplatingFileGenerator</Generator>
-          <LastGenOutput>IntrinsicMatchers.cs</LastGenOutput>
-        </None>
-        <None Update="IR\Types\ValueTuples.tt">
-          <Generator>TextTemplatingFileGenerator</Generator>
-          <LastGenOutput>ValueTuples.cs</LastGenOutput>
-        </None>
-        <None Update="Runtime\Cuda\CudaAsm.Generated.tt">
-          <Generator>TextTemplatingFileGenerator</Generator>
-          <LastGenOutput>CudaAsm.Generated.cs</LastGenOutput>
-        </None>
-        <None Update="Runtime\ExchangeBufferExtensions.tt">
-          <Generator>TextTemplatingFileGenerator</Generator>
-          <LastGenOutput>ExchangeBufferExtensions.cs</LastGenOutput>
-        </None>
-        <None Update="Runtime\PageLockedArrays.Generated.tt">
-          <Generator>TextTemplatingFileGenerator</Generator>
-          <LastGenOutput>PageLockedArrays.Generated.cs</LastGenOutput>
-        </None>
-        <None Update="Static\ArithmeticEnums.tt">
-          <Generator>TextTemplatingFileGenerator</Generator>
-          <LastGenOutput>ArithmeticEnums.cs</LastGenOutput>
-        </None>
-        <None Update="Runtime\KernelLoaders.tt">
-          <Generator>TextTemplatingFileGenerator</Generator>
-          <LastGenOutput>KernelLoaders.cs</LastGenOutput>
-        </None>
-        <None Update="Runtime\MemoryBuffers.tt">
-          <Generator>TextTemplatingFileGenerator</Generator>
-          <LastGenOutput>MemoryBuffers.cs</LastGenOutput>
-        </None>
-        <None Update="Memory.tt">
-          <Generator>TextTemplatingFileGenerator</Generator>
-          <LastGenOutput>Memory.cs</LastGenOutput>
-        </None>
-        <None Update="Static\CapabilitiesImporter.ttinclude">
-          <Generator></Generator>
-        </None>
-        <None Update="Static\DllImports.tt">
-          <Generator>TextTemplatingFileGenerator</Generator>
-          <LastGenOutput>DllImports.cs</LastGenOutput>
-        </None>
-        <None Update="Static\CapabilityContext.tt">
-          <Generator>TextTemplatingFileGenerator</Generator>
-          <LastGenOutput>CapabilityContext.cs</LastGenOutput>
-        </None>
-        <None Update="StrideTypes.tt">
-          <Generator>TextTemplatingFileGenerator</Generator>
-          <LastGenOutput>StrideTypes.cs</LastGenOutput>
-        </None>
-        <None Update="Util\PrimitiveDataBlocks.tt">
-          <LastGenOutput>PrimitiveDataBlocks.cs</LastGenOutput>
-          <Generator>TextTemplatingFileGenerator</Generator>
-        </None>
-        <None Update="Util\DataBlocks.tt">
-          <LastGenOutput>DataBlocks.cs</LastGenOutput>
-          <Generator>TextTemplatingFileGenerator</Generator>
-        </None>
-    </ItemGroup>
-    <ItemGroup>
-        <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
-    </ItemGroup>
-    <ItemGroup>
-        <EmbeddedResource Update="Resources\ErrorMessages.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>ErrorMessages.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="Resources\RuntimeErrorMessages.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>RuntimeErrorMessages.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-    </ItemGroup>
+  <ItemGroup>
+    <Compile Update="Memory.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Memory.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Runtime\ArrayViews.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ArrayViews.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Runtime\ArrayViewExtensions.Generated.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ArrayViewExtensions.Generated.tt</DependentUpon>
+    </Compile>
+    <Compile Update="AtomicFunctions.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>AtomicFunctions.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Backends\PTX\PTXIntrinsics.Generated.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>PTXIntrinsics.Generated.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Frontend\Intrinsic\RemappedIntrinsics.Generated.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>RemappedIntrinsics.Generated.tt</DependentUpon>
+    </Compile>
+    <Compile Update="IndexTypes.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>IndexTypes.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Interop.Generated.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Interop.Generated.tt</DependentUpon>
+    </Compile>
+    <Compile Update="IntrinsicMath.CPUOnly.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>IntrinsicMath.CPUOnly.tt</DependentUpon>
+    </Compile>
+    <Compile Update="HalfConversion.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>HalfConversion.tt</DependentUpon>
+    </Compile>
+    <Compile Update="IR\Intrinsics\IntrinsicMatchers.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>IntrinsicMatchers.tt</DependentUpon>
+    </Compile>
+    <Compile Update="IR\Types\ValueTuples.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ValueTuples.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Runtime\Cuda\CudaAsm.Generated.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>CudaAsm.Generated.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Runtime\MemoryBuffers.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>MemoryBuffers.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Runtime\PageLockedArrays.Generated.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>PageLockedArrays.Generated.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Static\ArithmeticEnums.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ArithmeticEnums.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Runtime\KernelLoaders.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>KernelLoaders.tt</DependentUpon>
+    </Compile>
+    <Compile Update="IR\Construction\CompareOperations.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>CompareOperations.tt</DependentUpon>
+    </Compile>
+    <Compile Update="IR\Construction\ArithmeticOperations.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ArithmeticOperations.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Resources\ErrorMessages.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ErrorMessages.resx</DependentUpon>
+    </Compile>
+    <Compile Update="Resources\RuntimeErrorMessages.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>RuntimeErrorMessages.resx</DependentUpon>
+    </Compile>
+    <Compile Update="Static\CapabilityContext.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>CapabilityContext.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Static\DllImports.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>DllImports.tt</DependentUpon>
+    </Compile>
+    <Compile Update="StrideTypes.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>StrideTypes.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Util\DataBlocks.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>DataBlocks.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Util\PrimitiveDataBlocks.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>PrimitiveDataBlocks.tt</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="Runtime\ArrayViews.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>ArrayViews.cs</LastGenOutput>
+    </None>
+    <None Update="Runtime\ArrayViewExtensions.Generated.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>ArrayViewExtensions.Generated.cs</LastGenOutput>
+    </None>
+    <None Update="AtomicFunctions.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>AtomicFunctions.cs</LastGenOutput>
+    </None>
+    <None Update="Backends\PTX\PTXIntrinsics.Generated.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>PTXIntrinsics.Generated.cs</LastGenOutput>
+    </None>
+    <None Update="Frontend\Intrinsic\RemappedIntrinsics.Generated.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>RemappedIntrinsics.Generated.cs</LastGenOutput>
+    </None>
+    <None Update="IndexTypes.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>IndexTypes.cs</LastGenOutput>
+    </None>
+    <None Update="Interop.Generated.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>Interop.Generated.cs</LastGenOutput>
+    </None>
+    <None Update="IntrinsicMath.CPUOnly.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>IntrinsicMath.CPUOnly.cs</LastGenOutput>
+    </None>
+    <None Update="HalfConversion.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>HalfConversion.cs</LastGenOutput>
+    </None>
+    <None Update="IR\Construction\CompareOperations.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>CompareOperations.cs</LastGenOutput>
+    </None>
+    <None Update="IR\Construction\ArithmeticOperations.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>ArithmeticOperations.cs</LastGenOutput>
+    </None>
+    <None Update="IR\Intrinsics\IntrinsicMatchers.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>IntrinsicMatchers.cs</LastGenOutput>
+    </None>
+    <None Update="IR\Types\ValueTuples.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>ValueTuples.cs</LastGenOutput>
+    </None>
+    <None Update="Runtime\Cuda\CudaAsm.Generated.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>CudaAsm.Generated.cs</LastGenOutput>
+    </None>
+    <None Update="Runtime\ExchangeBufferExtensions.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>ExchangeBufferExtensions.cs</LastGenOutput>
+    </None>
+    <None Update="Runtime\PageLockedArrays.Generated.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>PageLockedArrays.Generated.cs</LastGenOutput>
+    </None>
+    <None Update="Static\ArithmeticEnums.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>ArithmeticEnums.cs</LastGenOutput>
+    </None>
+    <None Update="Runtime\KernelLoaders.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>KernelLoaders.cs</LastGenOutput>
+    </None>
+    <None Update="Runtime\MemoryBuffers.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>MemoryBuffers.cs</LastGenOutput>
+    </None>
+    <None Update="Memory.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>Memory.cs</LastGenOutput>
+    </None>
+    <None Update="Static\CapabilitiesImporter.ttinclude">
+      <Generator></Generator>
+    </None>
+    <None Update="Static\DllImports.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>DllImports.cs</LastGenOutput>
+    </None>
+    <None Update="Static\CapabilityContext.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>CapabilityContext.cs</LastGenOutput>
+    </None>
+    <None Update="StrideTypes.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>StrideTypes.cs</LastGenOutput>
+    </None>
+    <None Update="Util\PrimitiveDataBlocks.tt">
+      <LastGenOutput>PrimitiveDataBlocks.cs</LastGenOutput>
+      <Generator>TextTemplatingFileGenerator</Generator>
+    </None>
+    <None Update="Util\DataBlocks.tt">
+      <LastGenOutput>DataBlocks.cs</LastGenOutput>
+      <Generator>TextTemplatingFileGenerator</Generator>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Update="Resources\ErrorMessages.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>ErrorMessages.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Resources\RuntimeErrorMessages.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>RuntimeErrorMessages.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
 
-    <Import Project="Properties\ILGPU.nuspec.targets" />
-    <Import Project="Properties\ILGPU.CheckStyles.targets" />
+  <Import Project="Properties\ILGPU.nuspec.targets" />
+  <Import Project="Properties\ILGPU.CheckStyles.targets" />
 </Project>

--- a/Src/ILGPU/ILGPU.csproj
+++ b/Src/ILGPU/ILGPU.csproj
@@ -1,10 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net47;netstandard2.1</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Unix'">netstandard2.1</TargetFrameworks>
-    <OutputPath>../../Bin/$(Configuration)/</OutputPath>
-    <DocumentationFile>../../Bin/$(Configuration)/ILGPU.xml</DocumentationFile>
-    <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Channel)' == 'experimental'">
@@ -12,13 +10,22 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <VersionPrefix>1.0.0-beta3</VersionPrefix>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <FileVersion>1.0.0.0</FileVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NeutralLanguage>en-US</NeutralLanguage>
     <!-- CAUTION: ILGPU supports a limited subset only - due to the .Net 4.7 backwards compatibility -->
     <LangVersion>8.0</LangVersion>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.0.0.0</FileVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputPath>../../Bin/$(Configuration)/</OutputPath>
+    <DocumentationFile>../../Bin/$(Configuration)/ILGPU.xml</DocumentationFile>
+    <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net47|AnyCPU'">

--- a/Src/ILGPU/IR/Construction/LanguageValues.cs
+++ b/Src/ILGPU/IR/Construction/LanguageValues.cs
@@ -10,7 +10,6 @@
 // ---------------------------------------------------------------------------------------
 
 using ILGPU.IR.Values;
-using ILGPU.Runtime;
 using FormatArray = System.Collections.Immutable.ImmutableArray<
     ILGPU.Util.FormatString.FormatExpression>;
 using ValueList = ILGPU.Util.InlineList<ILGPU.IR.Values.ValueReference>;

--- a/Src/ILGPU/IR/Construction/Structures.cs
+++ b/Src/ILGPU/IR/Construction/Structures.cs
@@ -17,7 +17,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using ValueList = ILGPU.Util.InlineList<ILGPU.IR.Values.ValueReference>;
 

--- a/Src/ILGPU/IR/Construction/Terminators.cs
+++ b/Src/ILGPU/IR/Construction/Terminators.cs
@@ -177,6 +177,6 @@ namespace ILGPU.IR.Construction
             ref BlockList targets) =>
             CreateTerminator(new BuilderTerminator(
                 GetInitializer(Location.Unknown),
-                ref targets)) as BuilderTerminator;
+                ref targets));
     }
 }

--- a/Src/ILGPU/IR/Transformations/SSAConstruction.cs
+++ b/Src/ILGPU/IR/Transformations/SSAConstruction.cs
@@ -666,7 +666,8 @@ namespace ILGPU.IR.Transformations
             /// </summary>
             private Dictionary<
                 Value,
-                (int ArrayLength, int NumElementFields)> ArrayData { get; }
+                (int ArrayLength, int NumElementFields)> ArrayData
+            { get; }
 
             /// <summary>
             /// Returns true if the given alloca should be converted.
@@ -746,7 +747,7 @@ namespace ILGPU.IR.Transformations
 
             // Prepare the internal data structure to refer to this array
             var initFieldRef = new FieldRef(alloca, new FieldSpan(0, numStructFields));
-            var arrayData =  new ArrayData(
+            var arrayData = new ArrayData(
                 arrayLength,
                 numFields,
                 new ConstructionFieldRef(initFieldRef));

--- a/Src/ILGPU/IR/Values/LanguageValues.cs
+++ b/Src/ILGPU/IR/Values/LanguageValues.cs
@@ -11,7 +11,6 @@
 
 using ILGPU.IR.Construction;
 using ILGPU.IR.Types;
-using ILGPU.Runtime;
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;

--- a/Src/ILGPU/IndexTypes.tt
+++ b/Src/ILGPU/IndexTypes.tt
@@ -362,14 +362,12 @@ namespace ILGPU
         /// Returns the hash code of this index.
         /// </summary>
         /// <returns>The hash code of this index.</returns>
-        public readonly override int GetHashCode()
-        {
+        public readonly override int GetHashCode() =>
 <# if (dimension == 1) { #>
-            return <#= def.Expression(", ", p => $"{p}") #>.GetHashCode();
+            <#= def.Expression(", ", p => $"{p}") #>.GetHashCode();
 <# } else { #>
-            return (<#= def.Expression(", ", p => $"{p}") #>).GetHashCode();
+            (<#= def.Expression(", ", p => $"{p}") #>).GetHashCode();
 <# } #>
-        }
 
         /// <summary>
         /// Returns the string representation of this index.

--- a/Src/ILGPU/InvalidKernelOperationException.cs
+++ b/Src/ILGPU/InvalidKernelOperationException.cs
@@ -11,7 +11,6 @@
 
 using ILGPU.Resources;
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 
 namespace ILGPU
@@ -20,9 +19,6 @@ namespace ILGPU
     /// An exception that is thrown when an ILGPU kernel method is called from the
     /// managed CPU side instead of a kernel.
     /// </summary>
-    [SuppressMessage(
-        "Microsoft.Design",
-        "CA1032:ImplementStandardExceptionConstructors")]
     [Serializable]
     public sealed class InvalidKernelOperationException : InvalidOperationException
     {
@@ -31,6 +27,16 @@ namespace ILGPU
         /// </summary>
         public InvalidKernelOperationException()
             : base(ErrorMessages.InvalidKernelOperation)
+        { }
+
+        /// <summary cref="Exception(string)"/>
+        public InvalidKernelOperationException(string message)
+            : base(message)
+        { }
+
+        /// <summary cref="Exception(string, Exception)"/>
+        public InvalidKernelOperationException(string message, Exception innerException)
+            : base(message, innerException)
         { }
 
         private InvalidKernelOperationException(

--- a/Src/ILGPU/Runtime/Accelerator.cs
+++ b/Src/ILGPU/Runtime/Accelerator.cs
@@ -15,7 +15,6 @@ using ILGPU.Resources;
 using ILGPU.Util;
 using System;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading;
 

--- a/Src/ILGPU/Runtime/Kernel.cs
+++ b/Src/ILGPU/Runtime/Kernel.cs
@@ -327,7 +327,7 @@ namespace ILGPU.Runtime
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public TDelegate CreateLauncherDelegate<TDelegate>()
             where TDelegate : Delegate =>
-            Launcher.CreateDelegate(typeof(TDelegate), this) as object as TDelegate;
+            Launcher.CreateDelegate(typeof(TDelegate), this) as TDelegate;
 
         /// <summary>
         /// Invokes the associated launcher via reflection.

--- a/Src/ILGPU/Runtime/PeerAccess.cs
+++ b/Src/ILGPU/Runtime/PeerAccess.cs
@@ -12,7 +12,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 
 namespace ILGPU.Runtime
 {

--- a/Src/ILGPU/Static/DllImports.tt
+++ b/Src/ILGPU/Static/DllImports.tt
@@ -25,6 +25,7 @@ using ILGPU.Resources;
 using System;
 using System.Runtime.InteropServices;
 
+#pragma warning disable CA5393 // Do not use unsafe DllImportSearchPath value
 #pragma warning disable IDE1006 // Naming
 
 <# foreach (var importFile in importFiles) { #>
@@ -164,4 +165,5 @@ namespace <#= imports.Namespace #>
 
 <# } #>
 
+#pragma warning restore CA5393 // Do not use unsafe DllImportSearchPath value
 #pragma warning restore IDE1006 // Naming


### PR DESCRIPTION
Ran `Code Cleanup` in VS2019 and fixed warnings when compiling with `net5.0`.

Updated indentation of ILGPU.csproj, since it is the only one using a different indentation. Also did some minor updates to the csproj files e.g. arranged the version number elements into their own Property Group.

Sealed all exception classes, and added standard Exception constructors.