### PR TITLE
enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates: 
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  # Enable version updates for nuget 
+  - package-ecosystem: "nuget"
+    # Look for NuGet dependency info from the `root` directory
+    directory: "/"
+    # Check the nuget registry for updates every day (weekdays) schedule: 
+    interval: "daily"


### PR DESCRIPTION
hi @m4rs-mt, sorry for my late reply and for causing CI to fail with #545 
I could only fetch the latest change and confirm that I didn't have your latest change which should be fixed with this PR
I'm adding only `.github/dependabot.yml` with few lines impacting only dependabot configuration, let me know if you notice anything else with your CI

Enable DependaBot security feature
Useful links:
https://docs.github.com/en/code-security/supply-chain-security/managing-vulnerabilities-in-your-projects-dependencies/about-alerts-for-vulnerable-dependencies
https://docs.github.com/en/code-security/supply-chain-security/managing-vulnerabilities-in-your-projects-dependencies/about-managing-vulnerable-dependencies#dependabot-alerts