### PR TITLE
Fixed invalid register/variable swaps.

### DIFF
--- a/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Views.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Views.cs
@@ -51,7 +51,6 @@ namespace ILGPU.Backends.OpenCL
                     // There is a specific cast operation
                     statement.AppendCommand(operation);
                     statement.BeginArguments();
-                    statement.Append(source);
                 }
                 else
                 {

--- a/Src/ILGPU/Backends/RegisterAllocator.cs
+++ b/Src/ILGPU/Backends/RegisterAllocator.cs
@@ -562,7 +562,7 @@ namespace ILGPU.Backends
         public void Free(Value node)
         {
             node.AssertNotNull(node);
-            FreeRecursive(registerLookup[node].Register);
+            Free(registerLookup[node].Register);
             registerLookup.Remove(node);
         }
 
@@ -570,7 +570,7 @@ namespace ILGPU.Backends
         /// Frees the given register recursively.
         /// </summary>
         /// <param name="register">The register to free.</param>
-        private void FreeRecursive(Register register)
+        public void Free(Register register)
         {
             switch (register)
             {
@@ -579,7 +579,7 @@ namespace ILGPU.Backends
                     break;
                 case CompoundRegister compoundRegister:
                     foreach (var child in compoundRegister.Children)
-                        FreeRecursive(child);
+                        Free(child);
                     break;
             }
         }


### PR DESCRIPTION
This PR fixes a critical problem in the current `OpenCL` and `PTX` backends. When swapping views inside loops and then accessing them, it could happen that the actual swap operations were not compiled correctly. Although the IR itself represented the operations in a legal way, the backends swapped the registers/variables involved without introducing temporary swap targets. This PR fixes this critical problem by introducing "Phi intermediate values". This concept allows us to reason about Phi values that need to be stored in temporary locations without overwriting their values.