### PR TITLE
Reduced expected precision of tanh to match PTX intrinsic on SM80 onwards.

### DIFF
--- a/Src/ILGPU.Algorithms.Tests/XMathTests.Trig.tt
+++ b/Src/ILGPU.Algorithms.Tests/XMathTests.Trig.tt
@@ -44,7 +44,7 @@ using Xunit;
         new TrigFunction("Sinh", "double", new Precision(15, 12, 13), projection: ".Select(x => XMath.DegToRad((double)x))"),
         new TrigFunction("Cosh", "float" , new Precision(15,  4,  4), projection: ".Select(x => XMath.DegToRad((float)x))"),
         new TrigFunction("Cosh", "double", new Precision(15, 12, 13), projection: ".Select(x => XMath.DegToRad((double)x))"),
-        new TrigFunction("Tanh", "float" , new Precision(15,  6,  6), projection: ".Select(x => XMath.DegToRad((float)x))"),
+        new TrigFunction("Tanh", "float" , new Precision(15,  5,  6), projection: ".Select(x => XMath.DegToRad((float)x))"),
         new TrigFunction("Tanh", "double", new Precision(15, 15, 15), projection: ".Select(x => XMath.DegToRad((double)x))"),
     };
 


### PR DESCRIPTION
Fixes #548.