### PR TITLE
Fix version conflicts caused by PR#582

### DIFF
--- a/Src/ILGPU/ILGPU.csproj
+++ b/Src/ILGPU/ILGPU.csproj
@@ -40,10 +40,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
-    <PackageReference Include="System.Reflection.Metadata" Version="1.8.0" />
+    <PackageReference Include="System.Reflection.Metadata" Version="5.0.0" />
     <PackageReference Include="T4.Build" Version="0.2.0" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump System.Reflection.Metadata from 1.8.0 to 5.0.0. [(PR#582)](https://github.com/m4rs-mt/ILGPU/pull/582).
Hope this fix can help you.

Best regards,
sucrose