### PR TITLE
Fix NuGet publishing bug in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,7 +266,7 @@ jobs:
   # Publish a preview version of the NuGet packages on feedz.io when there is
   # a push to master.
   publish-preview:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.event.repository.fork == 'false'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master' && !github.event.repository.fork
     needs: [all-required-checks-done]
     runs-on: ubuntu-latest
     steps:
@@ -281,7 +281,7 @@ jobs:
   # Create a GitHub release and publish the NuGet packages to nuget.org when
   # a tag is pushed.
   publish-release:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.event.repository.fork == 'false'
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !github.event.repository.fork
     needs: [all-required-checks-done]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
When we introduced a new check to avoid running the publishing CI jobs on forks in #533, we unfortunately introduced a bug 😞

This PR aims at fixing that so we can publish preview versions again, and more importantly `v1.0.0-beta3`.