### PR TITLE
Prepared conditional compilation for future .NET frameworks.

### DIFF
--- a/Src/ILGPU.Algorithms/Runtime/Cuda/CuBlasException.cs
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/CuBlasException.cs
@@ -76,7 +76,7 @@ namespace ILGPU.Runtime.Cuda
         #region Methods
 
         /// <summary cref="Exception.GetObjectData(SerializationInfo, StreamingContext)"/>
-#if !NET5_0
+#if !NET5_0_OR_GREATER
         [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
 #endif
         public override void GetObjectData(

--- a/Src/ILGPU.Algorithms/Runtime/Cuda/CuRandException.cs
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/CuRandException.cs
@@ -76,7 +76,7 @@ namespace ILGPU.Runtime.Cuda
         #region Methods
 
         /// <summary cref="Exception.GetObjectData(SerializationInfo, StreamingContext)"/>
-#if !NET5_0
+#if !NET5_0_OR_GREATER
         [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
 #endif
         public override void GetObjectData(

--- a/Src/ILGPU.Algorithms/XMath/Rem.cs
+++ b/Src/ILGPU.Algorithms/XMath/Rem.cs
@@ -57,7 +57,7 @@ namespace ILGPU.Algorithms
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [IntrinsicImplementation]
         public static float IEEERemainder(float x, float y) =>
-#if NETCORE
+#if !NETFRAMEWORK
             MathF.IEEERemainder(x, y);
 #else
             (float)Math.IEEERemainder(x, y);

--- a/Src/ILGPU.Tests/PageLockedMemory.cs
+++ b/Src/ILGPU.Tests/PageLockedMemory.cs
@@ -61,7 +61,7 @@ namespace ILGPU.Tests
             }
         }
 
-#if NET5_0
+#if NET5_0_OR_GREATER
         [Fact]
         [KernelMethod(nameof(PinnedMemoryKernel))]
         public void PinnedUsingGCAllocateArray()

--- a/Src/ILGPU/Backends/PhiBindings.cs
+++ b/Src/ILGPU/Backends/PhiBindings.cs
@@ -221,7 +221,7 @@ namespace ILGPU.Backends
             /// </param>
             public BlockInfo(int capacity)
             {
-#if NET5_0 || NETSTANDARD2_1_OR_GREATER
+#if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
                 LHSPhis = new HashSet<PhiValue>(capacity);
                 IntermediatePhis = new HashSet<PhiValue>(capacity);
 #else

--- a/Src/ILGPU/Runtime/ArrayViewExtensions.cs
+++ b/Src/ILGPU/Runtime/ArrayViewExtensions.cs
@@ -1554,7 +1554,7 @@ namespace ILGPU.Runtime
             if (view.HasNoData())
                 return PageLockedArray1D<T>.Empty;
             var accelerator = view.GetAccelerator();
-#if NET5_0
+#if NET5_0_OR_GREATER
             var result = accelerator.AllocatePageLockedArray1D<T>(
                 view.Length,
                 uninitialized: true);

--- a/Src/ILGPU/Runtime/Cuda/CudaException.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaException.cs
@@ -92,7 +92,7 @@ namespace ILGPU.Runtime.Cuda
 
         /// <summary cref="Exception.GetObjectData(
         /// SerializationInfo, StreamingContext)"/>
-#if !NET5_0
+#if !NET5_0_OR_GREATER
         [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
 #endif
         public override void GetObjectData(

--- a/Src/ILGPU/Runtime/OpenCL/CLException.cs
+++ b/Src/ILGPU/Runtime/OpenCL/CLException.cs
@@ -89,7 +89,7 @@ namespace ILGPU.Runtime.OpenCL
         #region Methods
 
         /// <summary cref="Exception.GetObjectData(SerializationInfo, StreamingContext)"/>
-#if !NET5_0
+#if !NET5_0_OR_GREATER
         [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
 #endif
         public override void GetObjectData(

--- a/Src/ILGPU/Runtime/PageLockedArrays.cs
+++ b/Src/ILGPU/Runtime/PageLockedArrays.cs
@@ -131,7 +131,7 @@ namespace ILGPU.Runtime
         #region Instance
 
         private readonly T[] array;
-#if !NET5_0
+#if !NET5_0_OR_GREATER
         private readonly GCHandle handle;
 #endif
 
@@ -157,7 +157,7 @@ namespace ILGPU.Runtime
         {
             if (extent < 0L)
                 throw new ArgumentOutOfRangeException(nameof(extent));
-#if NET5_0
+#if NET5_0_OR_GREATER
             array = uninitialized
                 ? GC.AllocateUninitializedArray<T>(extent.ToIntIndex(), pinned: true)
                 : GC.AllocateArray<T>(extent.ToIntIndex(), pinned: true);
@@ -210,7 +210,7 @@ namespace ILGPU.Runtime
 
         #endregion
 
-#if !NET5_0
+#if !NET5_0_OR_GREATER
         #region IDisposable
 
         /// <inheritdoc/>


### PR DESCRIPTION
Changed `NET5_0` to `NET5_0_OR_GREATER` in preparation for `net6.0`.

Also fixed incorrectly using `#if NETCORE` in `IEEERemainder` - `netstandard2.1` also supports `MathF.IEEERemainder`.