### PR TITLE
Fixed race condition in WarpReductions.Reduce for CPU accelerators.

### DIFF
--- a/Src/ILGPU.Algorithms/IL/ILGroupExtensions.cs
+++ b/Src/ILGPU.Algorithms/IL/ILGroupExtensions.cs
@@ -51,6 +51,16 @@ namespace ILGPU.Algorithms.IL
             public readonly int ThreadDimension => Group.Dimension.Size;
 
             /// <summary>
+            /// Returns 1.
+            /// </summary>
+            public readonly int ReduceSegments => 1;
+
+            /// <summary>
+            /// Returns 0.
+            /// </summary>
+            public readonly int ReduceSegmentIndex => 0;
+
+            /// <summary>
             /// Performs a group-wide barrier.
             /// </summary>
             public readonly void Barrier() => Group.Barrier();

--- a/Src/ILGPU.Algorithms/IL/ILWarpExtensions.cs
+++ b/Src/ILGPU.Algorithms/IL/ILWarpExtensions.cs
@@ -51,6 +51,16 @@ namespace ILGPU.Algorithms.IL
             public readonly int ThreadDimension => Warp.WarpSize;
 
             /// <summary>
+            /// Returns the number of warps per group.
+            /// </summary>
+            public readonly int ReduceSegments => MaxNumThreads / Warp.WarpSize;
+
+            /// <summary>
+            /// Returns the current warp index.
+            /// </summary>
+            public readonly int ReduceSegmentIndex => Warp.WarpIdx;
+
+            /// <summary>
             /// Performs a warp-wide barrier.
             /// </summary>
             public readonly void Barrier() => Warp.Barrier();


### PR DESCRIPTION
This PR fixes a critical race condition affecting the CPU implementation of `WarpExtensions.Reduce` and `WarpExtensions.AllReduce`.