### PR TITLE
Review and Comparison of CUDA and OpenCL APIs indicates InboundsExclusive will often fail in OpenCL

### DIFF
--- a/Src/ILGPU/Runtime/OpenCL/CLDevice.cs
+++ b/Src/ILGPU/Runtime/OpenCL/CLDevice.cs
@@ -285,10 +285,10 @@ namespace ILGPU.Runtime.OpenCL
                 DeviceId,
                 CLDeviceInfoType.CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS), 3);
 
-            //OpenCL does not report maximium grid sizes, MaxGridSize value is consistent
-            //with the CPU accelator and values returned by CUDA accelerators.
-            //MaxGridSize is ultimately contrained by system and device memory
-            //and how each kernel manages memory.
+            // OpenCL does not report maximium grid sizes, MaxGridSize value is consistent
+            // with the CPU accelator and values returned by CUDA accelerators.
+            // MaxGridSize is ultimately contrained by system and device memory
+            // and how each kernel manages memory.
             MaxGridSize = new Index3D(int.MaxValue, ushort.MaxValue, ushort.MaxValue);
 
             // Resolve max threads per group
@@ -296,7 +296,7 @@ namespace ILGPU.Runtime.OpenCL
                 DeviceId,
                 CLDeviceInfoType.CL_DEVICE_MAX_WORK_GROUP_SIZE).ToInt32();
 
-            // max work item thread dimensions
+            // Max work item thread dimensions
             var workItemSizes = new IntPtr[workItemDimensions];
 
             CurrentAPI.GetDeviceInfo(

--- a/Src/ILGPU/Runtime/OpenCL/CLDevice.cs
+++ b/Src/ILGPU/Runtime/OpenCL/CLDevice.cs
@@ -284,8 +284,10 @@ namespace ILGPU.Runtime.OpenCL
             int workItemDimensions = IntrinsicMath.Max(CurrentAPI.GetDeviceInfo<int>(
               DeviceId, CLDeviceInfoType.CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS), 3);
 
-            //OpenCL does not report maximium grid sizes, MaxGridSize value is consistent the CPU accelators and values returned by CUDA accelerators
-            //MaxGridSize is ultimately contrained by system and device memory and how each kernel manages memory.
+            //OpenCL does not report maximium grid sizes, MaxGridSize value is consistent
+            //the CPU accelator and values returned by CUDA accelerators.
+            //MaxGridSize is ultimately contrained by system and device memory
+            //and how each kernel manages memory.
             MaxGridSize = new Index3D(int.MaxValue, ushort.MaxValue, ushort.MaxValue);
 
             // Resolve max threads per group

--- a/Src/ILGPU/Runtime/OpenCL/CLDevice.cs
+++ b/Src/ILGPU/Runtime/OpenCL/CLDevice.cs
@@ -281,28 +281,30 @@ namespace ILGPU.Runtime.OpenCL
         /// </summary>
         private void InitGridInfo()
         {
-            // Max grid size
             int workItemDimensions = IntrinsicMath.Max(CurrentAPI.GetDeviceInfo<int>(
-                DeviceId,
-                CLDeviceInfoType.CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS), 3);
-            var workItemSizes = new IntPtr[workItemDimensions];
-            CurrentAPI.GetDeviceInfo(
-                DeviceId,
-                CLDeviceInfoType.CL_DEVICE_MAX_WORK_ITEM_SIZES,
-                workItemSizes);
-            MaxGridSize = new Index3D(
-                workItemSizes[0].ToInt32(),
-                workItemSizes[1].ToInt32(),
-                workItemSizes[2].ToInt32());
+              DeviceId, CLDeviceInfoType.CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS), 3);
+
+            //OpenCL does not report maximium grid sizes, MaxGridSize value is consistent the CPU accelators and values returned by CUDA accelerators
+            //MaxGridSize is ultimately contrained by system and device memory and how each kernel manages memory.
+            MaxGridSize = new Index3D(int.MaxValue, ushort.MaxValue, ushort.MaxValue);
 
             // Resolve max threads per group
             MaxNumThreadsPerGroup = CurrentAPI.GetDeviceInfo<IntPtr>(
                 DeviceId,
                 CLDeviceInfoType.CL_DEVICE_MAX_WORK_GROUP_SIZE).ToInt32();
+
+            // max work item thread dimensions
+            var workItemSizes = new IntPtr[workItemDimensions];
+
+            CurrentAPI.GetDeviceInfo(
+              DeviceId,
+              CLDeviceInfoType.CL_DEVICE_MAX_WORK_ITEM_SIZES,
+              workItemSizes);
+
             MaxGroupSize = new Index3D(
-                MaxNumThreadsPerGroup,
-                MaxNumThreadsPerGroup,
-                MaxNumThreadsPerGroup);
+                workItemSizes[0].ToInt32(),
+                workItemSizes[1].ToInt32(),
+                workItemSizes[2].ToInt32());
 
             // Result max number of threads per multiprocessor
             MaxNumThreadsPerMultiprocessor = MaxNumThreadsPerGroup;

--- a/Src/ILGPU/Runtime/OpenCL/CLDevice.cs
+++ b/Src/ILGPU/Runtime/OpenCL/CLDevice.cs
@@ -282,10 +282,11 @@ namespace ILGPU.Runtime.OpenCL
         private void InitGridInfo()
         {
             int workItemDimensions = IntrinsicMath.Max(CurrentAPI.GetDeviceInfo<int>(
-              DeviceId, CLDeviceInfoType.CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS), 3);
+                DeviceId,
+                CLDeviceInfoType.CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS), 3);
 
             //OpenCL does not report maximium grid sizes, MaxGridSize value is consistent
-            //the CPU accelator and values returned by CUDA accelerators.
+            //with the CPU accelator and values returned by CUDA accelerators.
             //MaxGridSize is ultimately contrained by system and device memory
             //and how each kernel manages memory.
             MaxGridSize = new Index3D(int.MaxValue, ushort.MaxValue, ushort.MaxValue);
@@ -299,9 +300,9 @@ namespace ILGPU.Runtime.OpenCL
             var workItemSizes = new IntPtr[workItemDimensions];
 
             CurrentAPI.GetDeviceInfo(
-              DeviceId,
-              CLDeviceInfoType.CL_DEVICE_MAX_WORK_ITEM_SIZES,
-              workItemSizes);
+                DeviceId,
+                CLDeviceInfoType.CL_DEVICE_MAX_WORK_ITEM_SIZES,
+                workItemSizes);
 
             MaxGroupSize = new Index3D(
                 workItemSizes[0].ToInt32(),


### PR DESCRIPTION
due to incorrect estimation of MaxGridSize in OpenCL. Cuda provides an API for MaxGridSize however the CUDA's result is identical to `MaxGridSize = new Index3D(int.MaxValue, ushort.MaxValue, ushort.MaxValue);` used in CPUDevice.

OpenCL CLDevice InitGridInfo() method conflated MaxGridSize with MaxWorkItemSizes resulting in "InboundsInclusive" returning false for modestly sized problems. OpenCL does not provides an API call for MaxGridSize.

MaxGridSize is set to `new Index3D(int.MaxValue, ushort.MaxValue, ushort.MaxValue);`
MaxGroupSize is set max work item dimensions.