### PR TITLE
Fixed invalid alignment of dynamic shared memory allocations.

### DIFF
--- a/Src/ILGPU/IR/Analyses/FixPointAnalysis.cs
+++ b/Src/ILGPU/IR/Analyses/FixPointAnalysis.cs
@@ -580,6 +580,7 @@ namespace ILGPU.IR.Analyses
             where TContext : IAnalysisValueContext<T> =>
             value switch
             {
+                Alloca _ => source,
                 GetField getField => GetField(source, getField, context),
                 SetField setField => SetField(source, setField, context),
                 StructureValue structureValue =>


### PR DESCRIPTION
This PR fixes a performance issue in O2 builds affecting the vectorization capabilities of shared-memory I/O operations. Before merging this PR, the following sample code will be converted to a sequence of non-vectorized IO operations:
```c#
            target[Group.IdxX] = shared[Group.IdxX];
```

Assembler code before:
```asm
	mul.wide.u32	%rd9, %r5, 16;
	add.u64	%rd8, %rd3, %rd9;
	mov.b32	%r6, %tid.x;
	mul.wide.u32	%rd10, %r6, 16;
	add.u64	%rd9, %rd5, %rd10;
	ld.shared.f32	%f5, [%rd9];
	ld.shared.f32	%f6, [%rd9+4];
	ld.shared.f32	%f7, [%rd9+8];
	ld.shared.f32	%f8, [%rd9+12];
	st.global.v4.f32	[%rd8], {%f5, %f6, %f7, %f8};
```

After merging this PR:
```asm
	mul.wide.u32	%rd9, %r5, 16;
	add.u64	%rd8, %rd3, %rd9;
	mov.b32	%r6, %tid.x;
	mul.wide.u32	%rd10, %r6, 16;
	add.u64	%rd9, %rd5, %rd10;
	ld.shared.v4.f32	{%f5, %f6, %f7, %f8}, [%rd9];
	st.global.v4.f32	[%rd8], {%f5, %f6, %f7, %f8};
```