### PR TITLE
Ensure Cuda accelerator is bound before calling CuBlas methods.

### DIFF
--- a/Src/ILGPU.Algorithms/Runtime/Cuda/CuBlas.cs
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/CuBlas.cs
@@ -267,6 +267,13 @@ namespace ILGPU.Runtime.Cuda
             pointerModeHandler.UpdatePointerMode(this, pointerMode);
         }
 
+        /// <summary>
+        /// Ensures that the accelerator for this CuBlas instance is made current.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void EnsureAcceleratorBinding() =>
+            Stream.Accelerator.Bind();
+
         #endregion
 
         #region IDisposable

--- a/Src/ILGPU.Algorithms/Runtime/Cuda/CuBlasMethodsLevel1.tt
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/CuBlasMethodsLevel1.tt
@@ -37,6 +37,7 @@ namespace ILGPU.Runtime.Cuda
         /// <returns>The computed value.</returns>
         public unsafe int <#= entry #>(ArrayView<<#= type #>> input)
         {
+            EnsureAcceleratorBinding();
             EnsurePointerMode(CuBlasPointerMode.Host);
 
             int result;
@@ -57,6 +58,7 @@ namespace ILGPU.Runtime.Cuda
         /// <param name="output">The output view.</param>
         public unsafe void <#= entry #>(ArrayView<<#= type #>> input, ArrayView<int> output)
         {
+            EnsureAcceleratorBinding();
             EnsurePointerMode(CuBlasPointerMode.Device);
 
             CuBlasException.ThrowIfFailed(
@@ -80,6 +82,7 @@ namespace ILGPU.Runtime.Cuda
         /// <returns>The computed value.</returns>
         public unsafe <#= type #> <#= entry #>(ArrayView<<#= type #>> input)
         {
+            EnsureAcceleratorBinding();
             EnsurePointerMode(CuBlasPointerMode.Host);
 
             <#= type #> result = default;
@@ -100,6 +103,7 @@ namespace ILGPU.Runtime.Cuda
         /// <param name="output">The output view.</param>
         public unsafe void <#= entry #>(ArrayView<<#= type #>> input, ArrayView<<#= type #>> output)
         {
+            EnsureAcceleratorBinding();
             EnsurePointerMode(CuBlasPointerMode.Device);
 
             CuBlasException.ThrowIfFailed(
@@ -126,8 +130,9 @@ namespace ILGPU.Runtime.Cuda
             ArrayView<<#= type #>> x,
             ArrayView<<#= type #>> y)
         {
-            <#= paramVerifier #>;
             Debug.Assert(x.Length == y.Length, "Invalid length");
+            EnsureAcceleratorBinding();
+            <#= paramVerifier #>;
 
             CuBlasException.ThrowIfFailed(
                 API.<#= func #>(
@@ -154,8 +159,9 @@ namespace ILGPU.Runtime.Cuda
             ArrayView<<#= type #>> x,
             ArrayView<<#= type #>> y)
         {
-            EnsurePointerMode(CuBlasPointerMode.Host);
             Debug.Assert(x.Length == y.Length, "Invalid length");
+            EnsureAcceleratorBinding();
+            EnsurePointerMode(CuBlasPointerMode.Host);
 
             <#= type #> result = default;
             CuBlasException.ThrowIfFailed(
@@ -181,8 +187,9 @@ namespace ILGPU.Runtime.Cuda
             ArrayView<<#= type #>> y,
             ArrayView<<#= type #>> output)
         {
-            EnsurePointerMode(CuBlasPointerMode.Device);
             Debug.Assert(x.Length == y.Length, "Invalid length");
+            EnsureAcceleratorBinding();
+            EnsurePointerMode(CuBlasPointerMode.Device);
 
             CuBlasException.ThrowIfFailed(
                 API.<#= func #>(
@@ -212,6 +219,7 @@ namespace ILGPU.Runtime.Cuda
             <#= paramType #> c,
             <#= paramType #> s)
         {
+            EnsureAcceleratorBinding();
             <#= paramVerifier #>;
 
             CuBlasException.ThrowIfFailed(
@@ -243,6 +251,8 @@ namespace ILGPU.Runtime.Cuda
             <#= elemType #> c,
             <#= type #> s)
         {
+            EnsureAcceleratorBinding();
+
             CuBlasException.ThrowIfFailed(
                 API.<#= func #>(
                     Handle,
@@ -265,6 +275,8 @@ namespace ILGPU.Runtime.Cuda
             ArrayView<<#= elemType #>> c,
             ArrayView<<#= type #>> s)
         {
+            EnsureAcceleratorBinding();
+
             CuBlasException.ThrowIfFailed(
                 API.<#= func #>(
                     Handle,
@@ -290,6 +302,7 @@ namespace ILGPU.Runtime.Cuda
             ArrayView<<#= type #>> y,
             <#= paramType #> param)
         {
+            EnsureAcceleratorBinding();
             <#= paramVerifier #>;
 
             CuBlasException.ThrowIfFailed(
@@ -316,6 +329,7 @@ namespace ILGPU.Runtime.Cuda
             <#= paramType #> alpha,
             ArrayView<<#= type #>> x)
         {
+            EnsureAcceleratorBinding();
             <#= paramVerifier #>;
 
             CuBlasException.ThrowIfFailed(
@@ -341,6 +355,7 @@ namespace ILGPU.Runtime.Cuda
             ArrayView<<#= type #>> y)
         {
             Debug.Assert(x.Length == y.Length, "Invalid length");
+            EnsureAcceleratorBinding();
 
             CuBlasException.ThrowIfFailed(
                 API.<#= func #>(

--- a/Src/ILGPU.Algorithms/Runtime/Cuda/CuBlasMethodsLevel2.tt
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/CuBlasMethodsLevel2.tt
@@ -46,6 +46,7 @@ namespace ILGPU.Runtime.Cuda
             ArrayView<<#= type #>> y,
             int incy)
         {
+            EnsureAcceleratorBinding();
             <#= paramVerifier #>;
 
             CuBlasException.ThrowIfFailed(
@@ -86,6 +87,7 @@ namespace ILGPU.Runtime.Cuda
             ArrayView<<#= type #>> y,
             int incy)
         {
+            EnsureAcceleratorBinding();
             <#= paramVerifier #>;
 
             CuBlasException.ThrowIfFailed(
@@ -122,6 +124,7 @@ namespace ILGPU.Runtime.Cuda
             ArrayView<<#= type #>> a,
             int lda)
         {
+            EnsureAcceleratorBinding();
             <#= paramVerifier #>;
 
             CuBlasException.ThrowIfFailed(
@@ -158,6 +161,7 @@ namespace ILGPU.Runtime.Cuda
             ArrayView<<#= type #>> y,
             int incy)
         {
+            EnsureAcceleratorBinding();
             <#= paramVerifier #>;
 
             CuBlasException.ThrowIfFailed(
@@ -194,6 +198,7 @@ namespace ILGPU.Runtime.Cuda
             ArrayView<<#= type #>> y,
             int incy)
         {
+            EnsureAcceleratorBinding();
             <#= paramVerifier #>;
 
             CuBlasException.ThrowIfFailed(
@@ -225,6 +230,7 @@ namespace ILGPU.Runtime.Cuda
             int incx,
             ArrayView<<#= type #>> ap)
         {
+            EnsureAcceleratorBinding();
             <#= paramVerifier #>;
 
             CuBlasException.ThrowIfFailed(
@@ -255,6 +261,7 @@ namespace ILGPU.Runtime.Cuda
             int incy,
             ArrayView<<#= type #>> ap)
         {
+            EnsureAcceleratorBinding();
             <#= paramVerifier #>;
 
             CuBlasException.ThrowIfFailed(
@@ -289,6 +296,7 @@ namespace ILGPU.Runtime.Cuda
             ArrayView<<#= type #>> y,
             int incy)
         {
+            EnsureAcceleratorBinding();
             <#= paramVerifier #>;
 
             CuBlasException.ThrowIfFailed(
@@ -322,6 +330,7 @@ namespace ILGPU.Runtime.Cuda
             ArrayView<<#= type #>> a,
             int lda)
         {
+            EnsureAcceleratorBinding();
             <#= paramVerifier #>;
 
             CuBlasException.ThrowIfFailed(
@@ -354,6 +363,7 @@ namespace ILGPU.Runtime.Cuda
             ArrayView<<#= type #>> a,
             int lda)
         {
+            EnsureAcceleratorBinding();
             <#= paramVerifier #>;
 
             CuBlasException.ThrowIfFailed(
@@ -389,6 +399,8 @@ namespace ILGPU.Runtime.Cuda
             ArrayView<<#= type #>> x,
             int incx)
         {
+            EnsureAcceleratorBinding();
+
             CuBlasException.ThrowIfFailed(
                 API.<#= func #>(
                     Handle,
@@ -420,6 +432,8 @@ namespace ILGPU.Runtime.Cuda
             ArrayView<<#= type #>> x,
             int incx)
         {
+            EnsureAcceleratorBinding();
+
             CuBlasException.ThrowIfFailed(
                 API.<#= func #>(
                     Handle,
@@ -450,6 +464,8 @@ namespace ILGPU.Runtime.Cuda
             ArrayView<<#= type #>> x,
             int incx)
         {
+            EnsureAcceleratorBinding();
+
             CuBlasException.ThrowIfFailed(
                 API.<#= func #>(
                     Handle,

--- a/Src/ILGPU.Algorithms/Runtime/Cuda/CuBlasMethodsLevel3.tt
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/CuBlasMethodsLevel3.tt
@@ -46,6 +46,7 @@ namespace ILGPU.Runtime.Cuda
             ArrayView<<#= type #>> c,
             int ldc)
         {
+            EnsureAcceleratorBinding();
             <#= paramVerifier #>;
 
             CuBlasException.ThrowIfFailed(
@@ -87,6 +88,7 @@ namespace ILGPU.Runtime.Cuda
             ArrayView<<#= type #>> c,
             int ldc)
         {
+            EnsureAcceleratorBinding();
             <#= paramVerifier #>;
 
             CuBlasException.ThrowIfFailed(
@@ -125,6 +127,7 @@ namespace ILGPU.Runtime.Cuda
             ArrayView<<#= type #>> c,
             int ldc)
         {
+            EnsureAcceleratorBinding();
             <#= paramVerifier #>;
 
             CuBlasException.ThrowIfFailed(
@@ -164,6 +167,7 @@ namespace ILGPU.Runtime.Cuda
             ArrayView<<#= type #>> c,
             int ldc)
         {
+            EnsureAcceleratorBinding();
             <#= paramVerifier #>;
 
             CuBlasException.ThrowIfFailed(
@@ -205,6 +209,7 @@ namespace ILGPU.Runtime.Cuda
             ArrayView<<#= type #>> c,
             int ldc)
         {
+            EnsureAcceleratorBinding();
             <#= paramVerifier #>;
 
             CuBlasException.ThrowIfFailed(
@@ -245,6 +250,7 @@ namespace ILGPU.Runtime.Cuda
             ArrayView<<#= type #>> b,
             int ldb)
         {
+            EnsureAcceleratorBinding();
             <#= paramVerifier #>;
 
             CuBlasException.ThrowIfFailed(
@@ -284,6 +290,7 @@ namespace ILGPU.Runtime.Cuda
             ArrayView<<#= type #>> c,
             int ldc)
         {
+            EnsureAcceleratorBinding();
             <#= paramVerifier #>;
 
             CuBlasException.ThrowIfFailed(
@@ -321,6 +328,8 @@ namespace ILGPU.Runtime.Cuda
             ArrayView<<#= type #>> c,
             int ldc)
         {
+            EnsureAcceleratorBinding();
+
             CuBlasException.ThrowIfFailed(
                 API.<#= func #>(
                     Handle,


### PR DESCRIPTION
Fixes https://github.com/m4rs-mt/ILGPU/issues/623.

Before calling a CuBlas method, ensure that the associated Accelerator is made the current accelerator.