### PR TITLE
Guard against zero-length (CUDA|CL) allocations

### DIFF
--- a/Samples/MonitorProgress/CudaProgress.cs
+++ b/Samples/MonitorProgress/CudaProgress.cs
@@ -50,23 +50,22 @@ namespace MonitorProgress
                 NativePtr = IntPtr.Zero;
             }
 
-            public override void CopyFrom(
+            protected override void CopyFrom(
                 AcceleratorStream stream,
                 in ArrayView<byte> sourceView,
-                long targetOffsetInBytes) =>
-                throw new NotSupportedException();
+                in ArrayView<byte> targetView) =>
+                throw new NotImplementedException();
 
-            public override void CopyTo(
+            protected override void CopyTo(
                 AcceleratorStream stream,
-                long sourceOffsetInBytes,
+                in ArrayView<byte> sourceView,
                 in ArrayView<byte> targetView) =>
                 throw new NotSupportedException();
 
-            public override void MemSet(
+            protected override void MemSet(
                 AcceleratorStream stream,
                 byte value,
-                long targetOffsetInBytes,
-                long length) =>
+                in ArrayView<byte> targetView) =>
                 throw new NotSupportedException();
         }
 

--- a/Src/ILGPU.Tests/MemoryBufferOperations.tt
+++ b/Src/ILGPU.Tests/MemoryBufferOperations.tt
@@ -95,6 +95,39 @@ namespace ILGPU.Tests
             output[index] = input[index];
         }
 
+        internal static void ZeroLength_Kernel<T>(
+            Index1D index,
+            ArrayView1D<T, Stride1D.Dense> input,
+            ArrayView1D<T, Stride1D.Dense> output)
+            where T : unmanaged
+        {
+            if (index < input.Length & index < output.Length)
+                output[index] = input[index];
+        }
+
+<#  foreach (var type in copyTypes) { #>
+        [Theory]
+<#      foreach (var length in lengths) { #>
+        [InlineData(<#= length #>)]
+<#      } #>
+        [KernelMethod(nameof(ZeroLength_Kernel))]
+        public void ZeroLength_<#= type.Name #>(int length)
+        {
+            using var source = Accelerator.Allocate1D<<#= type.Type #>>(0);
+            using var target = Accelerator.Allocate1D<<#= type.Type #>>(0);
+            var emptyData = Array.Empty<<#= type.Type #>>();
+
+            source.CopyTo(Accelerator.DefaultStream, target);
+            target.CopyFromCPU(Accelerator.DefaultStream, emptyData);
+
+            Execute<Index1D, <#= type.Type #>>(
+                length,
+                source.View,
+                target.View);
+        }
+
+<#  } #>
+
 <#  foreach (var type in copyTypes) { #>
         [Theory]
 <#      foreach (var stride in strides) { #>

--- a/Src/ILGPU/Runtime/CPU/CPUMemoryBuffer.cs
+++ b/Src/ILGPU/Runtime/CPU/CPUMemoryBuffer.cs
@@ -258,47 +258,29 @@ namespace ILGPU.Runtime.CPU
         #region Methods
 
         /// <inheritdoc/>
-        public override unsafe void MemSet(
+        protected internal override unsafe void MemSet(
             AcceleratorStream stream,
             byte value,
-            long targetOffsetInBytes,
-            long length)
-        {
-            if (length == 0)
-                return;
-
-            var targetView = AsRawArrayView(targetOffsetInBytes, length);
-            // Perform the memory set operation
+            in ArrayView<byte> targetView) =>
             CPUMemSet(
                 targetView.LoadEffectiveAddressAsPtr(),
                 value,
                 0L,
                 targetView.LengthInBytes);
-        }
 
         /// <inheritdoc/>
-        public override void CopyFrom(
+        protected internal override void CopyFrom(
             AcceleratorStream stream,
             in ArrayView<byte> sourceView,
-            long targetOffsetInBytes)
-        {
-            var targetView = AsRawArrayView(
-                targetOffsetInBytes,
-                sourceView.LengthInBytes);
+            in ArrayView<byte> targetView) =>
             CPUCopyFrom(stream, sourceView, targetView);
-        }
 
         /// <inheritdoc/>
-        public override unsafe void CopyTo(
+        protected internal override unsafe void CopyTo(
             AcceleratorStream stream,
-            long sourceOffsetInBytes,
-            in ArrayView<byte> targetView)
-        {
-            var sourceView = AsRawArrayView(
-                sourceOffsetInBytes,
-                targetView.LengthInBytes);
+            in ArrayView<byte> sourceView,
+            in ArrayView<byte> targetView) =>
             CPUCopyTo(stream, sourceView, targetView);
-        }
 
         #endregion
     }

--- a/Src/ILGPU/Runtime/Cuda/CudaAccelerator.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaAccelerator.cs
@@ -667,7 +667,7 @@ namespace ILGPU.Runtime.Cuda
         protected unsafe override PageLockScope<T> CreatePageLockFromPinnedInternal<T>(
             IntPtr pinned,
             long numElements) =>
-            Device.SupportsMappingHostMemory
+            Device.SupportsMappingHostMemory && numElements > 0
             ? new CudaPageLockScope<T>(this, pinned, numElements)
             : new NullPageLockScope<T>(this, pinned, numElements) as PageLockScope<T>;
 

--- a/Src/ILGPU/Runtime/Cuda/CudaMemoryBuffer.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaMemoryBuffer.cs
@@ -135,39 +135,25 @@ namespace ILGPU.Runtime.Cuda
         #region Methods
 
         /// <inheritdoc/>
-        public override unsafe void MemSet(
+        protected internal override unsafe void MemSet(
             AcceleratorStream stream,
             byte value,
-            long targetOffsetInBytes,
-            long length)
-        {
-            var targetView = AsRawArrayView(targetOffsetInBytes, length);
+            in ArrayView<byte> targetView) =>
             CudaMemSet(stream as CudaStream, value, targetView);
-        }
 
         /// <inheritdoc/>
-        public override void CopyFrom(
+        protected internal override void CopyFrom(
             AcceleratorStream stream,
             in ArrayView<byte> sourceView,
-            long targetOffsetInBytes)
-        {
-            var targetView = AsRawArrayView(
-                targetOffsetInBytes,
-                sourceView.LengthInBytes);
+            in ArrayView<byte> targetView) =>
             CudaCopy(stream as CudaStream, sourceView, targetView);
-        }
 
         /// <inheritdoc/>
-        public override unsafe void CopyTo(
+        protected internal override unsafe void CopyTo(
             AcceleratorStream stream,
-            long sourceOffsetInBytes,
-            in ArrayView<byte> targetView)
-        {
-            var sourceView = AsRawArrayView(
-                sourceOffsetInBytes,
-                targetView.LengthInBytes);
+            in ArrayView<byte> sourceView,
+            in ArrayView<byte> targetView) =>
             CudaCopy(stream as CudaStream, sourceView, targetView);
-        }
 
         #endregion
 

--- a/Src/ILGPU/Runtime/Cuda/CudaMemoryBuffer.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaMemoryBuffer.cs
@@ -116,11 +116,18 @@ namespace ILGPU.Runtime.Cuda
             int elementSize)
             : base(accelerator, length, elementSize)
         {
-            CudaException.ThrowIfFailed(
-                CurrentAPI.AllocateMemory(
-                    out IntPtr resultPtr,
-                    new IntPtr(LengthInBytes)));
-            NativePtr = resultPtr;
+            if (LengthInBytes == 0)
+            {
+                NativePtr = IntPtr.Zero;
+            }
+            else
+            {
+                CudaException.ThrowIfFailed(
+                    CurrentAPI.AllocateMemory(
+                        out IntPtr resultPtr,
+                        new IntPtr(LengthInBytes)));
+                NativePtr = resultPtr;
+            }
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/MemoryBuffer.cs
+++ b/Src/ILGPU/Runtime/MemoryBuffer.cs
@@ -152,7 +152,9 @@ namespace ILGPU.Runtime
         /// <returns></returns>
         public ArrayView<byte> AsRawArrayView(long offsetInBytes, long lengthInBytes)
         {
-            if (offsetInBytes < 0 || offsetInBytes >= LengthInBytes)
+            if (offsetInBytes < 0)
+                throw new ArgumentOutOfRangeException(nameof(offsetInBytes));
+            if ((LengthInBytes > 0) && (offsetInBytes >= LengthInBytes))
                 throw new ArgumentOutOfRangeException(nameof(offsetInBytes));
             if (lengthInBytes < 0 || offsetInBytes + lengthInBytes > LengthInBytes)
                 throw new ArgumentOutOfRangeException(nameof(lengthInBytes));
@@ -175,7 +177,7 @@ namespace ILGPU.Runtime
                     ErrorMessages.NotSupportedType,
                     nameof(T)));
             }
-            if (offset >= Length)
+            if ((Length > 0) && (offset >= Length))
                 throw new ArgumentOutOfRangeException(nameof(offset));
             if (offset + length > Length)
                 throw new ArgumentOutOfRangeException(nameof(length));

--- a/Src/ILGPU/Runtime/MemoryBuffer.cs
+++ b/Src/ILGPU/Runtime/MemoryBuffer.cs
@@ -13,6 +13,7 @@ using ILGPU.Resources;
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace ILGPU.Runtime
 {
@@ -101,11 +102,29 @@ namespace ILGPU.Runtime
         /// <param name="value">The value to write into the memory buffer.</param>
         /// <param name="targetOffsetInBytes">The target offset in bytes.</param>
         /// <param name="length">The number of bytes to set.</param>
-        public abstract void MemSet(
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void MemSet(
             AcceleratorStream stream,
             byte value,
             long targetOffsetInBytes,
-            long length);
+            long length)
+        {
+            if (length == 0)
+                return;
+            var targetView = AsRawArrayView(targetOffsetInBytes, length);
+            MemSet(stream, value, targetView);
+        }
+
+        /// <summary>
+        /// Sets the contents of the current buffer to the given byte value.
+        /// </summary>
+        /// <param name="stream">The used accelerator stream.</param>
+        /// <param name="value">The value to write into the memory buffer.</param>
+        /// <param name="targetView">The raw target view of this buffer.</param>
+        protected internal abstract void MemSet(
+            AcceleratorStream stream,
+            byte value,
+            in ArrayView<byte> targetView);
 
         /// <summary>
         /// Copies elements from the current buffer to the target view.
@@ -113,9 +132,29 @@ namespace ILGPU.Runtime
         /// <param name="stream">The used accelerator stream.</param>
         /// <param name="sourceOffsetInBytes">The source offset in bytes.</param>
         /// <param name="targetView">The target view.</param>
-        public abstract void CopyTo(
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void CopyTo(
             AcceleratorStream stream,
             long sourceOffsetInBytes,
+            in ArrayView<byte> targetView)
+        {
+            if (!targetView.IsValid)
+                return;
+            var sourceView = AsRawArrayView(
+                sourceOffsetInBytes,
+                targetView.LengthInBytes);
+            CopyTo(stream, sourceView, targetView);
+        }
+
+        /// <summary>
+        /// Copies elements from the current buffer to the target view.
+        /// </summary>
+        /// <param name="stream">The used accelerator stream.</param>
+        /// <param name="sourceView">The source view of this buffer.</param>
+        /// <param name="targetView">The target view.</param>
+        protected internal abstract void CopyTo(
+            AcceleratorStream stream,
+            in ArrayView<byte> sourceView,
             in ArrayView<byte> targetView);
 
         /// <summary>
@@ -124,15 +163,36 @@ namespace ILGPU.Runtime
         /// <param name="stream">The used accelerator stream.</param>
         /// <param name="sourceView">The source view.</param>
         /// <param name="targetOffsetInBytes">The target offset in bytes.</param>
-        public abstract void CopyFrom(
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void CopyFrom(
             AcceleratorStream stream,
             in ArrayView<byte> sourceView,
-            long targetOffsetInBytes);
+            long targetOffsetInBytes)
+        {
+            if (!sourceView.IsValid)
+                return;
+            var targetView = AsRawArrayView(
+                targetOffsetInBytes,
+                sourceView.LengthInBytes);
+            CopyFrom(stream, sourceView, targetView);
+        }
+
+        /// <summary>
+        /// Copies elements from the source view to the current buffer.
+        /// </summary>
+        /// <param name="stream">The used accelerator stream.</param>
+        /// <param name="sourceView">The source view.</param>
+        /// <param name="targetView">The target view of this buffer.</param>
+        protected internal abstract void CopyFrom(
+            AcceleratorStream stream,
+            in ArrayView<byte> sourceView,
+            in ArrayView<byte> targetView);
 
         /// <summary>
         /// Returns a raw array view of the whole buffer.
         /// </summary>
         /// <returns>The raw array view.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ArrayView<byte> AsRawArrayView() =>
             AsRawArrayView(0L, LengthInBytes);
 
@@ -141,6 +201,7 @@ namespace ILGPU.Runtime
         /// </summary>
         /// <param name="offsetInBytes">The raw offset in bytes.</param>
         /// <returns>The raw array view.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ArrayView<byte> AsRawArrayView(long offsetInBytes) =>
             AsRawArrayView(offsetInBytes, LengthInBytes - offsetInBytes);
 
@@ -154,7 +215,7 @@ namespace ILGPU.Runtime
         {
             if (offsetInBytes < 0)
                 throw new ArgumentOutOfRangeException(nameof(offsetInBytes));
-            if ((LengthInBytes > 0) && (offsetInBytes >= LengthInBytes))
+            if (LengthInBytes > 0 && offsetInBytes >= LengthInBytes)
                 throw new ArgumentOutOfRangeException(nameof(offsetInBytes));
             if (lengthInBytes < 0 || offsetInBytes + lengthInBytes > LengthInBytes)
                 throw new ArgumentOutOfRangeException(nameof(lengthInBytes));
@@ -177,7 +238,7 @@ namespace ILGPU.Runtime
                     ErrorMessages.NotSupportedType,
                     nameof(T)));
             }
-            if ((Length > 0) && (offset >= Length))
+            if (Length > 0 && offset >= Length)
                 throw new ArgumentOutOfRangeException(nameof(offset));
             if (offset + length > Length)
                 throw new ArgumentOutOfRangeException(nameof(length));
@@ -301,30 +362,25 @@ namespace ILGPU.Runtime
         #region Methods
 
         /// <inheritdoc/>
-        public override void MemSet(
+        protected internal override void MemSet(
             AcceleratorStream stream,
             byte value,
-            long targetOffsetInBytes,
-            long length) =>
-            Buffer.MemSet(
-                stream,
-                value,
-                targetOffsetInBytes,
-                length);
-
-        /// <inheritdoc/>
-        public override void CopyTo(
-            AcceleratorStream stream,
-            long sourceOffsetInBytes,
             in ArrayView<byte> targetView) =>
-            Buffer.CopyTo(stream, sourceOffsetInBytes, targetView);
+            Buffer.MemSet(stream, value, targetView);
 
         /// <inheritdoc/>
-        public override void CopyFrom(
+        protected internal override void CopyTo(
             AcceleratorStream stream,
             in ArrayView<byte> sourceView,
-            long targetOffsetInBytes) =>
-            Buffer.CopyFrom(stream, sourceView, targetOffsetInBytes);
+            in ArrayView<byte> targetView) =>
+            Buffer.CopyTo(stream, sourceView, targetView);
+
+        /// <inheritdoc/>
+        protected internal override void CopyFrom(
+            AcceleratorStream stream,
+            in ArrayView<byte> sourceView,
+            in ArrayView<byte> targetView) =>
+            Buffer.CopyFrom(stream, sourceView, targetView);
 
         /// <summary>
         /// Returns an array view that can access this array.

--- a/Src/ILGPU/Runtime/OpenCL/CLMemoryBuffer.cs
+++ b/Src/ILGPU/Runtime/OpenCL/CLMemoryBuffer.cs
@@ -145,14 +145,21 @@ namespace ILGPU.Runtime.OpenCL
             int elementSize)
             : base(accelerator, length, elementSize)
         {
-            CLException.ThrowIfFailed(
-                CurrentAPI.CreateBuffer(
-                    accelerator.NativePtr,
-                    CLBufferFlags.CL_MEM_READ_WRITE,
-                    new IntPtr(LengthInBytes),
-                    IntPtr.Zero,
-                    out IntPtr resultPtr));
-            NativePtr = resultPtr;
+            if (LengthInBytes == 0)
+            {
+                NativePtr = IntPtr.Zero;
+            }
+            else
+            {
+                CLException.ThrowIfFailed(
+                    CurrentAPI.CreateBuffer(
+                        accelerator.NativePtr,
+                        CLBufferFlags.CL_MEM_READ_WRITE,
+                        new IntPtr(LengthInBytes),
+                        IntPtr.Zero,
+                        out IntPtr resultPtr));
+                NativePtr = resultPtr;
+            }
         }
 
         #endregion
@@ -203,6 +210,10 @@ namespace ILGPU.Runtime.OpenCL
         /// </summary>
         protected override void DisposeAcceleratorObject(bool disposing)
         {
+            // Skip buffers with Length = 0
+            if (NativePtr == IntPtr.Zero)
+                return;
+
             CLException.VerifyDisposed(
                 disposing,
                 CurrentAPI.ReleaseBuffer(NativePtr));

--- a/Src/ILGPU/Runtime/OpenCL/CLMemoryBuffer.cs
+++ b/Src/ILGPU/Runtime/OpenCL/CLMemoryBuffer.cs
@@ -167,39 +167,25 @@ namespace ILGPU.Runtime.OpenCL
         #region Methods
 
         /// <inheritdoc/>
-        public override unsafe void MemSet(
+        protected internal override void MemSet(
             AcceleratorStream stream,
             byte value,
-            long targetOffsetInBytes,
-            long length)
-        {
-            var targetView = AsRawArrayView(targetOffsetInBytes, length);
+            in ArrayView<byte> targetView) =>
             CLMemSet(stream as CLStream, value, targetView);
-        }
 
         /// <inheritdoc/>
-        public override void CopyFrom(
+        protected internal override void CopyFrom(
             AcceleratorStream stream,
             in ArrayView<byte> sourceView,
-            long targetOffsetInBytes)
-        {
-            var targetView = AsRawArrayView(
-                targetOffsetInBytes,
-                sourceView.LengthInBytes);
+            in ArrayView<byte> targetView) =>
             CLCopy(stream as CLStream, sourceView, targetView);
-        }
 
         /// <inheritdoc/>
-        public override unsafe void CopyTo(
+        protected internal override void CopyTo(
             AcceleratorStream stream,
-            long sourceOffsetInBytes,
-            in ArrayView<byte> targetView)
-        {
-            var sourceView = AsRawArrayView(
-                sourceOffsetInBytes,
-                targetView.LengthInBytes);
+            in ArrayView<byte> sourceView,
+            in ArrayView<byte> targetView) =>
             CLCopy(stream as CLStream, sourceView, targetView);
-        }
 
         #endregion
 


### PR DESCRIPTION
This PR contains all changes from #547 including additional OpenCL extensions and test cases.

Note: includes all changes by @Joey9801 🎉 