### PR TITLE
Fixed naming of available static field modes.

### DIFF
--- a/Src/ILGPU/ContextProperties.cs
+++ b/Src/ILGPU/ContextProperties.cs
@@ -168,7 +168,7 @@ namespace ILGPU
         /// Adding this flag causes stores to static fields
         /// to be silently ignored instead of rejected.
         /// </summary>
-        Aggressive
+        IgnoreStaticFieldStores
     }
 
     /// <summary>

--- a/Src/ILGPU/Frontend/CodeGenerator/CodeGenerator.cs
+++ b/Src/ILGPU/Frontend/CodeGenerator/CodeGenerator.cs
@@ -439,7 +439,8 @@ namespace ILGPU.Frontend
         {
             Debug.Assert(field != null || !field.IsStatic, "Invalid field");
 
-            if (Context.Properties.StaticFieldMode < StaticFieldMode.Aggressive)
+            if (Context.Properties.StaticFieldMode
+                < StaticFieldMode.IgnoreStaticFieldStores)
             {
                 throw CompilationStackLocation.Append(Location).GetNotSupportedException(
                     ErrorMessages.NotSupportedStoreToStaticField,


### PR DESCRIPTION
This looks like a misnamed enum from the change to use context builders.