### PR TITLE
Changes InvalidEntryPointIndexParameterOfWrongType to be more descriptive

### DIFF
--- a/Src/ILGPU/Resources/ErrorMessages.Designer.cs
+++ b/Src/ILGPU/Resources/ErrorMessages.Designer.cs
@@ -196,7 +196,7 @@ namespace ILGPU.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An entry point must receive a compatible index type as first parameter.
+        ///   Looks up a localized string similar to An implicitly grouped entry point must receive an int index type as first parameter, long indecies will not work..
         /// </summary>
         internal static string InvalidEntryPointIndexParameterOfWrongType {
             get {

--- a/Src/ILGPU/Resources/ErrorMessages.Designer.cs
+++ b/Src/ILGPU/Resources/ErrorMessages.Designer.cs
@@ -196,7 +196,7 @@ namespace ILGPU.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An implicitly grouped entry point must receive an int index type as first parameter, long indecies will not work..
+        ///   Looks up a localized string similar to An implicitly grouped entry point must receive an int index type as first parameter, long indices will not work..
         /// </summary>
         internal static string InvalidEntryPointIndexParameterOfWrongType {
             get {

--- a/Src/ILGPU/Resources/ErrorMessages.resx
+++ b/Src/ILGPU/Resources/ErrorMessages.resx
@@ -124,7 +124,7 @@
     <value>An entry point must receive at least one index parameter</value>
   </data>
   <data name="InvalidEntryPointIndexParameterOfWrongType" xml:space="preserve">
-    <value>An implicitly grouped entry point must receive an int index type as first parameter, long indecies will not work.</value>
+    <value>An implicitly grouped entry point must receive an int index type as first parameter, long indices will not work.</value>
   </data>
   <data name="InvalidEntryPointInstanceKernelMethod" xml:space="preserve">
     <value>Only static methods and non-capturing lambdas are supported at the moment</value>

--- a/Src/ILGPU/Resources/ErrorMessages.resx
+++ b/Src/ILGPU/Resources/ErrorMessages.resx
@@ -124,7 +124,7 @@
     <value>An entry point must receive at least one index parameter</value>
   </data>
   <data name="InvalidEntryPointIndexParameterOfWrongType" xml:space="preserve">
-    <value>An implicitly grouped entry point must receive an int index type as first parameter, long indices will not work.</value>
+    <value>An implicitly grouped entry point must receive an int index type as first parameter, long indices are not supported.</value>
   </data>
   <data name="InvalidEntryPointInstanceKernelMethod" xml:space="preserve">
     <value>Only static methods and non-capturing lambdas are supported at the moment</value>

--- a/Src/ILGPU/Resources/ErrorMessages.resx
+++ b/Src/ILGPU/Resources/ErrorMessages.resx
@@ -124,7 +124,7 @@
     <value>An entry point must receive at least one index parameter</value>
   </data>
   <data name="InvalidEntryPointIndexParameterOfWrongType" xml:space="preserve">
-    <value>An entry point must receive a compatible index type as first parameter</value>
+    <value>An implicitly grouped entry point must receive an int index type as first parameter, long indecies will not work.</value>
   </data>
   <data name="InvalidEntryPointInstanceKernelMethod" xml:space="preserve">
     <value>Only static methods and non-capturing lambdas are supported at the moment</value>


### PR DESCRIPTION
`InvalidEntryPointIndexParameterOfWrongType` error did not help the user understand what was wrong and how to fix it, now it does!