### PR TITLE
Fixed `OutOfRessources` when emitting Code with debug assertions turned on using the Cuda backend

### DIFF
--- a/Src/ILGPU/Backends/IL/ILBackend.cs
+++ b/Src/ILGPU/Backends/IL/ILBackend.cs
@@ -111,7 +111,8 @@ namespace ILGPU.Backends.IL
                     new ILAcceleratorSpecializer(
                         PointerType,
                         warpSize,
-                        Context.Properties.EnableAssertions),
+                        Context.Properties.EnableAssertions,
+                        Context.Properties.EnableIOOperations),
                     context.Properties.InliningMode,
                     context.Properties.OptimizationLevel);
                 builder.Add(transformerBuilder.ToTransformer());

--- a/Src/ILGPU/Backends/IL/Transformations/ILAcceleratorSpecializer.cs
+++ b/Src/ILGPU/Backends/IL/Transformations/ILAcceleratorSpecializer.cs
@@ -10,7 +10,6 @@
 // ---------------------------------------------------------------------------------------
 
 using ILGPU.IR;
-using ILGPU.IR.Rewriting;
 using ILGPU.IR.Transformations;
 using ILGPU.IR.Types;
 using ILGPU.IR.Values;
@@ -31,15 +30,18 @@ namespace ILGPU.Backends.IL.Transformations
         /// <param name="pointerType">The actual pointer type to use.</param>
         /// <param name="warpSize">The warp size to use.</param>
         /// <param name="enableAssertions">True, if the assertions are enabled.</param>
+        /// <param name="enableIOOperations">True, if the IO is enabled.</param>
         public ILAcceleratorSpecializer(
             PrimitiveType pointerType,
             int warpSize,
-            bool enableAssertions)
+            bool enableAssertions,
+            bool enableIOOperations)
             : base(
                   AcceleratorType.CPU,
                   warpSize,
                   pointerType,
-                  enableAssertions)
+                  enableAssertions,
+                  enableIOOperations)
         { }
 
         #endregion
@@ -49,18 +51,20 @@ namespace ILGPU.Backends.IL.Transformations
         /// <summary>
         /// Keeps the debug assertion operation.
         /// </summary>
-        protected override void Specialize(
-            in RewriterContext context,
-            IRContext irContext,
+        protected override void Implement(
+            IRContext context,
+            Method.Builder methodBuilder,
+            BasicBlock.Builder builder,
             DebugAssertOperation debugAssert)
         { }
 
         /// <summary>
         /// Keeps the IO operation.
         /// </summary>
-        protected override void Specialize(
-            in RewriterContext context,
-            IRContext irContext,
+        protected override void Implement(
+            IRContext context,
+            Method.Builder methodBuilder,
+            BasicBlock.Builder builder,
             WriteToOutput writeToOutput)
         { }
 

--- a/Src/ILGPU/Backends/OpenCL/CLBackend.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLBackend.cs
@@ -73,7 +73,9 @@ namespace ILGPU.Backends.OpenCL
                 var transformerBuilder = Transformer.CreateBuilder(
                     TransformerConfiguration.Empty);
                 transformerBuilder.AddBackendOptimizations(
-                    new CLAcceleratorSpecializer(PointerType),
+                    new CLAcceleratorSpecializer(
+                        PointerType,
+                        Context.Properties.EnableIOOperations),
                     context.Properties.InliningMode,
                     context.Properties.OptimizationLevel);
                 builder.Add(transformerBuilder.ToTransformer());

--- a/Src/ILGPU/Backends/PTX/PTXBackend.cs
+++ b/Src/ILGPU/Backends/PTX/PTXBackend.cs
@@ -101,7 +101,8 @@ namespace ILGPU.Backends.PTX
                 transformerBuilder.AddBackendOptimizations(
                     new PTXAcceleratorSpecializer(
                         PointerType,
-                        Context.Properties.EnableAssertions),
+                        Context.Properties.EnableAssertions,
+                        Context.Properties.EnableIOOperations),
                     context.Properties.InliningMode,
                     context.Properties.OptimizationLevel);
 

--- a/Src/ILGPU/Backends/PTX/PTXCodeGenerator.Values.cs
+++ b/Src/ILGPU/Backends/PTX/PTXCodeGenerator.Values.cs
@@ -653,26 +653,22 @@ namespace ILGPU.Backends.PTX
                 stringConstants.Add(key, stringBinding);
             }
 
-            // Move the value into a register
-            var tempValueRegister = AllocatePlatformRegister(
-                out RegisterDescription description);
+            // Move the value into the target register
+            var register = AllocateHardware(value);
             using (var command = BeginMove())
             {
-                command.AppendSuffix(description.BasicValueType);
-                command.AppendArgument(tempValueRegister);
+                command.AppendSuffix(register.Description.BasicValueType);
+                command.AppendArgument(register);
                 command.AppendRawValueReference(stringBinding);
             }
 
             // Convert the string value into the generic address space
-            // string (global) -> string (generic)
-            var register = AllocateHardware(value);
+            // string (global) -> string (generic) (in place conversion)
             CreateAddressSpaceCast(
-                tempValueRegister,
+                register,
                 register,
                 MemoryAddressSpace.Global,
                 MemoryAddressSpace.Generic);
-
-            FreeRegister(tempValueRegister);
         }
 
         /// <summary>

--- a/Src/ILGPU/Backends/PTX/PTXCodeGenerator.cs
+++ b/Src/ILGPU/Backends/PTX/PTXCodeGenerator.cs
@@ -336,7 +336,6 @@ namespace ILGPU.Backends.PTX
 
             Architecture = args.Backend.Architecture;
             FastMath = args.Properties.MathMode >= MathMode.Fast;
-            EnableAssertions = args.Properties.EnableAssertions;
 
             labelPrefix = "L_" + Method.Id.ToString();
             ReturnParamName = "retval_" + Method.Id;
@@ -391,11 +390,6 @@ namespace ILGPU.Backends.PTX
         /// Returns true if fast math is active.
         /// </summary>
         public bool FastMath { get; }
-
-        /// <summary>
-        /// Returns true if assertions are enabled.
-        /// </summary>
-        public bool EnableAssertions { get; }
 
         /// <summary>
         /// Returns the associated string builder.

--- a/Src/ILGPU/Context.Builder.cs
+++ b/Src/ILGPU/Context.Builder.cs
@@ -120,7 +120,7 @@ namespace ILGPU
 
             /// <summary>
             /// Turns on all assertion checks (including out-of-bounds checks) for view
-            /// accesses.
+            /// and array accesses.
             /// </summary>
             /// <remarks>
             /// Note that calling this function automatically switches the debug mode
@@ -130,6 +130,21 @@ namespace ILGPU
             public Builder Assertions()
             {
                 EnableAssertions = true;
+                return DebugSymbols(DebugSymbolsMode.Basic);
+            }
+
+            /// <summary>
+            /// Turns on all IO operations checks.
+            /// accesses.
+            /// </summary>
+            /// <remarks>
+            /// Note that calling this function automatically switches the debug mode
+            /// to at least <see cref="DebugSymbolsMode.Basic"/>.
+            /// </remarks>
+            /// <returns>The current builder instance.</returns>
+            public Builder IOOperations()
+            {
+                EnableIOOperations = true;
                 return DebugSymbols(DebugSymbolsMode.Basic);
             }
 
@@ -194,6 +209,13 @@ namespace ILGPU
             public Builder AutoAssertions() => Debugger.IsAttached ? Assertions() : this;
 
             /// <summary>
+            /// Automatically enables all IO operations as soon as a debugger is attached.
+            /// </summary>
+            /// <returns>The current builder instance.</returns>
+            public Builder AutoIOOperations() =>
+                Debugger.IsAttached ? IOOperations() : this;
+
+            /// <summary>
             /// Automatically switches to <see cref="Debug()"/> mode if a debugger is
             /// attached.
             /// </summary>
@@ -201,13 +223,15 @@ namespace ILGPU
             public Builder AutoDebug() => Debugger.IsAttached ? Debug() : this;
 
             /// <summary>
-            /// Sets the optimization level to <see cref="OptimizationLevel.Debug"/> and
-            /// call <see cref="Assertions()"/> to turn on all debug assertion checks.
+            /// Sets the optimization level to <see cref="OptimizationLevel.Debug"/>,
+            /// calls <see cref="Assertions()"/> to turn on all debug assertion checks
+            /// and calls <see cref="IOOperations"/> to turn on all debug outputs.
             /// </summary>
             /// <returns>The current builder instance.</returns>
             public Builder Debug() =>
                 Optimize(OptimizationLevel.Debug).
                 Assertions().
+                IOOperations().
                 DebugSymbols(DebugSymbolsMode.Kernel);
 
             /// <summary>

--- a/Src/ILGPU/ContextProperties.cs
+++ b/Src/ILGPU/ContextProperties.cs
@@ -304,6 +304,12 @@ namespace ILGPU
         public bool EnableAssertions { get; protected set; }
 
         /// <summary>
+        /// Returns true if IO is enabled.
+        /// </summary>
+        /// <remarks>Disabled by default.</remarks>
+        public bool EnableIOOperations { get; protected set; }
+
+        /// <summary>
         /// Returns true if additional kernel information is enabled.
         /// </summary>
         /// <remarks>Disabled by default.</remarks>

--- a/Src/ILGPU/IR/Transformations/AcceleratorSpecializer.cs
+++ b/Src/ILGPU/IR/Transformations/AcceleratorSpecializer.cs
@@ -13,8 +13,7 @@ using ILGPU.IR.Rewriting;
 using ILGPU.IR.Types;
 using ILGPU.IR.Values;
 using ILGPU.Runtime;
-using ILGPU.Util;
-using System.Reflection;
+using System.Collections.Generic;
 
 namespace ILGPU.IR.Transformations
 {
@@ -36,11 +35,18 @@ namespace ILGPU.IR.Transformations
             /// </summary>
             public SpecializerData(
                 AcceleratorSpecializer specializer,
-                IRContext context)
+                IRContext context,
+                List<Value> toImplement)
             {
+                ToImplement = toImplement;
                 Specializer = specializer;
                 Context = context;
             }
+
+            /// <summary>
+            /// A list of values to be implemented in the next step.
+            /// </summary>
+            public List<Value> ToImplement { get; }
 
             /// <summary>
             /// Returns the parent specializer instance.
@@ -72,66 +78,11 @@ namespace ILGPU.IR.Transformations
             /// Returns true if assertions are enabled.
             /// </summary>
             public readonly bool EnableAssertions => Specializer.EnableAssertions;
-        }
 
-        #endregion
-
-        #region Static
-
-        /// <summary>
-        /// Builds an assert implementation that calls a nested fail function based on
-        /// a boolean condition (first parameter).
-        /// </summary>
-        protected static Method BuildDebugAssertImplementation(
-            IRContext irContext,
-            MethodBase debugAssertMethod,
-            MethodBase assertFailedMethod)
-        {
-            // Create a call to the debug-implementation wrapper while taking the
-            // current source location into account
-            var method = irContext.Declare(debugAssertMethod, out bool created);
-            if (!created)
-                return method;
-
-            var location = Location.Nowhere;
-            using var builder = method.CreateBuilder();
-            method.AddFlags(MethodFlags.Inline);
-
-            // Create the entry, body and exit blocks
-            var entryBlock = builder.EntryBlockBuilder;
-            var bodyBlock = builder.CreateBasicBlock(location);
-            var exitBlock = builder.CreateBasicBlock(location);
-
-            // Initialize the parameters
-            var sourceParameters = debugAssertMethod.GetParameters();
-            var parameters = InlineList<Parameter>.Create(sourceParameters.Length);
-            foreach (var parameter in sourceParameters)
-            {
-                var paramType = entryBlock.CreateType(parameter.ParameterType);
-                parameters.Add(builder.AddParameter(paramType, parameter.Name));
-            }
-
-            // Check condition
-            entryBlock.CreateIfBranch(
-                location,
-                parameters[0],
-                exitBlock,
-                bodyBlock);
-
-            // Fill the body
-            var assertFailed = bodyBlock.CreateCall(
-                location,
-                irContext.Declare(assertFailedMethod, out var _));
-            for (int i = 1; i < parameters.Count; ++i)
-                assertFailed.Add(parameters[i]);
-            assertFailed.Seal();
-
-            bodyBlock.CreateBranch(location, exitBlock);
-
-            // Create return
-            exitBlock.CreateReturn(location);
-
-            return method;
+            /// <summary>
+            /// Returns true if IO is enabled.
+            /// </summary>
+            public readonly bool EnableIOOperations => Specializer.EnableIOOperations;
         }
 
         #endregion
@@ -243,9 +194,7 @@ namespace ILGPU.IR.Transformations
         }
 
         /// <summary>
-        /// Specializes debug operations via the instance method
-        /// <see cref="Specialize(in RewriterContext, IRContext, DebugAssertOperation)"/>
-        /// of the parent <paramref name="data"/> instance.
+        /// Removes or collects debug operations.
         /// </summary>
         private static void Specialize(
             RewriterContext context,
@@ -253,21 +202,24 @@ namespace ILGPU.IR.Transformations
             DebugAssertOperation value)
         {
             if (data.EnableAssertions)
-                data.Specializer.Specialize(context, data.Context, value);
+                data.ToImplement.Add(value);
             else
                 context.Remove(value);
         }
 
         /// <summary>
-        /// Specializes IO output operations via the instance method
-        /// <see cref="Specialize(in RewriterContext, IRContext, WriteToOutput)"/> of
-        /// the parent <paramref name="data"/> instance.
+        /// Removes or collects IO operations.
         /// </summary>
         private static void Specialize(
             RewriterContext context,
             SpecializerData data,
-            WriteToOutput value) =>
-            data.Specializer.Specialize(context, data.Context, value);
+            WriteToOutput value)
+        {
+            if (data.EnableAssertions)
+                data.ToImplement.Add(value);
+            else
+                context.Remove(value);
+        }
 
         #endregion
 
@@ -305,16 +257,19 @@ namespace ILGPU.IR.Transformations
         /// <param name="warpSize">The warp size (if any).</param>
         /// <param name="intPointerType">The native integer pointer type.</param>
         /// <param name="enableAssertions">True, if the assertions are enabled.</param>
+        /// <param name="enableIOOperations">True, if the IO is enabled.</param>
         public AcceleratorSpecializer(
             AcceleratorType acceleratorType,
             int? warpSize,
             PrimitiveType intPointerType,
-            bool enableAssertions)
+            bool enableAssertions,
+            bool enableIOOperations)
         {
             AcceleratorType = acceleratorType;
             WarpSize = warpSize;
             IntPointerType = intPointerType;
             EnableAssertions = enableAssertions;
+            EnableIOOperations = enableIOOperations;
         }
 
         #endregion
@@ -341,6 +296,11 @@ namespace ILGPU.IR.Transformations
         /// </summary>
         public bool EnableAssertions { get; }
 
+        /// <summary>
+        /// Returns true if debug output is enabled.
+        /// </summary>
+        public bool EnableIOOperations { get; }
+
         #endregion
 
         #region Methods
@@ -350,37 +310,59 @@ namespace ILGPU.IR.Transformations
         /// </summary>
         protected override bool PerformTransformation(
             IRContext context,
-            Method.Builder builder) =>
-            Rewriter.Rewrite(
-                builder.SourceBlocks,
-                builder,
-                new SpecializerData(this, context));
+            Method.Builder builder)
+        {
+            var toImplement = new List<Value>(16);
+            var data = new SpecializerData(this, context, toImplement);
+            if (!Rewriter.Rewrite(builder.SourceBlocks, builder, data))
+                return false;
+
+            foreach (var value in toImplement)
+            {
+                switch (value)
+                {
+                    case DebugAssertOperation assert:
+                        Implement(context, builder, builder[assert.BasicBlock], assert);
+                        break;
+                    case WriteToOutput write:
+                        Implement(context, builder, builder[write.BasicBlock], write);
+                        break;
+                    default:
+                        throw builder.GetInvalidOperationException();
+                }
+            }
+            return true;
+        }
 
         /// <summary>
         /// Specializes debug output operations (if any). Note that this default
         /// implementation removes the output operations from the current program.
         /// </summary>
-        /// <param name="context">The current rewriter context.</param>
-        /// <param name="irContext">The parent IR context.</param>
+        /// <param name="context">The parent IR context.</param>
+        /// <param name="methodBuilder">The parent method builder.</param>
+        /// <param name="builder">The current block builder.</param>
         /// <param name="debugAssert">The debug assert operation.</param>
-        protected virtual void Specialize(
-            in RewriterContext context,
-            IRContext irContext,
+        protected virtual void Implement(
+            IRContext context,
+            Method.Builder methodBuilder,
+            BasicBlock.Builder builder,
             DebugAssertOperation debugAssert) =>
-            context.Remove(debugAssert);
+            builder.Remove(debugAssert);
 
         /// <summary>
         /// Specializes IO output operations (if any). Note that this default
         /// implementation removes the output operations from the current program.
         /// </summary>
-        /// <param name="context">The current rewriter context.</param>
-        /// <param name="irContext">The parent IR context.</param>
+        /// <param name="context">The parent IR context.</param>
+        /// <param name="methodBuilder">The parent method builder.</param>
+        /// <param name="builder">The current block builder.</param>
         /// <param name="writeToOutput">The IO output operation.</param>
-        protected virtual void Specialize(
-            in RewriterContext context,
-            IRContext irContext,
+        protected virtual void Implement(
+            IRContext context,
+            Method.Builder methodBuilder,
+            BasicBlock.Builder builder,
             WriteToOutput writeToOutput) =>
-            context.Remove(writeToOutput);
+            builder.Remove(writeToOutput);
 
         #endregion
     }


### PR DESCRIPTION
This PR fixes an often mentioned but extremely complicated to find problem regarding launch errors in debug builds with enabled assertion checks. From time to time, it could happen that a working kernel could no longer be started in `Debug` mode, because enabled assertion checks seemed to cause problems with the `CudaAccelerator`. After working on #615, I was able to deterministically reproduce this problem using one of our more complex test cases from the `Algorithms` library.

It turns out that the way we emit assertion checks can cause problems in the `PTX assembler` (which ships with the NVIDIA drivers). The problems occurred in the form that the assembler "overestimating" (!) the live ranges of certain registers that appear in the error messages of the assertion checks. The following example demonstrates the problem:

```asm
	and.pred	%p3, %p1, %p2;
        // Move all string constants into the registers before we check for a failed assertion
	mov.b64	%rd4, __strconst1463;
	cvta.global.u64	%rd5, %rd4;
	mov.b64	%rd4, __strconst1537;
	cvta.global.u64	%rd6, %rd4;
	mov.b64	%rd4, __strconst1539;
	cvta.global.u64	%rd7, %rd4;
	@%p3 bra	L_14503;
	bra	L_14502;

	L_14502:
        // Setup the actual assertion call
	{
	.param .b64 callParam0;
	st.param.b64	[callParam0], %rd5;
	.param .b64 callParam1;
	st.param.b64	[callParam1], %rd6;
	.param .b32 callParam2;
	st.param.b32	[callParam2], 66;
	.param .b64 callParam3;
	st.param.b64	[callParam3], %rd7;
	.param .b32 callParam4;
	st.param.b32	[callParam4], 1;
	call __assertfail, (
		callParam0,
		callParam1,
		callParam2,
		callParam3,
		callParam4
	);
	}

	bra	L_14503;
```

After investigating the samples for quite some time while looking at the `SASS` code, it turned out that changing the emitted IR code to (based on the sample above):

```asm
        // Check whether the assertion failed
	@%p5 bra	L_6632;
	bra	L_6631;

        // Move all string constants into the right registers and convert the address spaces in place
	L_6631:
	mov.b64	%rd5, __strconst730;
	cvta.global.u64	%rd5, %rd5;
	mov.b64	%rd6, __strconst731;
	cvta.global.u64	%rd6, %rd6;
	mov.b64	%rd7, __strconst733;
	cvta.global.u64	%rd7, %rd7;

        // Setup the actual assertion call
	{
	.param .b64 callParam0;
	st.param.b64	[callParam0], %rd5;
	.param .b64 callParam1;
	st.param.b64	[callParam1], %rd6;
	.param .b32 callParam2;
	st.param.b32	[callParam2], 66;
	.param .b64 callParam3;
	st.param.b64	[callParam3], %rd7;
	.param .b32 callParam4;
	st.param.b32	[callParam4], 1;
	call __assertfail, (
		callParam0,
		callParam1,
		callParam2,
		callParam3,
		callParam4
	);
	}

	bra	L_6632;

	L_6632:
```

This solves the problem as the `PTX Assembler` was able to compute all live ranges of all involved registers properly 🔢.

This PR changes the current PTX code generator to emit the "newly determined" pattern for all debug assertions using the `CudaAccelerator`/`PTXBackend`. Please also note that I added an option to turn on/off all debug outputs (`Interop.WriteLine`, disabled by default).