### PR TITLE
Added missing struct type constraints.

### DIFF
--- a/Src/ILGPU/IR/Analyses/ControlFlowDirection.cs
+++ b/Src/ILGPU/IR/Analyses/ControlFlowDirection.cs
@@ -52,7 +52,7 @@ namespace ILGPU.IR.Analyses.ControlFlowDirection
         /// <returns>The entry block.</returns>
         BasicBlock GetEntryBlock<TSource, TDirection>(in TSource source)
             where TSource : IControlFlowAnalysisSource<TDirection>
-            where TDirection : IControlFlowDirection;
+            where TDirection : struct, IControlFlowDirection;
     }
 
     /// <summary>
@@ -72,7 +72,7 @@ namespace ILGPU.IR.Analyses.ControlFlowDirection
         public readonly BasicBlock GetEntryBlock<TSource, TDirection>(
             in TSource source)
             where TSource : IControlFlowAnalysisSource<TDirection>
-            where TDirection : IControlFlowDirection
+            where TDirection : struct, IControlFlowDirection
         {
             TDirection direction = default;
             return direction.IsForwards ? source.EntryBlock : source.FindExitBlock();
@@ -97,7 +97,7 @@ namespace ILGPU.IR.Analyses.ControlFlowDirection
         public readonly BasicBlock GetEntryBlock<TSource, TDirection>(
             in TSource source)
             where TSource : IControlFlowAnalysisSource<TDirection>
-            where TDirection : IControlFlowDirection
+            where TDirection : struct, IControlFlowDirection
         {
             TDirection direction = default;
             return direction.IsForwards ? source.FindExitBlock() : source.EntryBlock;

--- a/Src/ILGPU/IR/BasicBlock.cs
+++ b/Src/ILGPU/IR/BasicBlock.cs
@@ -395,7 +395,7 @@ namespace ILGPU.IR
         /// <typeparam name="TDirection">The control-flow direction.</typeparam>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ReadOnlySpan<BasicBlock> GetPredecessors<TDirection>()
-            where TDirection : IControlFlowDirection
+            where TDirection : struct, IControlFlowDirection
         {
             AssertNoControlFlowUpdate();
 
@@ -409,7 +409,7 @@ namespace ILGPU.IR
         /// <typeparam name="TDirection">The control-flow direction.</typeparam>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ReadOnlySpan<BasicBlock> GetSuccessors<TDirection>()
-            where TDirection : IControlFlowDirection
+            where TDirection : struct, IControlFlowDirection
         {
             AssertNoControlFlowUpdate();
 

--- a/Src/ILGPU/IR/Construction/IRRebuilder.cs
+++ b/Src/ILGPU/IR/Construction/IRRebuilder.cs
@@ -150,7 +150,7 @@ namespace ILGPU.IR.Construction
             Method.ParameterMapping parameterMapping,
             Method.MethodMapping methodRemapping,
             in BlockCollection blocks)
-            where TMode : IMode =>
+            where TMode : struct, IMode =>
             Create<TMode, IdentityRemapper>(
                 builder,
                 parameterMapping,
@@ -175,7 +175,7 @@ namespace ILGPU.IR.Construction
             Method.MethodMapping methodRemapping,
             in BlockCollection blocks,
             in TRemapper remapper)
-            where TMode : IMode
+            where TMode : struct, IMode
             where TRemapper : struct, IDirectTargetRemapper
         {
             // Init mapping

--- a/Src/ILGPU/IR/Construction/Method.Builder.cs
+++ b/Src/ILGPU/IR/Construction/Method.Builder.cs
@@ -346,7 +346,7 @@ namespace ILGPU.IR
             public IRRebuilder CreateRebuilder<TMode>(
                 ParameterMapping parameterMapping,
                 in BasicBlockCollection<ReversePostOrder, Forwards> blocks)
-                where TMode : IRRebuilder.IMode =>
+                where TMode : struct, IRRebuilder.IMode =>
                 CreateRebuilder<TMode>(parameterMapping, default, blocks);
 
             /// <summary>
@@ -363,7 +363,7 @@ namespace ILGPU.IR
                 ParameterMapping parameterMapping,
                 MethodMapping methodMapping,
                 in BasicBlockCollection<ReversePostOrder, Forwards> blocks)
-                where TMode : IRRebuilder.IMode =>
+                where TMode : struct, IRRebuilder.IMode =>
                 IRRebuilder.Create<TMode>(
                     this,
                     parameterMapping,

--- a/Src/ILGPU/IR/Transformations/LowerStructures.cs
+++ b/Src/ILGPU/IR/Transformations/LowerStructures.cs
@@ -85,7 +85,7 @@ namespace ILGPU.IR.Transformations
             TValue value)
             where TValue : ThreadValue
             where TLoweringImplementation :
-                LowerThreadIntrinsics.ILoweringImplementation<TValue>
+                struct, LowerThreadIntrinsics.ILoweringImplementation<TValue>
         {
             // We require a single input
             var variable = AssembleStructure(


### PR DESCRIPTION
Fixed missing constraint for `IControlFlowDirection` and `LowerThreadIntrinsics.ILoweringImplementation` - other uses of these interfaces already include the `struct` type constraint.

Added constraint to `IRRebuilder.IMode` - all implementations are currently structs.

These instances were found in the initial investigation into enabling nullable references types.