### PR TITLE
Ensure that Cuda accelerator runs using 64-bit platform.

### DIFF
--- a/Src/ILGPU/Resources/RuntimeErrorMessages.Designer.cs
+++ b/Src/ILGPU/Resources/RuntimeErrorMessages.Designer.cs
@@ -97,6 +97,15 @@ namespace ILGPU.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cuda accelerator requires 64-bit application ({0} not supported). Ensure Prefer32Bit is set to &apos;false&apos;..
+        /// </summary>
+        internal static string CudaPlatformX64 {
+            get {
+                return ResourceManager.GetString("CudaPlatformX64", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid code generation operation.
         /// </summary>
         internal static string InvalidCodeGenerationOperation0 {

--- a/Src/ILGPU/Resources/RuntimeErrorMessages.resx
+++ b/Src/ILGPU/Resources/RuntimeErrorMessages.resx
@@ -129,6 +129,9 @@
   <data name="CudaNotSupported" xml:space="preserve">
     <value>Cuda is not supported on this platform</value>
   </data>
+  <data name="CudaPlatformX64" xml:space="preserve">
+    <value>Cuda accelerator requires 64-bit application ({0} not supported). Ensure Prefer32Bit is set to 'false'.</value>
+  </data>
   <data name="InvalidCodeGenerationOperation0" xml:space="preserve">
     <value>Invalid code generation operation</value>
   </data>

--- a/Src/ILGPU/Runtime/Cuda/CudaAccelerator.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaAccelerator.cs
@@ -71,9 +71,6 @@ namespace ILGPU.Runtime.Cuda
         /// <returns>The resolved memory type</returns>
         public static unsafe CudaMemoryType GetCudaMemoryType(IntPtr value)
         {
-            // This functionality requires unified addresses (X64)
-            Backends.Backend.EnsureRunningOnPlatform(TargetPlatform.X64);
-
             int data = 0;
             var err = CurrentAPI.GetPointerAttribute(
                     new IntPtr(Unsafe.AsPointer(ref data)),
@@ -164,8 +161,6 @@ namespace ILGPU.Runtime.Cuda
             CudaAcceleratorFlags acceleratorFlags)
             : base(context, description)
         {
-            Backends.Backend.EnsureRunningOnPlatform(TargetPlatform.X64);
-
             // Create new context
             CudaException.ThrowIfFailed(
                 CurrentAPI.CreateContext(

--- a/Src/ILGPU/Runtime/Cuda/CudaContextExtensions.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaContextExtensions.cs
@@ -9,7 +9,9 @@
 // Source License. See LICENSE.txt for details
 // ---------------------------------------------------------------------------------------
 
+using ILGPU.Backends;
 using ILGPU.Backends.PTX;
+using ILGPU.Resources;
 using System;
 
 namespace ILGPU.Runtime.Cuda
@@ -45,6 +47,13 @@ namespace ILGPU.Runtime.Cuda
             this Context.Builder builder,
             Predicate<CudaDevice> predicate)
         {
+            if (Backend.RuntimePlatform != TargetPlatform.X64)
+            {
+                throw new NotSupportedException(string.Format(
+                    RuntimeErrorMessages.CudaPlatformX64,
+                    Backend.RuntimePlatform));
+            }
+
             CudaDevice.GetDevices(
                 predicate,
                 builder.DeviceRegistry);

--- a/Src/ILGPU/Runtime/Cuda/CudaDevice.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaDevice.cs
@@ -145,8 +145,6 @@ namespace ILGPU.Runtime.Cuda
             if (deviceId < 0)
                 throw new ArgumentOutOfRangeException(nameof(deviceId));
 
-            Backend.EnsureRunningOnPlatform(TargetPlatform.X64);
-
             DeviceId = deviceId;
 
             InitDeviceInfo();


### PR DESCRIPTION
ILGPU has some existing code to ensure that the Cuda accelerator is run using X64 platform. However, the change in v1.0.0 to using the ContextBuilder meant that the user no longer explicitly created a CudaAccelerator. Instead, when using the ContextBuilder, ILGPU will initialize the 32-bit Cuda DLL, which [fails to find most Cuda GPUs](https://docs.nvidia.com/cuda/cuda-installation-guide-microsoft-windows/index.html#x86-32-bit-support).

This PR moves the X64 platform check into the ContextBuilder, and uses the specific error message `Cuda accelerator requires 64-bit application (X86 not supported). Ensure Prefer32Bit is set to 'false'.` rather than the generic `Not supported platform 'X86' (X64 required)`. This is because the use could get confused when using `Context.CreateDefault()` with OpenCL.