### PR TITLE
Fixed constant folding when converting unsigned integers.

### DIFF
--- a/Src/ILGPU.Tests/ConvertIntOperations.Generated.tt
+++ b/Src/ILGPU.Tests/ConvertIntOperations.Generated.tt
@@ -54,6 +54,33 @@ namespace ILGPU.Tests
             Verify(b.View, reference);
         }
 
+        internal static void <#= kernelName #>_MaxValue(
+            Index1D index,
+            ArrayView1D<<#= targetType.Type #>, Stride1D.Dense> output)
+        {
+            unchecked
+            {
+                output[index] = (<#= targetType.Type #>)<#= type.Type #>.MaxValue;
+            }
+        }
+
+        [Fact]
+        [KernelMethod(nameof(<#= kernelName #>_MaxValue))]
+        public void <#= testName #>_MaxValue()
+        {
+            const int length = 32;
+            using var output = Accelerator.Allocate1D<<#= targetType.Type #>>(length);
+            Execute(length, output.View);
+
+            <#= targetType.Type #> result;
+            unchecked
+            {
+                result = (<#= targetType.Type #>)(<#= type.Type #>.MaxValue);
+            }
+            var reference = Enumerable.Repeat(result, length).ToArray();
+            Verify(output.View, reference);
+        }
+
 <#      } #>
 <# } #>
     }

--- a/Src/ILGPU/IR/Construction/Convert.cs
+++ b/Src/ILGPU/IR/Construction/Convert.cs
@@ -250,31 +250,29 @@ namespace ILGPU.IR.Construction
                                         location,
                                         Convert.ToDouble(value.Int64Value));
                             default:
-                                if (!isSourceUnsigned && !isTargetUnsigned)
+                                var rawValue = value.BasicValueType switch
                                 {
-                                    switch (value.BasicValueType)
-                                    {
-                                        case BasicValueType.Int8:
-                                            return CreatePrimitiveValue(
-                                                location,
-                                                targetBasicValueType,
-                                                value.Int8Value);
-                                        case BasicValueType.Int16:
-                                            return CreatePrimitiveValue(
-                                                location,
-                                                targetBasicValueType,
-                                                value.Int16Value);
-                                        case BasicValueType.Int32:
-                                            return CreatePrimitiveValue(
-                                                location,
-                                                targetBasicValueType,
-                                                value.Int32Value);
-                                    }
-                                }
+                                    BasicValueType.Int8 => isSourceUnsigned
+                                        ? (long)value.UInt8Value
+                                        : value.Int8Value,
+                                    BasicValueType.Int16 => isSourceUnsigned
+                                        ? (long)value.UInt16Value
+                                        : value.Int16Value,
+                                    BasicValueType.Int32 => isSourceUnsigned
+                                        ? (long)value.UInt32Value
+                                        : value.Int32Value,
+                                    BasicValueType.Int64 => isSourceUnsigned
+                                        ? (long)value.UInt64Value
+                                        : value.Int64Value,
+                                    _ => throw location.GetNotSupportedException(
+                                        ErrorMessages.NotSupportedConversion,
+                                        value.BasicValueType,
+                                        targetBasicValueType)
+                                };
                                 return CreatePrimitiveValue(
                                     location,
                                     targetBasicValueType,
-                                    value.RawValue);
+                                    rawValue);
                         }
                     case BasicValueType.Float16:
                         switch (targetBasicValueType)


### PR DESCRIPTION
Fixes #544.

The following new unit tests fail with the existing code:
- `ConvertOperation_UInt32_Int64_MaxValue`
- `ConvertOperation_UInt32_UInt64_MaxValue`

From the reproduction steps in #544, the C# compiler recognizes `0x0000000080000001` as `0x80000001`, which fits as UInt32. It then generates a cast from UInt32 to UInt64.

The issue occurs during generation of the IR for this constant value. The cast from UInt32 to UInt64 is incorrectly folded, and produces the constant `0xffffffff80000001`.
