### PR TITLE
Fixed invalid conversion of LFA values in SSAStructureConstruction.

### DIFF
--- a/Src/ILGPU.Tests/Arrays.cs
+++ b/Src/ILGPU.Tests/Arrays.cs
@@ -825,6 +825,31 @@ namespace ILGPU.Tests
             Verify(buffer.View, expected);
         }
 
+        internal static void StaticInlineStructureArrayKernel(
+            Index1D index,
+            ArrayView<int> data)
+        {
+            var staticInlineArray = new PairStruct<int, int>[]
+            {
+                new PairStruct<int, int>(1, 2),
+                new PairStruct<int, int>(3, 4),
+            };
+            data[index] =
+                staticInlineArray[0].Val0 +
+                staticInlineArray[1].Val1;
+        }
+
+        [Fact]
+        [KernelMethod(nameof(StaticInlineStructureArrayKernel))]
+        public void StaticInlineStructureArray()
+        {
+            using var buffer = Accelerator.Allocate1D<int>(1);
+            Execute(1, buffer.AsContiguous());
+
+            var expected = new int[] { 5 };
+            Verify(buffer.View, expected);
+        }
+
         internal static void ConditionalArrayFoldingKernel(
             Index1D index,
             ArrayView<int> buffer)


### PR DESCRIPTION
This PR fixes a critical issue that can occur in the `SSAStructureConstruction` pass. It can be triggered by loading constant values from arrays that are stored within structures.

Sample to reproduce this issue:
```c#
var data = new Vector2[]
{
    new Vector2(1.0f, 2.0f),
    new Vector2(3.0f, 4.0f),
};
output[index] = data0].X+ data[1].Y;

```