### PR TITLE
Enable dependabot for GitHub Actions, libraries, tests, and samples

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "nuget"
+    directory: "/Src/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "nuget"
+    directory: "/Samples/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Another attempt at enabling Dependabot, following #545 and #551. This time it's been validated on a forked repo to make sure it's the right syntax and points to the right directories, so should be working after it gets merged.

Be ready for a bunch of pull requests to update dependencies. Some might work, some might fail, some might not be useful, but a lot of it is tunable. All in all, it should help easily identify what dependencies can be updated thanks to our pretty good test coverage.