### PR TITLE
Allow zero-length subviews of zero-length views

### DIFF
--- a/Src/ILGPU.Tests/ArrayViews.cs
+++ b/Src/ILGPU.Tests/ArrayViews.cs
@@ -235,6 +235,7 @@ namespace ILGPU.Tests
         {
             using var buffer = Accelerator.Allocate1D<int>(128);
 
+            // Take a zero-length subview of a non-zero length view
             var subView1 = buffer.View.SubView(64, 0);
             Assert.Equal(0, subView1.Length);
             Assert.Equal(0, subView1.LengthInBytes);
@@ -244,6 +245,18 @@ namespace ILGPU.Tests
             Assert.Equal(0, subView2.Length);
             Assert.Equal(0, subView2.LengthInBytes);
             Assert.Equal(0, subView2.Extent.X);
+
+            // Take a zero-length subview of a zero length view
+            var subView3 = subView1.SubView(0, 0);
+            Assert.Equal(0, subView3.Length);
+            Assert.Equal(0, subView3.LengthInBytes);
+            Assert.Equal(0, subView3.Extent.X);
+
+            var subView4 = subView2.SubView(0, 0);
+            Assert.Equal(0, subView4.Length);
+            Assert.Equal(0, subView4.LengthInBytes);
+            Assert.Equal(0, subView4.Extent.X);
+
         }
 
         [Fact]
@@ -260,11 +273,21 @@ namespace ILGPU.Tests
 
                 foreach (var extent in extents)
                 {
+                    // A subview with a zero in one extent dimension, of a view
+                    // with non-zero extent in every dimension.
                     var subView = view.SubView((4, 4), extent);
                     Assert.Equal(0, subView.Length);
                     Assert.Equal(0, subView.LengthInBytes);
                     Assert.Equal(extent.X, subView.Extent.X);
                     Assert.Equal(extent.Y, subView.Extent.Y);
+
+                    // A subview with a zero in one extent dimension, of a view
+                    // with zero extent in the same dimension.
+                    var subView2 = subView.SubView((0, 0), extent);
+                    Assert.Equal(0, subView2.Length);
+                    Assert.Equal(0, subView2.LengthInBytes);
+                    Assert.Equal(extent.X, subView2.Extent.X);
+                    Assert.Equal(extent.Y, subView2.Extent.Y);
                 }
             }
 
@@ -291,12 +314,23 @@ namespace ILGPU.Tests
 
                 foreach (var extent in extents)
                 {
+                    // A subview with a zero in one extent dimension, of a view
+                    // with non-zero extent in every dimension.
                     var subView = view.SubView((4, 4, 4), extent);
                     Assert.Equal(0, subView.Length);
                     Assert.Equal(0, subView.LengthInBytes);
                     Assert.Equal(extent.X, subView.Extent.X);
                     Assert.Equal(extent.Y, subView.Extent.Y);
                     Assert.Equal(extent.Z, subView.Extent.Z);
+
+                    // A subview with a zero in one extent dimension, of a view
+                    // with zero extent in the same dimension.
+                    var subView2 = subView.SubView((0, 0, 0), extent);
+                    Assert.Equal(0, subView2.Length);
+                    Assert.Equal(0, subView2.LengthInBytes);
+                    Assert.Equal(extent.X, subView2.Extent.X);
+                    Assert.Equal(extent.Y, subView2.Extent.Y);
+                    Assert.Equal(extent.Z, subView2.Extent.Z);
                 }
             }
 

--- a/Src/ILGPU/Runtime/ArrayViews.tt
+++ b/Src/ILGPU/Runtime/ArrayViews.tt
@@ -248,7 +248,9 @@ namespace ILGPU.Runtime
 <#      for (int i = 0; i < dim.Dimension; ++i) { #>
 <#          var iName = IndexDimensions[i].PropertyName; #>
             Trace.Assert(
-                index.<#= iName #> >= 0 & index.<#= iName #> < Extent.<#= iName #>,
+                index.<#= iName #> >= 0 & (
+                    index.<#= iName #> < Extent.<#= iName #>
+                    || index.<#= iName #> == 0),
                 "Index <#= iName #> out of bounds");
 <#      } #>
             return Stride.ComputeElementIndex(index);
@@ -268,10 +270,11 @@ namespace ILGPU.Runtime
         {
 <#      for (int i = 0; i < dim.Dimension; ++i) { #>
 <#          var iName = IndexDimensions[i].PropertyName; #>
+<#          var thisExtent = $"({baseType})Extent.{iName}"; #>
             Trace.Assert(
-                index.<#= iName #> >= 0 &
-                index.<#= iName #> + extent.<#= iName #> <=
-                    (<#= baseType #>)Extent.<#= iName #>,
+                index.<#= iName #> >= 0 &&
+                (index.<#= iName #> + extent.<#= iName #> <= <#= thisExtent #>
+                 || (index.<#= iName #> == 0 && extent.<#= iName #> == 0)),
                 "Index/Extent <#= iName #> out of bounds");
 <#      } #>
             <#= baseType #> offset = ComputeLinearIndex(index);

--- a/Src/ILGPU/Runtime/ArrayViews.tt
+++ b/Src/ILGPU/Runtime/ArrayViews.tt
@@ -250,7 +250,7 @@ namespace ILGPU.Runtime
             Trace.Assert(
                 index.<#= iName #> >= 0 & (
                     index.<#= iName #> < Extent.<#= iName #>
-                    || index.<#= iName #> == 0),
+                    | index.<#= iName #> == 0),
                 "Index <#= iName #> out of bounds");
 <#      } #>
             return Stride.ComputeElementIndex(index);
@@ -272,9 +272,9 @@ namespace ILGPU.Runtime
 <#          var iName = IndexDimensions[i].PropertyName; #>
 <#          var thisExtent = $"({baseType})Extent.{iName}"; #>
             Trace.Assert(
-                index.<#= iName #> >= 0 &&
+                index.<#= iName #> >= 0 &
                 (index.<#= iName #> + extent.<#= iName #> <= <#= thisExtent #>
-                 || (index.<#= iName #> == 0 && extent.<#= iName #> == 0)),
+                 | (index.<#= iName #> == 0 & extent.<#= iName #> == 0)),
                 "Index/Extent <#= iName #> out of bounds");
 <#      } #>
             <#= baseType #> offset = ComputeLinearIndex(index);


### PR DESCRIPTION
#550 made it possible to make a zero-length subview of a non-zero-length view. It turns out that it was still not possible to make a zero-length subview of a zero-length subview.

For example, prior to this PR the following does not work:
```c#
var a = accelerator.Allocate2DDenseY((10, 10));
var b = a.View.SubView(index: (0, 0), extent: (5, 0));
var c = b.View.SubView(index: (0, 0), extent: (3, 0)); // <-- Fails
```

The only problem here was pair of slightly too conservative `Trace.Assert`s. This PR extends the unit tests to cover this case, and amends those asserts.