### PR TITLE
Fixed transformation issues regarding many functions in kernel modules (without inlining)

### DIFF
--- a/Src/ILGPU/IR/NodeId.cs
+++ b/Src/ILGPU/IR/NodeId.cs
@@ -52,6 +52,17 @@ namespace ILGPU.IR
 
         #endregion
 
+        #region Methods
+
+        /// <summary>
+        /// Returns true if the given id is equal to this node id.
+        /// </summary>
+        /// <param name="id">The id to test.</param>
+        /// <returns>True if the given id is equal to this node id.</returns>
+        public readonly bool Is(long id) => Id.Value == id;
+
+        #endregion
+
         #region IEquatable
 
         /// <summary>

--- a/Src/ILGPU/IR/Transformations/InferAddressSpaces.cs
+++ b/Src/ILGPU/IR/Transformations/InferAddressSpaces.cs
@@ -902,6 +902,7 @@ namespace ILGPU.IR.Transformations
                 var targetAddressSpace = intermediate[builder.Method];
                 builder.UpdateReturnType(
                     GetAddressSpaceConverter(targetAddressSpace));
+                applied = true;
             }
 
             // Adjust all method calls

--- a/Src/ILGPU/IR/Transformations/LowerStructures.cs
+++ b/Src/ILGPU/IR/Transformations/LowerStructures.cs
@@ -644,7 +644,16 @@ namespace ILGPU.IR.Transformations
         /// <summary>
         /// Constructs a new structure conversion pass.
         /// </summary>
-        public LowerStructures() { }
+        public LowerStructures() : this(LowerStructureFlags.None) { }
+
+        /// <summary>
+        /// Constructs a new structure conversion pass.
+        /// </summary>
+        /// <param name="flags">The transformation flags.</param>
+        public LowerStructures(LowerStructureFlags flags)
+        {
+            Flags = flags;
+        }
 
         #endregion
 

--- a/Src/ILGPU/IR/Transformations/LowerTypes.cs
+++ b/Src/ILGPU/IR/Transformations/LowerTypes.cs
@@ -23,7 +23,7 @@ namespace ILGPU.IR.Transformations
     /// This transformation does not change function parameters and calls to other
     /// functions.
     /// </remarks>
-    public abstract class LowerTypes<TType> : UnorderedTransformation
+    public abstract class LowerTypes<TType> : UnorderedTransformationWithPrePass
         where TType : TypeNode
     {
         #region Rewriter Methods
@@ -297,6 +297,8 @@ namespace ILGPU.IR.Transformations
                 (typeConverter, value) =>
                     IsTypeDependent(typeConverter, value, value.AllocaType),
                 Lower);
+            rewriter.Add<Load>(IsTypeDependent, InvalidateType);
+            rewriter.Add<AddressSpaceCast>(IsTypeDependent, InvalidateType);
             rewriter.Add<PointerCast>(
                 (typeConverter, value) =>
                     IsTypeDependent(typeConverter, value, value.TargetType),
@@ -309,6 +311,10 @@ namespace ILGPU.IR.Transformations
                 (typeConverter, value) =>
                     IsTypeDependent(typeConverter, value, value.PhiType),
                 Lower);
+
+            rewriter.Add<Broadcast>(IsTypeDependent, InvalidateType);
+            rewriter.Add<WarpShuffle>(IsTypeDependent, InvalidateType);
+            rewriter.Add<SubWarpShuffle>(IsTypeDependent, InvalidateType);
 
             rewriter.Add<Predicate>(IsTypeDependent, InvalidateType);
             rewriter.Add<MethodCall>(IsTypeDependent, InvalidateType);
@@ -337,6 +343,19 @@ namespace ILGPU.IR.Transformations
             Method.Builder builder);
 
         /// <summary>
+        /// Updates all return types of all affected methods.
+        /// </summary>
+        /// <param name="builder">The current builder.</param>
+        protected sealed override void PrePerformTransformation(Method.Builder builder)
+        {
+            var typeConverter = CreateLoweringConverter(builder);
+
+            // Update return type
+            if (typeConverter.IsTypeDependent(builder.Method.ReturnType))
+                builder.UpdateReturnType(typeConverter);
+        }
+
+        /// <summary>
         /// Performs a complete type lowering transformation.
         /// </summary>
         /// <param name="builder">The current builder.</param>
@@ -354,10 +373,6 @@ namespace ILGPU.IR.Transformations
                 builder,
                 typeConverter,
                 out var rewriting);
-
-            // Update return type
-            if (typeConverter.IsTypeDependent(builder.Method.ReturnType))
-                builder.UpdateReturnType(typeConverter);
 
             // Update parameter types
             builder.UpdateParameterTypes(typeConverter);

--- a/Src/ILGPU/IR/Types/StructureType.cs
+++ b/Src/ILGPU/IR/Types/StructureType.cs
@@ -725,6 +725,7 @@ namespace ILGPU.IR.Types
                 hashCode ^= type.GetHashCode() ^ offsets[i];
                 AddFlags(type.Flags);
             }
+            AddFlags(TypeFlags.StructureDependent);
         }
 
         #endregion

--- a/Src/ILGPU/IR/Types/TypeNode.cs
+++ b/Src/ILGPU/IR/Types/TypeNode.cs
@@ -38,9 +38,14 @@ namespace ILGPU.IR.Types
         ViewDependent = 1 << 1,
 
         /// <summary>
+        /// The type is either a structure or contains a structure.
+        /// </summary>
+        StructureDependent = 1 << 2,
+
+        /// <summary>
         /// The type is either an array or contains an array.
         /// </summary>
-        ArrayDependent = 1 << 2,
+        ArrayDependent = 1 << 3,
 
         /// <summary>
         /// The type depends on an address space.


### PR DESCRIPTION
This PR fixes several critical issues in the internal transformation pipeline. This includes fixes for the `LowerStructures`, `InferAddressSpaces` and `LowerTypes` transformations.

To ensure that we do not run into any concurrency issues in the future, this PR also introduces an `UnorderedTransformationWithPrePass` base transformation class. It allows to perform a separate pass over all functions before running the main transformation logic.

*! Note that the added test case will crash from time to time without this fix, since the behavior is generally not deterministic !*