### PR TITLE
Fixed generated call to `ValueType.GetHashCode`

### DIFF
--- a/Src/ILGPU.Tests/Generic/TestData.cs
+++ b/Src/ILGPU.Tests/Generic/TestData.cs
@@ -83,6 +83,22 @@ namespace ILGPU.Tests
         public override int GetHashCode() => 0;
     }
 
+    [Serializable]
+    // warning disabled intentionally for testing this scenario
+    #pragma warning disable CS0659 // Type does not override Object.GetHashCode()
+    public struct NoHashCodeStruct : IXunitSerializable, IEquatable<NoHashCodeStruct>
+    #pragma warning restore CS0659 // Type does not override Object.GetHashCode()
+    {
+        public void Deserialize(IXunitSerializationInfo info) { }
+
+        public void Serialize(IXunitSerializationInfo info) { }
+
+        public bool Equals(NoHashCodeStruct other) => true;
+
+        public override bool Equals(object obj) =>
+            obj is NoHashCodeStruct other && Equals(other);
+    }
+
     public static class PairStruct
     {
         public static PairStruct<float, float> MaxFloats =>

--- a/Src/ILGPU.Tests/SpecializedKernels.cs
+++ b/Src/ILGPU.Tests/SpecializedKernels.cs
@@ -27,6 +27,7 @@ namespace ILGPU.Tests
             { default(float) },
             { default(double) },
             { default(EmptyStruct) },
+            { default(NoHashCodeStruct) },
             { default(TestStruct) },
             { default(TestStructEquatable<TestStructEquatable<byte>>) },
             { default(


### PR DESCRIPTION
The bug (https://github.com/m4rs-mt/ILGPU/issues/614) occured when type `T` inside `SpecializedValue<T>` does not implement `GetHashCode`, and instead inherits one from `ValueType`.

Because `ValueType` itself is not a struct, to call its `GetHashCode` the first parameter must be an object reference. Therefore the object of type `T` (which `SpecializedValue<T>` requires to be a `struct`) must be boxed before calling `GetHashCode`.