### PR TITLE
Improved hash code of index types.

### DIFF
--- a/Src/ILGPU/IndexTypes.tt
+++ b/Src/ILGPU/IndexTypes.tt
@@ -363,7 +363,11 @@ namespace ILGPU
         /// </summary>
         /// <returns>The hash code of this index.</returns>
         public readonly override int GetHashCode() =>
+#if NETFRAMEWORK
             <#= def.Expression(" ^ ", p => $"{p}.GetHashCode()") #>;
+#else
+            HashCode.Combine(<#= def.Expression(", ", p => $"{p}") #>);
+#endif
 
         /// <summary>
         /// Returns the string representation of this index.

--- a/Src/ILGPU/IndexTypes.tt
+++ b/Src/ILGPU/IndexTypes.tt
@@ -363,11 +363,7 @@ namespace ILGPU
         /// </summary>
         /// <returns>The hash code of this index.</returns>
         public readonly override int GetHashCode() =>
-<# if (dimension == 1) { #>
-            <#= def.Expression(", ", p => $"{p}") #>.GetHashCode();
-<# } else { #>
-            (<#= def.Expression(", ", p => $"{p}") #>).GetHashCode();
-<# } #>
+            <#= def.Expression(" ^ ", p => $"{p}.GetHashCode()") #>;
 
         /// <summary>
         /// Returns the string representation of this index.


### PR DESCRIPTION
As part of the copyright transfer https://github.com/m4rs-mt/ILGPU/issues/598, this is a replacement implementation for #510.

Reverted to the original hash code calculation (pre-#510) on `net471`. On newer frameworks, we take advantage of the `HashCode.Combine` functionality.