### PR TITLE
Updated CuBlas interface.

### DIFF
--- a/Samples/AlgorithmsCuBlas/Program.cs
+++ b/Samples/AlgorithmsCuBlas/Program.cs
@@ -42,25 +42,25 @@ namespace AlgorithmsCuBlas
                 {
                     // Set pointer mode to Host to enable data transfer to CPU memory
                     blas.PointerMode = CuBlasPointerMode.Host;
-                    float output = blas.Nrm2(buf.View);
+                    float output = blas.Nrm2(buf.View.AsGeneral());
 
                     // Set pointer mode to Device to enable data transfer to GPU memory
                     blas.PointerMode = CuBlasPointerMode.Device;
-                    blas.Nrm2(buf.View, buf2.View);
+                    blas.Nrm2(buf.View.AsGeneral(), buf2.View);
 
                     // Use pointer mode scopes to recover the previous pointer mode
                     using var scope = blas.BeginPointerScope(CuBlasPointerMode.Host);
-                    float output2 = blas.Nrm2(buf.View);
+                    float output2 = blas.Nrm2(buf.View.AsGeneral());
                 }
 
                 // Initialize the CuBlas<T> library using custom pointer mode handlers
                 using (var blas = new CuBlas<CuBlasPointerModeHandlers.AutomaticMode>(accelerator))
                 {
                     // Automatic transfer to host
-                    float output = blas.Nrm2(buf.View);
+                    float output = blas.Nrm2(buf.View.AsGeneral());
 
                     // Automatic transfer to device
-                    blas.Nrm2(buf.View, buf2.View);
+                    blas.Nrm2(buf.View.AsGeneral(), buf2.View);
                 }
             }
         }

--- a/Src/ILGPU.Algorithms/Runtime/Cuda/CuBlasMethodsLevel1.tt
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/CuBlasMethodsLevel1.tt
@@ -35,7 +35,7 @@ namespace ILGPU.Runtime.Cuda
         /// </summary>
         /// <param name="input">The input view.</param>
         /// <returns>The computed value.</returns>
-        public unsafe int <#= entry #>(ArrayView<<#= type #>> input)
+        public unsafe int <#= entry #>(ArrayView1D<<#= type #>, Stride1D.General> input)
         {
             EnsureAcceleratorBinding();
             EnsurePointerMode(CuBlasPointerMode.Host);
@@ -45,8 +45,8 @@ namespace ILGPU.Runtime.Cuda
                 API.<#= func #>(
                     Handle,
                     input.IntLength,
-                    LoadCuBlasAddress(input),
-                    1,
+                    LoadCuBlasAddress(input.BaseView),
+                    input.Stride.XStride,
                     &result));
             return result;
         }
@@ -56,7 +56,9 @@ namespace ILGPU.Runtime.Cuda
         /// </summary>
         /// <param name="input">The input view.</param>
         /// <param name="output">The output view.</param>
-        public unsafe void <#= entry #>(ArrayView<<#= type #>> input, ArrayView<int> output)
+        public unsafe void <#= entry #>(
+            ArrayView1D<<#= type #>, Stride1D.General> input,
+            ArrayView<int> output)
         {
             EnsureAcceleratorBinding();
             EnsurePointerMode(CuBlasPointerMode.Device);
@@ -65,8 +67,8 @@ namespace ILGPU.Runtime.Cuda
                 API.<#= func #>(
                     Handle,
                     input.IntLength,
-                    LoadCuBlasAddress(input),
-                    1,
+                    LoadCuBlasAddress(input.BaseView),
+                    input.Stride.XStride,
                     LoadCuBlasAddress(output)));
         }
 
@@ -80,7 +82,8 @@ namespace ILGPU.Runtime.Cuda
         /// </summary>
         /// <param name="input">The input view.</param>
         /// <returns>The computed value.</returns>
-        public unsafe <#= type #> <#= entry #>(ArrayView<<#= type #>> input)
+        public unsafe <#= type #> <#= entry #>(
+            ArrayView1D<<#= type #>, Stride1D.General> input)
         {
             EnsureAcceleratorBinding();
             EnsurePointerMode(CuBlasPointerMode.Host);
@@ -90,8 +93,8 @@ namespace ILGPU.Runtime.Cuda
                 API.<#= func #>(
                     Handle,
                     input.IntLength,
-                    LoadCuBlasAddress(input),
-                    1,
+                    LoadCuBlasAddress(input.BaseView),
+                    input.Stride.XStride,
                     Unsafe.AsPointer(ref result)));
             return result;
         }
@@ -101,7 +104,9 @@ namespace ILGPU.Runtime.Cuda
         /// </summary>
         /// <param name="input">The input view.</param>
         /// <param name="output">The output view.</param>
-        public unsafe void <#= entry #>(ArrayView<<#= type #>> input, ArrayView<<#= type #>> output)
+        public unsafe void <#= entry #>(
+            ArrayView1D<<#= type #>, Stride1D.General> input,
+            ArrayView<<#= type #>> output)
         {
             EnsureAcceleratorBinding();
             EnsurePointerMode(CuBlasPointerMode.Device);
@@ -110,8 +115,8 @@ namespace ILGPU.Runtime.Cuda
                 API.<#= func #>(
                     Handle,
                     input.IntLength,
-                    LoadCuBlasAddress(input),
-                    1,
+                    LoadCuBlasAddress(input.BaseView),
+                    input.Stride.XStride,
                     LoadCuBlasAddress(output)));
         }
 
@@ -127,8 +132,8 @@ namespace ILGPU.Runtime.Cuda
         /// <param name="y">The y vector.</param>
         public unsafe void <#= entry #>(
             <#= paramType #> alpha,
-            ArrayView<<#= type #>> x,
-            ArrayView<<#= type #>> y)
+            ArrayView1D<<#= type #>, Stride1D.General> x,
+            ArrayView1D<<#= type #>, Stride1D.General> y)
         {
             Debug.Assert(x.Length == y.Length, "Invalid length");
             EnsureAcceleratorBinding();
@@ -139,10 +144,10 @@ namespace ILGPU.Runtime.Cuda
                     Handle,
                     x.IntLength,
                     <#= paramGetter("alpha") #>,
-                    LoadCuBlasAddress(x),
-                    1,
-                    LoadCuBlasAddress(y),
-                    1));
+                    LoadCuBlasAddress(x.BaseView),
+                    x.Stride.XStride,
+                    LoadCuBlasAddress(y.BaseView),
+                    y.Stride.XStride));
         }
 
 <# } #>
@@ -156,8 +161,8 @@ namespace ILGPU.Runtime.Cuda
         /// <param name="y">The y vector.</param>
         /// <returns>The computed value.</returns>
         public unsafe <#= type #> <#= entry #>(
-            ArrayView<<#= type #>> x,
-            ArrayView<<#= type #>> y)
+            ArrayView1D<<#= type #>, Stride1D.General> x,
+            ArrayView1D<<#= type #>, Stride1D.General> y)
         {
             Debug.Assert(x.Length == y.Length, "Invalid length");
             EnsureAcceleratorBinding();
@@ -168,10 +173,10 @@ namespace ILGPU.Runtime.Cuda
                 API.<#= func #>(
                     Handle,
                     x.IntLength,
-                    LoadCuBlasAddress(x),
-                    1,
-                    LoadCuBlasAddress(y),
-                    1,
+                    LoadCuBlasAddress(x.BaseView),
+                    x.Stride.XStride,
+                    LoadCuBlasAddress(y.BaseView),
+                    y.Stride.XStride,
                     Unsafe.AsPointer(ref result)));
             return result;
         }
@@ -183,8 +188,8 @@ namespace ILGPU.Runtime.Cuda
         /// <param name="y">The y vector.</param>
         /// <param name="output">The output view.</param>
         public unsafe void <#= entry #>(
-            ArrayView<<#= type #>> x,
-            ArrayView<<#= type #>> y,
+            ArrayView1D<<#= type #>, Stride1D.General> x,
+            ArrayView1D<<#= type #>, Stride1D.General> y,
             ArrayView<<#= type #>> output)
         {
             Debug.Assert(x.Length == y.Length, "Invalid length");
@@ -195,10 +200,10 @@ namespace ILGPU.Runtime.Cuda
                 API.<#= func #>(
                     Handle,
                     x.IntLength,
-                    LoadCuBlasAddress(x),
-                    1,
-                    LoadCuBlasAddress(y),
-                    1,
+                    LoadCuBlasAddress(x.BaseView),
+                    x.Stride.XStride,
+                    LoadCuBlasAddress(y.BaseView),
+                    y.Stride.XStride,
                     LoadCuBlasAddress(output)));
         }
 
@@ -214,8 +219,8 @@ namespace ILGPU.Runtime.Cuda
         /// <param name="c">The cos angle.</param>
         /// <param name="s">The sin angle.</param>
         public unsafe void <#= entry #>(
-            ArrayView<<#= type #>> x,
-            ArrayView<<#= type #>> y,
+            ArrayView1D<<#= type #>, Stride1D.General> x,
+            ArrayView1D<<#= type #>, Stride1D.General> y,
             <#= paramType #> c,
             <#= paramType #> s)
         {
@@ -226,10 +231,10 @@ namespace ILGPU.Runtime.Cuda
                 API.<#= func #>(
                     Handle,
                     x.IntLength,
-                    LoadCuBlasAddress(x),
-                    1,
-                    LoadCuBlasAddress(y),
-                    1,
+                    LoadCuBlasAddress(x.BaseView),
+                    x.Stride.XStride,
+                    LoadCuBlasAddress(y.BaseView),
+                    y.Stride.XStride,
                     <#= paramGetter("c") #>,
                     <#= paramGetter("s") #>));
         }
@@ -298,8 +303,8 @@ namespace ILGPU.Runtime.Cuda
         /// <param name="y">The y vector.</param>
         /// <param name="param">The Givens param.</param>
         public unsafe void <#= entry #>(
-            ArrayView<<#= type #>> x,
-            ArrayView<<#= type #>> y,
+            ArrayView1D<<#= type #>, Stride1D.General> x,
+            ArrayView1D<<#= type #>, Stride1D.General> y,
             <#= paramType #> param)
         {
             EnsureAcceleratorBinding();
@@ -309,10 +314,10 @@ namespace ILGPU.Runtime.Cuda
                 API.<#= func #>(
                     Handle,
                     x.IntLength,
-                    LoadCuBlasAddress(x),
-                    1,
-                    LoadCuBlasAddress(y),
-                    1,
+                    LoadCuBlasAddress(x.BaseView),
+                    x.Stride.XStride,
+                    LoadCuBlasAddress(y.BaseView),
+                    y.Stride.XStride,
                     <#= paramGetter("param") #>));
         }
 
@@ -327,7 +332,7 @@ namespace ILGPU.Runtime.Cuda
         /// <param name="x">The x vector.</param>
         public unsafe void <#= entry #>(
             <#= paramType #> alpha,
-            ArrayView<<#= type #>> x)
+            ArrayView1D<<#= type #>, Stride1D.General> x)
         {
             EnsureAcceleratorBinding();
             <#= paramVerifier #>;
@@ -337,8 +342,8 @@ namespace ILGPU.Runtime.Cuda
                     Handle,
                     x.IntLength,
                     <#= paramGetter("alpha") #>,
-                    LoadCuBlasAddress(x),
-                    1));
+                    LoadCuBlasAddress(x.BaseView),
+                    x.Stride.XStride));
         }
 
 <# } #>
@@ -351,8 +356,8 @@ namespace ILGPU.Runtime.Cuda
         /// <param name="x">The x vector.</param>
         /// <param name="y">The y vector.</param>
         public unsafe void <#= entry #>(
-            ArrayView<<#= type #>> x,
-            ArrayView<<#= type #>> y)
+            ArrayView1D<<#= type #>, Stride1D.General> x,
+            ArrayView1D<<#= type #>, Stride1D.General> y)
         {
             Debug.Assert(x.Length == y.Length, "Invalid length");
             EnsureAcceleratorBinding();
@@ -361,10 +366,10 @@ namespace ILGPU.Runtime.Cuda
                 API.<#= func #>(
                     Handle,
                     x.IntLength,
-                    LoadCuBlasAddress(x),
-                    1,
-                    LoadCuBlasAddress(y),
-                    1));
+                    LoadCuBlasAddress(x.BaseView),
+                    x.Stride.XStride,
+                    LoadCuBlasAddress(y.BaseView),
+                    y.Stride.XStride));
         }
 
 <# } #>

--- a/Src/ILGPU.Algorithms/Runtime/Cuda/CuBlasMethodsLevel2.tt
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/CuBlasMethodsLevel2.tt
@@ -40,11 +40,9 @@ namespace ILGPU.Runtime.Cuda
             <#= paramType #> alpha,
             ArrayView<<#= type #>> a,
             int lda,
-            ArrayView<<#= type #>> x,
-            int incx,
+            ArrayView1D<<#= type #>, Stride1D.General> x,
             <#= paramType #> beta,
-            ArrayView<<#= type #>> y,
-            int incy)
+            ArrayView1D<<#= type #>, Stride1D.General> y)
         {
             EnsureAcceleratorBinding();
             <#= paramVerifier #>;
@@ -60,11 +58,11 @@ namespace ILGPU.Runtime.Cuda
                     <#= paramGetter("alpha") #>,
                     LoadCuBlasAddress(a),
                     lda,
-                    LoadCuBlasAddress(x),
-                    incx,
+                    LoadCuBlasAddress(x.BaseView),
+                    x.Stride.XStride,
                     <#= paramGetter("beta") #>,
-                    LoadCuBlasAddress(y),
-                    incy));
+                    LoadCuBlasAddress(y.BaseView),
+                    y.Stride.XStride));
         }
 
 <# } #>
@@ -81,11 +79,9 @@ namespace ILGPU.Runtime.Cuda
             <#= paramType #> alpha,
             ArrayView<<#= type #>> a,
             int lda,
-            ArrayView<<#= type #>> x,
-            int incx,
+            ArrayView1D<<#= type #>, Stride1D.General> x,
             <#= paramType #> beta,
-            ArrayView<<#= type #>> y,
-            int incy)
+            ArrayView1D<<#= type #>, Stride1D.General> y)
         {
             EnsureAcceleratorBinding();
             <#= paramVerifier #>;
@@ -99,11 +95,11 @@ namespace ILGPU.Runtime.Cuda
                     <#= paramGetter("alpha") #>,
                     LoadCuBlasAddress(a),
                     lda,
-                    LoadCuBlasAddress(x),
-                    incx,
+                    LoadCuBlasAddress(x.BaseView),
+                    x.Stride.XStride,
                     <#= paramGetter("beta") #>,
-                    LoadCuBlasAddress(y),
-                    incy));
+                    LoadCuBlasAddress(y.BaseView),
+                    y.Stride.XStride));
         }
 
 <# } #>
@@ -117,10 +113,8 @@ namespace ILGPU.Runtime.Cuda
             int m,
             int n,
             <#= paramType #> alpha,
-            ArrayView<<#= type #>> x,
-            int incx,
-            ArrayView<<#= type #>> y,
-            int incy,
+            ArrayView1D<<#= type #>, Stride1D.General> x,
+            ArrayView1D<<#= type #>, Stride1D.General> y,
             ArrayView<<#= type #>> a,
             int lda)
         {
@@ -133,10 +127,10 @@ namespace ILGPU.Runtime.Cuda
                     m,
                     n,
                     <#= paramGetter("alpha") #>,
-                    LoadCuBlasAddress(x),
-                    incx,
-                    LoadCuBlasAddress(y),
-                    incy,
+                    LoadCuBlasAddress(x.BaseView),
+                    x.Stride.XStride,
+                    LoadCuBlasAddress(y.BaseView),
+                    y.Stride.XStride,
                     LoadCuBlasAddress(a),
                     lda));
         }
@@ -155,11 +149,9 @@ namespace ILGPU.Runtime.Cuda
             <#= paramType #> alpha,
             ArrayView<<#= type #>> a,
             int lda,
-            ArrayView<<#= type #>> x,
-            int incx,
+            ArrayView1D<<#= type #>, Stride1D.General> x,
             <#= paramType #> beta,
-            ArrayView<<#= type #>> y,
-            int incy)
+            ArrayView1D<<#= type #>, Stride1D.General> y)
         {
             EnsureAcceleratorBinding();
             <#= paramVerifier #>;
@@ -173,11 +165,11 @@ namespace ILGPU.Runtime.Cuda
                     <#= paramGetter("alpha") #>,
                     LoadCuBlasAddress(a),
                     lda,
-                    LoadCuBlasAddress(x),
-                    incx,
+                    LoadCuBlasAddress(x.BaseView),
+                    x.Stride.XStride,
                     <#= paramGetter("beta") #>,
-                    LoadCuBlasAddress(y),
-                    incy));
+                    LoadCuBlasAddress(y.BaseView),
+                    y.Stride.XStride));
         }
 
 <# } #>
@@ -192,11 +184,9 @@ namespace ILGPU.Runtime.Cuda
             int n,
             <#= paramType #> alpha,
             ArrayView<<#= type #>> ap,
-            ArrayView<<#= type #>> x,
-            int incx,
+            ArrayView1D<<#= type #>, Stride1D.General> x,
             <#= paramType #> beta,
-            ArrayView<<#= type #>> y,
-            int incy)
+            ArrayView1D<<#= type #>, Stride1D.General> y)
         {
             EnsureAcceleratorBinding();
             <#= paramVerifier #>;
@@ -208,11 +198,11 @@ namespace ILGPU.Runtime.Cuda
                     n,
                     <#= paramGetter("alpha") #>,
                     LoadCuBlasAddress(ap),
-                    LoadCuBlasAddress(x),
-                    incx,
+                    LoadCuBlasAddress(x.BaseView),
+                    x.Stride.XStride,
                     <#= paramGetter("beta") #>,
-                    LoadCuBlasAddress(y),
-                    incy));
+                    LoadCuBlasAddress(y.BaseView),
+                    y.Stride.XStride));
         }
 
 <# } #>
@@ -226,8 +216,7 @@ namespace ILGPU.Runtime.Cuda
             CuBlasFillMode uplo,
             int n,
             <#= paramType #> alpha,
-            ArrayView<<#= type #>> x,
-            int incx,
+            ArrayView1D<<#= type #>, Stride1D.General> x,
             ArrayView<<#= type #>> ap)
         {
             EnsureAcceleratorBinding();
@@ -239,8 +228,8 @@ namespace ILGPU.Runtime.Cuda
                     uplo,
                     n,
                     <#= paramGetter("alpha") #>,
-                    LoadCuBlasAddress(x),
-                    incx,
+                    LoadCuBlasAddress(x.BaseView),
+                    x.Stride.XStride,
                     LoadCuBlasAddress(ap)));
         }
 
@@ -255,10 +244,8 @@ namespace ILGPU.Runtime.Cuda
             CuBlasFillMode uplo,
             int n,
             <#= paramType #> alpha,
-            ArrayView<<#= type #>> x,
-            int incx,
-            ArrayView<<#= type #>> y,
-            int incy,
+            ArrayView1D<<#= type #>, Stride1D.General> x,
+            ArrayView1D<<#= type #>, Stride1D.General> y,
             ArrayView<<#= type #>> ap)
         {
             EnsureAcceleratorBinding();
@@ -270,10 +257,10 @@ namespace ILGPU.Runtime.Cuda
                     uplo,
                     n,
                     <#= paramGetter("alpha") #>,
-                    LoadCuBlasAddress(x),
-                    incx,
-                    LoadCuBlasAddress(y),
-                    incy,
+                    LoadCuBlasAddress(x.BaseView),
+                    x.Stride.XStride,
+                    LoadCuBlasAddress(y.BaseView),
+                    y.Stride.XStride,
                     LoadCuBlasAddress(ap)));
         }
 
@@ -290,11 +277,9 @@ namespace ILGPU.Runtime.Cuda
             <#= paramType #> alpha,
             ArrayView<<#= type #>> a,
             int lda,
-            ArrayView<<#= type #>> x,
-            int incx,
+            ArrayView1D<<#= type #>, Stride1D.General> x,
             <#= paramType #> beta,
-            ArrayView<<#= type #>> y,
-            int incy)
+            ArrayView1D<<#= type #>, Stride1D.General> y)
         {
             EnsureAcceleratorBinding();
             <#= paramVerifier #>;
@@ -307,11 +292,11 @@ namespace ILGPU.Runtime.Cuda
                     <#= paramGetter("alpha") #>,
                     LoadCuBlasAddress(a),
                     lda,
-                    LoadCuBlasAddress(x),
-                    incx,
+                    LoadCuBlasAddress(x.BaseView),
+                    x.Stride.XStride,
                     <#= paramGetter("beta") #>,
-                    LoadCuBlasAddress(y),
-                    incy));
+                    LoadCuBlasAddress(y.BaseView),
+                    y.Stride.XStride));
         }
 
 <# } #>
@@ -325,8 +310,7 @@ namespace ILGPU.Runtime.Cuda
             CuBlasFillMode uplo,
             int n,
             <#= paramType #> alpha,
-            ArrayView<<#= type #>> x,
-            int incx,
+            ArrayView1D<<#= type #>, Stride1D.General> x,
             ArrayView<<#= type #>> a,
             int lda)
         {
@@ -339,8 +323,8 @@ namespace ILGPU.Runtime.Cuda
                     uplo,
                     n,
                     <#= paramGetter("alpha") #>,
-                    LoadCuBlasAddress(x),
-                    incx,
+                    LoadCuBlasAddress(x.BaseView),
+                    x.Stride.XStride,
                     LoadCuBlasAddress(a),
                     lda));
         }
@@ -356,10 +340,8 @@ namespace ILGPU.Runtime.Cuda
             CuBlasFillMode uplo,
             int n,
             <#= paramType #> alpha,
-            ArrayView<<#= type #>> x,
-            int incx,
-            ArrayView<<#= type #>> y,
-            int incy,
+            ArrayView1D<<#= type #>, Stride1D.General> x,
+            ArrayView1D<<#= type #>, Stride1D.General> y,
             ArrayView<<#= type #>> a,
             int lda)
         {
@@ -372,10 +354,10 @@ namespace ILGPU.Runtime.Cuda
                     uplo,
                     n,
                     <#= paramGetter("alpha") #>,
-                    LoadCuBlasAddress(x),
-                    incx,
-                    LoadCuBlasAddress(y),
-                    incy,
+                    LoadCuBlasAddress(x.BaseView),
+                    x.Stride.XStride,
+                    LoadCuBlasAddress(y.BaseView),
+                    y.Stride.XStride,
                     LoadCuBlasAddress(a),
                     lda));
         }
@@ -396,8 +378,7 @@ namespace ILGPU.Runtime.Cuda
             int k,
             ArrayView<<#= type #>> a,
             int lda,
-            ArrayView<<#= type #>> x,
-            int incx)
+            ArrayView1D<<#= type #>, Stride1D.General> x)
         {
             EnsureAcceleratorBinding();
 
@@ -411,8 +392,8 @@ namespace ILGPU.Runtime.Cuda
                     k,
                     LoadCuBlasAddress(a),
                     lda,
-                    LoadCuBlasAddress(x),
-                    incx));
+                    LoadCuBlasAddress(x.BaseView),
+                    x.Stride.XStride));
         }
 
 <# } #>
@@ -429,8 +410,7 @@ namespace ILGPU.Runtime.Cuda
             CuBlasDiagType diag,
             int n, 
             ArrayView<<#= type #>> ap,
-            ArrayView<<#= type #>> x,
-            int incx)
+            ArrayView1D<<#= type #>, Stride1D.General> x)
         {
             EnsureAcceleratorBinding();
 
@@ -442,8 +422,8 @@ namespace ILGPU.Runtime.Cuda
                     diag,
                     n,
                     LoadCuBlasAddress(ap),
-                    LoadCuBlasAddress(x),
-                    incx));
+                    LoadCuBlasAddress(x.BaseView),
+                    x.Stride.XStride));
         }
 
 <# } #>
@@ -461,8 +441,7 @@ namespace ILGPU.Runtime.Cuda
             int n, 
             ArrayView<<#= type #>> a,
             int lda,
-            ArrayView<<#= type #>> x,
-            int incx)
+            ArrayView1D<<#= type #>, Stride1D.General> x)
         {
             EnsureAcceleratorBinding();
 
@@ -475,8 +454,8 @@ namespace ILGPU.Runtime.Cuda
                     n,
                     LoadCuBlasAddress(a),
                     lda,
-                    LoadCuBlasAddress(x),
-                    incx));
+                    LoadCuBlasAddress(x.BaseView),
+                    x.Stride.XStride));
         }
 
 <# } #>

--- a/Src/ILGPU.Algorithms/Runtime/Cuda/CuBlasMethodsLevel3.tt
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/CuBlasMethodsLevel3.tt
@@ -323,8 +323,7 @@ namespace ILGPU.Runtime.Cuda
             int n,
             ArrayView<<#= type #>> a,
             int lda,
-            ArrayView<<#= type #>> x,
-            int incx,
+            ArrayView1D<<#= type #>, Stride1D.General> x,
             ArrayView<<#= type #>> c,
             int ldc)
         {
@@ -338,8 +337,8 @@ namespace ILGPU.Runtime.Cuda
                     n,
                     LoadCuBlasAddress(a),
                     lda,
-                    LoadCuBlasAddress(x),
-                    incx,
+                    LoadCuBlasAddress(x.BaseView),
+                    x.Stride.XStride,
                     LoadCuBlasAddress(c),
                     ldc));
         }


### PR DESCRIPTION
This PR updates the CuBlas interface to accept vectors with arbitrary stride information. Old way of calling CuBlas interface methods:
```c#
ArrayView<T> x  = ...
xyz_cublas_method(.., x, x_stride, ...)
```
New way:
```c#
ArrayView1D<T, Stride1D.General> x  = ...
xyz_cublas_method(.., x, ...)
// or
ArrayView1D<T, Stride1D.Dense> x  = ...
xyz_cublas_method(.., x.AsGeneral(), ...)
```

*! Note that this is a breaking change !*