### PR TITLE
Fix release creation in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,7 +253,7 @@ jobs:
           path: ./Bin/Release/ILGPU*.${{ steps.package.outputs.version }}.*nupkg
 
     outputs:
-      tag: ${{ steps.version.outputs.version }}
+      version: ${{ steps.version.outputs.version }}
 
   # Virtual job that can be configured as a required check before a PR can be
   # merged.
@@ -282,7 +282,8 @@ jobs:
   # a tag is pushed.
   publish-release:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !github.event.repository.fork
-    needs: [all-required-checks-done]
+    # Depends explictly on the 'package' job so we can access its output
+    needs: [all-required-checks-done, package]
     runs-on: ubuntu-latest
     steps:
       - name: Download NuGet package artifact


### PR DESCRIPTION
This PR aims at fixing a bug I introduced during the CI refactor in #536 😓

The output of the `package` job was not accessible anymore to the `publish-release` job, which resulted in the wrong Release name, and the `prerelease` flag never being set.