### PR TITLE
Fix zero-length subview behaviour

### DIFF
--- a/Src/ILGPU.Tests/ArrayViews.cs
+++ b/Src/ILGPU.Tests/ArrayViews.cs
@@ -249,7 +249,8 @@ namespace ILGPU.Tests
         [Fact]
         public void ArrayViewZeroLengthSubView2D()
         {
-            void Check<TStride>(ArrayView2D<int, TStride> view) where TStride : struct, IStride2D
+            void Check<TStride>(ArrayView2D<int, TStride> view)
+                where TStride : struct, IStride2D
             {
                 var extents = new[]
                 {
@@ -278,7 +279,8 @@ namespace ILGPU.Tests
         [Fact]
         public void ArrayViewZeroLengthSubView3D()
         {
-            void Check<TStride>(ArrayView3D<int, TStride> view) where TStride : struct, IStride3D
+            void Check<TStride>(ArrayView3D<int, TStride> view)
+                where TStride : struct, IStride3D
             {
                 var extents = new[]
                 {

--- a/Src/ILGPU.Tests/ArrayViews.cs
+++ b/Src/ILGPU.Tests/ArrayViews.cs
@@ -231,7 +231,7 @@ namespace ILGPU.Tests
         }
 
         [Fact]
-        public void ArrayViewZeroLengthSubview1d()
+        public void ArrayViewZeroLengthSubView1D()
         {
             using var buffer = Accelerator.Allocate1D<int>(128);
 
@@ -247,7 +247,7 @@ namespace ILGPU.Tests
         }
 
         [Fact]
-        public void ArrayViewZeroLengthSubview2d()
+        public void ArrayViewZeroLengthSubView2D()
         {
             void Check<TStride>(ArrayView2D<int, TStride> view) where TStride : struct, IStride2D
             {
@@ -276,7 +276,7 @@ namespace ILGPU.Tests
         }
 
         [Fact]
-        public void ArrayViewZeroLengthSubview3d()
+        public void ArrayViewZeroLengthSubView3D()
         {
             void Check<TStride>(ArrayView3D<int, TStride> view) where TStride : struct, IStride3D
             {

--- a/Src/ILGPU.Tests/ArrayViews.cs
+++ b/Src/ILGPU.Tests/ArrayViews.cs
@@ -234,9 +234,16 @@ namespace ILGPU.Tests
         public void ArrayViewZeroLengthSubview1d()
         {
             using var buffer = Accelerator.Allocate1D<int>(128);
-            var zero = buffer.View.SubView(64, 0);
-            Assert.Equal(0, zero.Length);
-            Assert.Equal(0, zero.LengthInBytes);
+
+            var subView1 = buffer.View.SubView(64, 0);
+            Assert.Equal(0, subView1.Length);
+            Assert.Equal(0, subView1.LengthInBytes);
+            Assert.Equal(0, subView1.Extent.X);
+
+            var subView2 = buffer.View.AsGeneral().SubView(64, 0);
+            Assert.Equal(0, subView2.Length);
+            Assert.Equal(0, subView2.LengthInBytes);
+            Assert.Equal(0, subView2.Extent.X);
         }
 
         [Fact]

--- a/Src/ILGPU.Tests/ArrayViews.cs
+++ b/Src/ILGPU.Tests/ArrayViews.cs
@@ -230,6 +230,75 @@ namespace ILGPU.Tests
             Verify(buffer.View, expected);
         }
 
+        [Fact]
+        public void ArrayViewZeroLengthSubview1d()
+        {
+            using var buffer = Accelerator.Allocate1D<int>(128);
+            var zero = buffer.View.SubView(64, 0);
+            Assert.Equal(0, zero.Length);
+            Assert.Equal(0, zero.LengthInBytes);
+        }
+
+        [Fact]
+        public void ArrayViewZeroLengthSubview2d()
+        {
+            void Check<TStride>(ArrayView2D<int, TStride> view) where TStride : struct, IStride2D
+            {
+                var extents = new[]
+                {
+                    new Index2D(0, 2),
+                    new Index2D(2, 0),
+                };
+
+                foreach (var extent in extents)
+                {
+                    var subView = view.SubView((4, 4), extent);
+                    Assert.Equal(0, subView.Length);
+                    Assert.Equal(0, subView.LengthInBytes);
+                    Assert.Equal(extent.X, subView.Extent.X);
+                    Assert.Equal(extent.Y, subView.Extent.Y);
+                }
+            }
+
+            using var buff1 = Accelerator.Allocate2DDenseY<int>((10, 10));
+            using var buff2 = Accelerator.Allocate2DDenseX<int>((10, 10));
+            Check<Stride2D.DenseY>(buff1.View);
+            Check<Stride2D.General>(buff1.View.AsGeneral());
+            Check<Stride2D.DenseX>(buff2.View);
+            Check<Stride2D.General>(buff2.View.AsGeneral());
+        }
+
+        [Fact]
+        public void ArrayViewZeroLengthSubview3d()
+        {
+            void Check<TStride>(ArrayView3D<int, TStride> view) where TStride : struct, IStride3D
+            {
+                var extents = new[]
+                {
+                    new Index3D(0, 2, 2),
+                    new Index3D(2, 0, 2),
+                    new Index3D(2, 2, 0),
+                };
+
+                foreach (var extent in extents)
+                {
+                    var subView = view.SubView((4, 4, 4), extent);
+                    Assert.Equal(0, subView.Length);
+                    Assert.Equal(0, subView.LengthInBytes);
+                    Assert.Equal(extent.X, subView.Extent.X);
+                    Assert.Equal(extent.Y, subView.Extent.Y);
+                    Assert.Equal(extent.Z, subView.Extent.Z);
+                }
+            }
+
+            using var buff1 = Accelerator.Allocate3DDenseXY<int>((10, 10, 10));
+            using var buff2 = Accelerator.Allocate3DDenseZY<int>((10, 10, 10));
+            Check<Stride3D.DenseXY>(buff1.View);
+            Check<Stride3D.General>(buff1.View.AsGeneral());
+            Check<Stride3D.DenseZY>(buff2.View);
+            Check<Stride3D.General>(buff2.View.AsGeneral());
+        }
+
         internal static void ArrayViewGetSubViewKernel(
             Index1D index,
             ArrayView1D<int, Stride1D.Dense> data,

--- a/Src/ILGPU/Stride.cs
+++ b/Src/ILGPU/Stride.cs
@@ -318,8 +318,14 @@ namespace ILGPU
             /// <param name="extent">The extent to allocate.</param>
             /// <returns>The 32-bit length of a required allocation.</returns>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public readonly int ComputeBufferLength(Index2D extent) =>
-                ComputeElementIndex(extent - Index2D.One) + 1;
+            public readonly int ComputeBufferLength(Index2D extent)
+            {
+                if (extent.X == 0 || extent.Y == 0)
+                {
+                    return 0;
+                }
+                return ComputeElementIndex(extent - Index2D.One) + 1;
+            }
 
             /// <summary>
             /// Computes the 64-bit length of a required allocation.
@@ -327,8 +333,14 @@ namespace ILGPU
             /// <param name="extent">The extent to allocate.</param>
             /// <returns>The 64-bit length of a required allocation.</returns>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public readonly long ComputeBufferLength(LongIndex2D extent) =>
-                ComputeElementIndex(extent - LongIndex2D.One) + 1L;
+            public readonly long ComputeBufferLength(LongIndex2D extent)
+            {
+                if (extent.X == 0 || extent.Y == 0)
+                {
+                    return 0;
+                }
+                return ComputeElementIndex(extent - LongIndex2D.One) + 1L;
+            }
 
             /// <summary>
             /// Computes a new extent and stride based on the given cast context.
@@ -445,8 +457,14 @@ namespace ILGPU
             /// <returns>The 32-bit length of a required allocation.</returns>
             /// <remarks>This method is not supported on accelerators.</remarks>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public readonly int ComputeBufferLength(Index2D extent) =>
-                Stride2D.ComputeBufferLength(this, extent);
+            public readonly int ComputeBufferLength(Index2D extent)
+            {
+                if (extent.X == 0 || extent.Y == 0)
+                {
+                    return 0;
+                }
+                return Stride2D.ComputeBufferLength(this, extent);
+            }
 
             /// <summary>
             /// Computes the 64-bit length of a required allocation.
@@ -455,8 +473,15 @@ namespace ILGPU
             /// <returns>The 64-bit length of a required allocation.</returns>
             /// <remarks>This method is not supported on accelerators.</remarks>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public readonly long ComputeBufferLength(LongIndex2D extent) =>
-                Stride2D.ComputeBufferLength(this, extent);
+            public readonly long ComputeBufferLength(LongIndex2D extent)
+            {
+                if (extent.X == 0 || extent.Y == 0)
+                {
+                    return 0;
+                }
+
+                return Stride2D.ComputeBufferLength(this, extent);
+            }
 
             /// <summary>
             /// Computes a new extent and stride based on the given cast context.
@@ -586,8 +611,14 @@ namespace ILGPU
             /// <returns>The 3264-bit length of a required allocation.</returns>
             /// <remarks>This method is not supported on accelerators.</remarks>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public readonly int ComputeBufferLength(Index3D extent) =>
-                Stride3D.ComputeBufferLength(this, extent);
+            public readonly int ComputeBufferLength(Index3D extent)
+            {
+                if (extent.X == 0 || extent.Y == 0 || extent.Z == 0)
+                {
+                    return 0;
+                }
+                return Stride3D.ComputeBufferLength(this, extent);
+            }
 
             /// <summary>
             /// Computes the 64-bit length of a required allocation.
@@ -596,8 +627,15 @@ namespace ILGPU
             /// <returns>The 64-bit length of a required allocation.</returns>
             /// <remarks>This method is not supported on accelerators.</remarks>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public readonly long ComputeBufferLength(LongIndex3D extent) =>
-                Stride3D.ComputeBufferLength(this, extent);
+            public readonly long ComputeBufferLength(LongIndex3D extent)
+            {
+                if (extent.X == 0 || extent.Y == 0 || extent.Z == 0)
+                {
+                    return 0;
+                }
+
+                return Stride3D.ComputeBufferLength(this, extent);
+            }
 
             /// <summary>
             /// Computes a new extent and stride based on the given cast context.
@@ -725,8 +763,14 @@ namespace ILGPU
             /// <returns>The 32-bit length of a required allocation.</returns>
             /// <remarks>This method is not supported on accelerators.</remarks>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public readonly int ComputeBufferLength(Index3D extent) =>
-                Stride3D.ComputeBufferLength(this, extent);
+            public readonly int ComputeBufferLength(Index3D extent)
+            {
+                if (extent.X == 0 || extent.Y == 0 || extent.Z == 0)
+                {
+                    return 0;
+                }
+                return Stride3D.ComputeBufferLength(this, extent);
+            }
 
             /// <summary>
             /// Computes the 64-bit length of a required allocation.
@@ -735,8 +779,14 @@ namespace ILGPU
             /// <returns>The 64-bit length of a required allocation.</returns>
             /// <remarks>This method is not supported on accelerators.</remarks>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public readonly long ComputeBufferLength(LongIndex3D extent) =>
-                Stride3D.ComputeBufferLength(this, extent);
+            public readonly long ComputeBufferLength(LongIndex3D extent)
+            {
+                if (extent.X == 0 || extent.Y == 0 || extent.Z == 0)
+                {
+                    return 0;
+                }
+                return Stride3D.ComputeBufferLength(this, extent);
+            }
 
             /// <summary>
             /// Computes a new extent and stride based on the given cast context.

--- a/Src/ILGPU/Stride.cs
+++ b/Src/ILGPU/Stride.cs
@@ -318,14 +318,8 @@ namespace ILGPU
             /// <param name="extent">The extent to allocate.</param>
             /// <returns>The 32-bit length of a required allocation.</returns>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public readonly int ComputeBufferLength(Index2D extent)
-            {
-                if (extent.X == 0 || extent.Y == 0)
-                {
-                    return 0;
-                }
-                return ComputeElementIndex(extent - Index2D.One) + 1;
-            }
+            public readonly int ComputeBufferLength(Index2D extent) =>
+                Stride2D.ComputeBufferLength(this, extent);
 
             /// <summary>
             /// Computes the 64-bit length of a required allocation.
@@ -333,14 +327,8 @@ namespace ILGPU
             /// <param name="extent">The extent to allocate.</param>
             /// <returns>The 64-bit length of a required allocation.</returns>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public readonly long ComputeBufferLength(LongIndex2D extent)
-            {
-                if (extent.X == 0 || extent.Y == 0)
-                {
-                    return 0;
-                }
-                return ComputeElementIndex(extent - LongIndex2D.One) + 1L;
-            }
+            public readonly long ComputeBufferLength(LongIndex2D extent) =>
+                Stride2D.ComputeBufferLength(this, extent);
 
             /// <summary>
             /// Computes a new extent and stride based on the given cast context.
@@ -457,14 +445,8 @@ namespace ILGPU
             /// <returns>The 32-bit length of a required allocation.</returns>
             /// <remarks>This method is not supported on accelerators.</remarks>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public readonly int ComputeBufferLength(Index2D extent)
-            {
-                if (extent.X == 0 || extent.Y == 0)
-                {
-                    return 0;
-                }
-                return Stride2D.ComputeBufferLength(this, extent);
-            }
+            public readonly int ComputeBufferLength(Index2D extent) =>
+                Stride2D.ComputeBufferLength(this, extent);
 
             /// <summary>
             /// Computes the 64-bit length of a required allocation.
@@ -473,15 +455,8 @@ namespace ILGPU
             /// <returns>The 64-bit length of a required allocation.</returns>
             /// <remarks>This method is not supported on accelerators.</remarks>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public readonly long ComputeBufferLength(LongIndex2D extent)
-            {
-                if (extent.X == 0 || extent.Y == 0)
-                {
-                    return 0;
-                }
-
-                return Stride2D.ComputeBufferLength(this, extent);
-            }
+            public readonly long ComputeBufferLength(LongIndex2D extent) =>
+                Stride2D.ComputeBufferLength(this, extent);
 
             /// <summary>
             /// Computes a new extent and stride based on the given cast context.
@@ -611,14 +586,8 @@ namespace ILGPU
             /// <returns>The 3264-bit length of a required allocation.</returns>
             /// <remarks>This method is not supported on accelerators.</remarks>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public readonly int ComputeBufferLength(Index3D extent)
-            {
-                if (extent.X == 0 || extent.Y == 0 || extent.Z == 0)
-                {
-                    return 0;
-                }
-                return Stride3D.ComputeBufferLength(this, extent);
-            }
+            public readonly int ComputeBufferLength(Index3D extent) =>
+                Stride3D.ComputeBufferLength(this, extent);
 
             /// <summary>
             /// Computes the 64-bit length of a required allocation.
@@ -627,15 +596,8 @@ namespace ILGPU
             /// <returns>The 64-bit length of a required allocation.</returns>
             /// <remarks>This method is not supported on accelerators.</remarks>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public readonly long ComputeBufferLength(LongIndex3D extent)
-            {
-                if (extent.X == 0 || extent.Y == 0 || extent.Z == 0)
-                {
-                    return 0;
-                }
-
-                return Stride3D.ComputeBufferLength(this, extent);
-            }
+            public readonly long ComputeBufferLength(LongIndex3D extent) =>
+                Stride3D.ComputeBufferLength(this, extent);
 
             /// <summary>
             /// Computes a new extent and stride based on the given cast context.
@@ -763,14 +725,8 @@ namespace ILGPU
             /// <returns>The 32-bit length of a required allocation.</returns>
             /// <remarks>This method is not supported on accelerators.</remarks>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public readonly int ComputeBufferLength(Index3D extent)
-            {
-                if (extent.X == 0 || extent.Y == 0 || extent.Z == 0)
-                {
-                    return 0;
-                }
-                return Stride3D.ComputeBufferLength(this, extent);
-            }
+            public readonly int ComputeBufferLength(Index3D extent) =>
+                Stride3D.ComputeBufferLength(this, extent);
 
             /// <summary>
             /// Computes the 64-bit length of a required allocation.
@@ -779,14 +735,8 @@ namespace ILGPU
             /// <returns>The 64-bit length of a required allocation.</returns>
             /// <remarks>This method is not supported on accelerators.</remarks>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public readonly long ComputeBufferLength(LongIndex3D extent)
-            {
-                if (extent.X == 0 || extent.Y == 0 || extent.Z == 0)
-                {
-                    return 0;
-                }
-                return Stride3D.ComputeBufferLength(this, extent);
-            }
+            public readonly long ComputeBufferLength(LongIndex3D extent) =>
+                Stride3D.ComputeBufferLength(this, extent);
 
             /// <summary>
             /// Computes a new extent and stride based on the given cast context.

--- a/Src/ILGPU/StrideTypes.tt
+++ b/Src/ILGPU/StrideTypes.tt
@@ -386,9 +386,8 @@ namespace ILGPU
             where TStride : <#= strideName #> {
 <#      for (int i = 0; i < def.Dimension; ++i) { #>
 <#          var iName = IndexDimensions[i].PropertyName; #>
-            if (extent.<#= iName #> == 0) {
+            if (extent.<#= iName #> == 0)
                 return 0;
-            }
 <#      } #>
             return stride.ComputeElementIndex(extent - <#= indexName #>.One) + 1;
         }
@@ -406,9 +405,8 @@ namespace ILGPU
             where TStride : <#= strideName #> {
 <#      for (int i = 0; i < def.Dimension; ++i) { #>
 <#          var iName = IndexDimensions[i].PropertyName; #>
-            if (extent.<#= iName #> == 0L) {
+            if (extent.<#= iName #> == 0L)
                 return 0L;
-            }
 <#      } #>
             return stride.ComputeElementIndex(extent - <#= longIndexName #>.One) + 1L;
         }

--- a/Src/ILGPU/StrideTypes.tt
+++ b/Src/ILGPU/StrideTypes.tt
@@ -383,8 +383,15 @@ namespace ILGPU
         public static int ComputeBufferLength<TStride>(
             this TStride stride,
             <#= indexName #> extent)
-            where TStride : <#= strideName #> =>
-            stride.ComputeElementIndex(extent - <#= indexName #>.One) + 1;
+            where TStride : <#= strideName #> {
+<#      for (int i = 0; i < def.Dimension; ++i) { #>
+<#          var iName = IndexDimensions[i].PropertyName; #>
+            if (extent.<#= iName #> == 0) {
+                return 0;
+            }
+<#      } #>
+            return stride.ComputeElementIndex(extent - <#= indexName #>.One) + 1;
+        }
 
         /// <summary>
         /// Computes the 64-bit length of a required allocation.
@@ -396,8 +403,16 @@ namespace ILGPU
         public static long ComputeBufferLength<TStride>(
             this TStride stride,
             <#= longIndexName #> extent)
-            where TStride : <#= strideName #> =>
-            stride.ComputeElementIndex(extent - <#= longIndexName #>.One) + 1L;
+            where TStride : <#= strideName #> {
+<#      for (int i = 0; i < def.Dimension; ++i) { #>
+<#          var iName = IndexDimensions[i].PropertyName; #>
+            if (extent.<#= iName #> == 0L) {
+                return 0L;
+            }
+<#      } #>
+            return stride.ComputeElementIndex(extent - <#= longIndexName #>.One) + 1L;
+        }
+
     }
 
 <#  } #>

--- a/Src/ILGPU/StrideTypes.tt
+++ b/Src/ILGPU/StrideTypes.tt
@@ -298,7 +298,7 @@ namespace ILGPU
             /// Computes the 32-bit length of a required allocation.
             /// </summary>
             /// <param name="extent">The extent to allocate.</param>
-            /// <returns>The 3264-bit length of a required allocation.</returns>
+            /// <returns>The 32-bit length of a required allocation.</returns>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public readonly int ComputeBufferLength(<#= indexName #> extent) =>
                 <#= className #>.ComputeBufferLength(this, extent);
@@ -378,7 +378,7 @@ namespace ILGPU
         /// </summary>
         /// <param name="stride">The stride to use.</param>
         /// <param name="extent">The extent to allocate.</param>
-        /// <returns>The 3264-bit length of a required allocation.</returns>
+        /// <returns>The 32-bit length of a required allocation.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int ComputeBufferLength<TStride>(
             this TStride stride,


### PR DESCRIPTION
Currently if you attempt to create a subview that has zero length in at least one non-dense dimension, an exception gets thrown complaining about an index being out of range. It turns out that this comes from `ComputeBufferLength` returning a negative number.

The existing calculation in `ComputeBufferLength` is something like `stride.ComputeElementIndex(extent - IndexND.One) + 1`, ie it computes a value one past the end of the last element. When the extent is zero in at least one dimension however this behaves oddly, as the subtraction is non-saturating:
- If the only zero is in a dense dimension, it will return a positive non-zero number (not dangerously wrong, but more than required)
- If there is a zero in a non-dense dimension, it will return a negative number.  This is clearly wrong, and gets caught shortly afterwards when trying to create a subview of the BaseView.

This PR:
- Adds unit tests demonstrating the issue
- Adds some guards to the various `ComputeBufferLength` methods to fix this behaviour.
- Normalizes the implementation of `Stride2D.DenseX` such that it defers to the templated `ComputeBufferLength` methods like the other `Stride[2, 3]D.DenseAB` structs.