### PR TITLE
Updated Algorithms.Scan implementation to work on arbitrary stride types.

### DIFF
--- a/Samples/AlgorithmsScan/Program.cs
+++ b/Samples/AlgorithmsScan/Program.cs
@@ -41,7 +41,11 @@ namespace AlgorithmsScan
                 {
                     // Create a new inclusive scan using the AddInt32 scan operation
                     // Use the available scan operations in the namespace ILGPU.Algorithms.ScanReduceOperations.
-                    var scan = accelerator.CreateInclusiveScan<int, AddInt32>();
+                    var scan = accelerator.CreateScan<
+                        int,
+                        Stride1D.Dense,
+                        Stride1D.Dense,
+                        AddInt32>(ScanKind.Inclusive);
 
                     // Compute the required amount of temporary memory
                     var tempMemSize = accelerator.ComputeScanTempStorageSize<int>(targetBuffer.Length);
@@ -69,7 +73,11 @@ namespace AlgorithmsScan
                 {
                     // Create a new exclusive scan using the AddInt32 scan operation
                     // Use the available scan operations in the namespace ILGPU.Algorithms.ScanReduceOperations.
-                    var scan = accelerator.CreateExclusiveScan<int, AddInt32>();
+                    var scan = accelerator.CreateScan<
+                        int,
+                        Stride1D.Dense,
+                        Stride1D.Dense,
+                        AddInt32>(ScanKind.Exclusive);
 
                     // Compute the required amount of temporary memory
                     var tempMemSize = accelerator.ComputeScanTempStorageSize<int>(targetBuffer.Length);
@@ -97,7 +105,11 @@ namespace AlgorithmsScan
                 // an extra cache.
                 using (var scanProvider = accelerator.CreateScanProvider<int>(sourceBuffer.Length))
                 {
-                    var scanUsingScanProvider = scanProvider.CreateInclusiveScan<int, AddInt32>();
+                    var scanUsingScanProvider = scanProvider.CreateScan<
+                        int,
+                        Stride1D.Dense,
+                        Stride1D.Dense,
+                        AddInt32>(ScanKind.Inclusive);
 
                     // Please note that the create scan does not need additional temporary memory
                     // allocations as they will be automatically managed by the ScanProvider instance.

--- a/Src/ILGPU.Algorithms.Tests/ScanExtensionTests.tt
+++ b/Src/ILGPU.Algorithms.Tests/ScanExtensionTests.tt
@@ -134,9 +134,13 @@ namespace ILGPU.Algorithms.Tests
             var inputSeq = sequencer.ComputeSequence(start, stepSize, length);
             input.CopyFromCPU(stream, inputSeq);
 
-            var scan = Accelerator.CreateInclusiveScan<T, TScanFunc>();
+            var scan = Accelerator.CreateScan<
+                T,
+                Stride1D.General,
+                Stride1D.General,
+                TScanFunc>(ScanKind.Inclusive);
 
-            scan(stream, input.View, output.View, tmp.View);
+            scan(stream, input.View.AsGeneral(), output.View.AsGeneral(), tmp.View);
             stream.Synchronize();
 
             var expected = CalcValues(inputSeq, func, ScanKind.Inclusive);
@@ -175,9 +179,13 @@ namespace ILGPU.Algorithms.Tests
             var inputSeq = sequencer.ComputeSequence(start, stepSize, length);
             input.CopyFromCPU(stream, inputSeq);
 
-            var scan = Accelerator.CreateExclusiveScan<T, TScanFunc>();
+            var scan = Accelerator.CreateScan<
+                T,
+                Stride1D.General,
+                Stride1D.General,
+                TScanFunc>(ScanKind.Exclusive);
 
-            scan(stream, input.View, output.View, tmp.View);
+            scan(stream, input.View.AsGeneral(), output.View.AsGeneral(), tmp.View);
             stream.Synchronize();
 
             var expected = CalcValues(inputSeq, func, ScanKind.Exclusive);
@@ -211,10 +219,14 @@ namespace ILGPU.Algorithms.Tests
             input.CopyFromCPU(stream, inputSeq);
 
             using var scanProvider = Accelerator.CreateScanProvider<T>(length);
-            var scan = scanProvider.CreateExclusiveScan<T, TScanFunc>();
+            var scan = scanProvider.CreateScan<
+                T,
+                Stride1D.General,
+                Stride1D.General,
+                TScanFunc>(ScanKind.Exclusive);
             stream.Synchronize();
 
-            scan(stream, input.View, output.View);
+            scan(stream, input.View.AsGeneral(), output.View.AsGeneral());
             stream.Synchronize();
             
             var expected = CalcValues(inputSeq, func, ScanKind.Exclusive);
@@ -244,10 +256,14 @@ namespace ILGPU.Algorithms.Tests
             input.CopyFromCPU(stream, inputSeq);
 
             using var scanProvider = Accelerator.CreateScanProvider<T>(length);
-            var scan = scanProvider.CreateInclusiveScan<T, TScanFunc>();
+            var scan = scanProvider.CreateScan<
+                T,
+                Stride1D.General,
+                Stride1D.General,
+                TScanFunc>(ScanKind.Inclusive);
             stream.Synchronize();
 
-            scan(stream, input.View, output.View);
+            scan(stream, input.View.AsGeneral(), output.View.AsGeneral());
             stream.Synchronize();
             
             var expected = CalcValues(inputSeq, func, ScanKind.Inclusive);

--- a/Src/ILGPU.Algorithms/RadixSortExtensions.cs
+++ b/Src/ILGPU.Algorithms/RadixSortExtensions.cs
@@ -666,7 +666,7 @@ namespace ILGPU.Algorithms
                 addMemory[j] = 0;
             }
 
-            var tileInfo = new TileInfo<T>(input, numIterationsPerGroup);
+            var tileInfo = new TileInfo(input.IntLength, numIterationsPerGroup);
 
             // Compute local segment information
             for (Index1D i = tileInfo.StartIndex; i < tileInfo.MaxLength; ++i)
@@ -816,7 +816,7 @@ namespace ILGPU.Algorithms
             where TSpecialization : struct, IRadixSortSpecialization
         {
             TSpecialization specialization = default;
-            var tileInfo = new TileInfo<T>(input, numIterationsPerGroup);
+            var tileInfo = new TileInfo(input.IntLength, numIterationsPerGroup);
 
             for (Index1D i = tileInfo.StartIndex; i < tileInfo.MaxLength; ++i)
             {
@@ -988,7 +988,11 @@ namespace ILGPU.Algorithms
             where TRadixSortOperation : struct, IRadixSortOperation<T>
         {
             var initializer = accelerator.CreateInitializer<int, Stride1D.Dense>();
-            var inclusiveScan = accelerator.CreateInclusiveScan<int, AddInt32>();
+            var inclusiveScan = accelerator.CreateScan<
+                int,
+                Stride1D.Dense,
+                Stride1D.Dense,
+                AddInt32>(ScanKind.Inclusive);
 
             var specializationType = typeof(Specialization4);
             var specialization = new Specialization4();

--- a/Src/ILGPU.Algorithms/ScanExtensions.cs
+++ b/Src/ILGPU.Algorithms/ScanExtensions.cs
@@ -43,29 +43,37 @@ namespace ILGPU.Algorithms
     /// Represents a scan operation using a shuffle and operation logic.
     /// </summary>
     /// <typeparam name="T">The underlying type of the scan operation.</typeparam>
+    /// <typeparam name="TStrideIn">The stride of the input view.</typeparam>
+    /// <typeparam name="TStrideOut">The stride of the output view.</typeparam>
     /// <param name="stream">The accelerator stream.</param>
     /// <param name="input">The input elements to scan.</param>
     /// <param name="output">The output view to store the scanned values.</param>
     /// <param name="temp">The temp view to store temporary results.</param>
-    public delegate void Scan<T>(
+    public delegate void Scan<T, TStrideIn, TStrideOut>(
         AcceleratorStream stream,
-        ArrayView<T> input,
-        ArrayView<T> output,
+        ArrayView1D<T, TStrideIn> input,
+        ArrayView1D<T, TStrideOut> output,
         ArrayView<int> temp)
-        where T : unmanaged;
+        where T : unmanaged
+        where TStrideIn : struct, IStride1D
+        where TStrideOut : struct, IStride1D;
 
     /// <summary>
     /// Represents a scan operation using a shuffle and operation logic.
     /// </summary>
     /// <typeparam name="T">The underlying type of the scan operation.</typeparam>
+    /// <typeparam name="TStrideIn">The stride of the input view.</typeparam>
+    /// <typeparam name="TStrideOut">The stride of the output view.</typeparam>
     /// <param name="stream">The accelerator stream.</param>
     /// <param name="input">The input elements to scan.</param>
     /// <param name="output">The output view to store the scanned values.</param>
-    public delegate void BufferedScan<T>(
+    public delegate void BufferedScan<T, TStrideIn, TStrideOut>(
         AcceleratorStream stream,
-        ArrayView<T> input,
-        ArrayView<T> output)
-        where T : unmanaged;
+        ArrayView1D<T, TStrideIn> input,
+        ArrayView1D<T, TStrideOut> output)
+        where T : unmanaged
+        where TStrideIn : struct, IStride1D
+        where TStrideOut : struct, IStride1D;
 
     #endregion
 
@@ -93,40 +101,27 @@ namespace ILGPU.Algorithms
         /// Creates a new buffered scan operation.
         /// </summary>
         /// <typeparam name="T">The underlying type of the scan operation.</typeparam>
+        /// <typeparam name="TStrideIn">The stride of the input view.</typeparam>
+        /// <typeparam name="TStrideOut">The stride of the output view.</typeparam>
         /// <typeparam name="TScanOperation">The type of the scan operation.</typeparam>
         /// <param name="kind">The scan kind.</param>
         /// <returns>The created scan handler.</returns>
-        public BufferedScan<T> CreateScan<T, TScanOperation>(
+        public BufferedScan<T, TStrideIn, TStrideOut> CreateScan<
+            T,
+            TStrideIn,
+            TStrideOut,
+            TScanOperation>(
             ScanKind kind)
             where T : unmanaged
+            where TStrideIn : struct, IStride1D
+            where TStrideOut : struct, IStride1D
             where TScanOperation : struct, IScanReduceOperation<T>
         {
-            var scan = Accelerator.CreateScan<T, TScanOperation>(kind);
+            var scan = Accelerator.CreateScan<T, TStrideIn, TStrideOut, TScanOperation>(
+                kind);
             return (stream, input, output) =>
                 scan(stream, input, output, tempBuffer.View);
         }
-
-        /// <summary>
-        /// Creates a new buffered inclusive scan operation.
-        /// </summary>
-        /// <typeparam name="T">The underlying type of the scan operation.</typeparam>
-        /// <typeparam name="TScanOperation">The type of the scan operation.</typeparam>
-        /// <returns>The created inclusive scan handler.</returns>
-        public BufferedScan<T> CreateInclusiveScan<T, TScanOperation>()
-            where T : unmanaged
-            where TScanOperation : struct, IScanReduceOperation<T> =>
-            CreateScan<T, TScanOperation>(ScanKind.Inclusive);
-
-        /// <summary>
-        /// Creates a new buffered exclusive scan operation.
-        /// </summary>
-        /// <typeparam name="T">The underlying type of the scan operation.</typeparam>
-        /// <typeparam name="TScanOperation">The type of the scan operation.</typeparam>
-        /// <returns>The created exclusive scan handler.</returns>
-        public BufferedScan<T> CreateExclusiveScan<T, TScanOperation>()
-            where T : unmanaged
-            where TScanOperation : struct, IScanReduceOperation<T> =>
-            CreateScan<T, TScanOperation>(ScanKind.Exclusive);
 
         #endregion
 
@@ -273,6 +268,7 @@ namespace ILGPU.Algorithms
         /// Computes the right tile boundary.
         /// </summary>
         /// <typeparam name="T">The element type.</typeparam>
+        /// <typeparam name="TStrideIn">The stride of the input view.</typeparam>
         /// <typeparam name="TScanOperation">The scan-operation type.</typeparam>
         /// <typeparam name="TGroupScanImplementation">
         /// The group-scan implementation type.
@@ -283,11 +279,13 @@ namespace ILGPU.Algorithms
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static T ComputeTileRightBoundary<
             T,
+            TStrideIn,
             TScanOperation,
             TGroupScanImplementation>(
-            TileInfo<T> tileInfo,
-            ArrayView<T> input)
+            TileInfo tileInfo,
+            ArrayView1D<T, TStrideIn> input)
             where T : unmanaged
+            where TStrideIn : struct, IStride1D
             where TScanOperation : struct, IScanReduceOperation<T>
             where TGroupScanImplementation
                 : struct, IScanImplementation<T, TScanOperation>
@@ -322,6 +320,8 @@ namespace ILGPU.Algorithms
         /// Computes a single scan within a single tile.
         /// </summary>
         /// <typeparam name="T">The element type.</typeparam>
+        /// <typeparam name="TStrideIn">The stride of the input view.</typeparam>
+        /// <typeparam name="TStrideOut">The stride of the output view.</typeparam>
         /// <typeparam name="TScanOperation">The scan-operation type.</typeparam>
         /// <typeparam name="TGroupScanImplementation">
         /// The group-scan implementation type.
@@ -333,12 +333,19 @@ namespace ILGPU.Algorithms
         /// The left boundary (e.g. of the previous tile).
         /// </param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void ComputeTileScan<T, TScanOperation, TGroupScanImplementation>(
-            TileInfo<T> tileInfo,
-            ArrayView<T> input,
-            ArrayView<T> output,
+        private static void ComputeTileScan<
+            T,
+            TStrideIn,
+            TStrideOut,
+            TScanOperation,
+            TGroupScanImplementation>(
+            TileInfo tileInfo,
+            ArrayView1D<T, TStrideIn> input,
+            ArrayView1D<T, TStrideOut> output,
             T leftBoundary)
             where T : unmanaged
+            where TStrideIn : struct, IStride1D
+            where TStrideOut : struct, IStride1D
             where TScanOperation : struct, IScanReduceOperation<T>
             where TGroupScanImplementation :
             struct, IScanImplementation<T, TScanOperation>
@@ -384,6 +391,8 @@ namespace ILGPU.Algorithms
         /// Performs a scan operation within a single group only.
         /// </summary>
         /// <typeparam name="T">The element type.</typeparam>
+        /// <typeparam name="TStrideIn">The stride of the input view.</typeparam>
+        /// <typeparam name="TStrideOut">The stride of the output view.</typeparam>
         /// <typeparam name="TScanOperation">The scan operation.</typeparam>
         /// <typeparam name="TGroupScanImplementation">
         /// The actual group-scan implementation that provides the required group-level
@@ -393,23 +402,32 @@ namespace ILGPU.Algorithms
         /// <param name="output">The output view to store the scanned values.</param>
         internal static void SingleGroupScanKernel<
             T,
+            TStrideIn,
+            TStrideOut,
             TScanOperation,
             TGroupScanImplementation>(
-            ArrayView<T> input,
-            ArrayView<T> output)
+            ArrayView1D<T, TStrideIn> input,
+            ArrayView1D<T, TStrideOut> output)
             where T : unmanaged
+            where TStrideIn : struct, IStride1D
+            where TStrideOut : struct, IStride1D
             where TScanOperation : struct, IScanReduceOperation<T>
             where TGroupScanImplementation :
                 struct,
                 IScanImplementation<T, TScanOperation>
         {
-            var tileInfo = new TileInfo<T>(
-                input,
+            var tileInfo = new TileInfo(
+                input.IntLength,
                 XMath.DivRoundUp(input.IntLength, Group.DimX));
 
             TScanOperation scanOperation = default;
 
-            ComputeTileScan<T, TScanOperation, TGroupScanImplementation>(
+            ComputeTileScan<
+                T,
+                TStrideIn,
+                TStrideOut,
+                TScanOperation,
+                TGroupScanImplementation>(
                 tileInfo,
                 input,
                 output,
@@ -420,30 +438,45 @@ namespace ILGPU.Algorithms
         /// Creates a new single group scan.
         /// </summary>
         /// <typeparam name="T">The element type.</typeparam>
+        /// <typeparam name="TStrideIn">The stride of the input view.</typeparam>
+        /// <typeparam name="TStrideOut">The stride of the output view.</typeparam>
         /// <typeparam name="TScanOperation">The scan operation.</typeparam>
         /// <param name="accelerator">The accelerator.</param>
         /// <param name="kind">The scan kind.</param>
         /// <returns>The created scan operation.</returns>
-        private static Scan<T> CreateSingleGroupScan<T, TScanOperation>(
+        private static Scan<T, TStrideIn, TStrideOut> CreateSingleGroupScan<
+            T,
+            TStrideIn,
+            TStrideOut,
+            TScanOperation>(
             Accelerator accelerator,
             ScanKind kind)
             where T : unmanaged
+            where TStrideIn : struct, IStride1D
+            where TStrideOut : struct, IStride1D
             where TScanOperation : struct, IScanReduceOperation<T>
         {
-            Action<AcceleratorStream, KernelConfig, ArrayView<T>, ArrayView<T>> kernel;
+            Action<AcceleratorStream, KernelConfig, ArrayView1D<T, TStrideIn>,
+                ArrayView1D<T, TStrideOut>> kernel;
             if (kind == ScanKind.Inclusive)
             {
-                kernel = accelerator.LoadKernel<ArrayView<T>, ArrayView<T>>(
+                kernel = accelerator.LoadKernel<ArrayView1D<T, TStrideIn>,
+                    ArrayView1D<T, TStrideOut>>(
                     SingleGroupScanKernel<
                         T,
+                        TStrideIn,
+                        TStrideOut,
                         TScanOperation,
                         InclusiveScanImplementation<T, TScanOperation>>);
             }
             else
             {
-                kernel = accelerator.LoadKernel<ArrayView<T>, ArrayView<T>>(
+                kernel = accelerator.LoadKernel<ArrayView1D<T, TStrideIn>,
+                    ArrayView1D<T, TStrideOut>>(
                     SingleGroupScanKernel<
                         T,
+                        TStrideIn,
+                        TStrideOut,
                         TScanOperation,
                         ExclusiveScanImplementation<T, TScanOperation>>);
             }
@@ -472,6 +505,8 @@ namespace ILGPU.Algorithms
         /// Performs a scan operation with a single pass.
         /// </summary>
         /// <typeparam name="T">The element type.</typeparam>
+        /// <typeparam name="TStrideIn">The stride of the input view.</typeparam>
+        /// <typeparam name="TStrideOut">The stride of the output view.</typeparam>
         /// <typeparam name="TScanOperation">The scan operation.</typeparam>
         /// <typeparam name="TGroupScanImplementation">
         /// The actual group-scan implementation that provides the required group-level
@@ -490,20 +525,24 @@ namespace ILGPU.Algorithms
         /// </param>
         internal static void SinglePassScanKernel<
             T,
+            TStrideIn,
+            TStrideOut,
             TScanOperation,
             TGroupScanImplementation>(
-            ArrayView<T> input,
-            ArrayView<T> output,
+            ArrayView1D<T, TStrideIn> input,
+            ArrayView1D<T, TStrideOut> output,
             SequentialGroupExecutor sequentialGroupExecutor,
             VariableView<T> boundaryValue,
             Index1D numIterationsPerGroup)
             where T : unmanaged
+            where TStrideIn : struct, IStride1D
+            where TStrideOut : struct, IStride1D
             where TScanOperation : struct, IScanReduceOperation<T>
             where TGroupScanImplementation :
                 struct,
                 IScanImplementation<T, TScanOperation>
         {
-            var tileInfo = new TileInfo<T>(input, numIterationsPerGroup);
+            var tileInfo = new TileInfo(input.IntLength, numIterationsPerGroup);
 
             TScanOperation scanOperation = default;
 
@@ -512,6 +551,7 @@ namespace ILGPU.Algorithms
             // Determine our right boundary and resolve our left boundary
             T rightBoundary = ComputeTileRightBoundary<
                 T,
+                TStrideIn,
                 TScanOperation,
                 TGroupScanImplementation>(
                 tileInfo,
@@ -540,7 +580,12 @@ namespace ILGPU.Algorithms
             sequentialGroupExecutor.Release();
 
             // Perform the final tile scan
-            ComputeTileScan<T, TScanOperation, TGroupScanImplementation>(
+            ComputeTileScan<
+                T,
+                TStrideIn,
+                TStrideOut,
+                TScanOperation,
+                TGroupScanImplementation>(
                 tileInfo,
                 input,
                 output,
@@ -562,36 +607,41 @@ namespace ILGPU.Algorithms
         /// Creates a new single pass scan.
         /// </summary>
         /// <typeparam name="T">The element type.</typeparam>
+        /// <typeparam name="TStrideIn">The stride of the input view.</typeparam>
+        /// <typeparam name="TStrideOut">The stride of the output view.</typeparam>
         /// <typeparam name="TScanOperation">The scan operation.</typeparam>
         /// <param name="accelerator">The accelerator.</param>
         /// <param name="kind">The scan kind.</param>
         /// <returns>The created scan operation.</returns>
-        private static Scan<T> CreateSinglePassScan<T, TScanOperation>(
+        private static Scan<T, TStrideIn, TStrideOut> CreateSinglePassScan<
+            T,
+            TStrideIn,
+            TStrideOut,
+            TScanOperation>(
             Accelerator accelerator,
             ScanKind kind)
             where T : unmanaged
+            where TStrideIn : struct, IStride1D
+            where TStrideOut : struct, IStride1D
             where TScanOperation : struct, IScanReduceOperation<T>
         {
             var initializer = accelerator.CreateInitializer<int, Stride1D.Dense>();
 
-            Action<
-                AcceleratorStream,
-                KernelConfig,
-                ArrayView<T>,
-                ArrayView<T>,
-                SequentialGroupExecutor,
-                VariableView<T>,
+            Action<AcceleratorStream, KernelConfig, ArrayView1D<T, TStrideIn>,
+                ArrayView1D<T, TStrideOut>, SequentialGroupExecutor, VariableView<T>,
                 Index1D> kernel;
             if (kind == ScanKind.Inclusive)
             {
                 kernel = accelerator.LoadKernel<
-                    ArrayView<T>,
-                    ArrayView<T>,
+                    ArrayView1D<T, TStrideIn>,
+                    ArrayView1D<T, TStrideOut>,
                     SequentialGroupExecutor,
                     VariableView<T>,
                     Index1D>(
                     SinglePassScanKernel<
                         T,
+                        TStrideIn,
+                        TStrideOut,
                         TScanOperation,
                         InclusiveScanImplementation<T,
                         TScanOperation>>);
@@ -599,13 +649,15 @@ namespace ILGPU.Algorithms
             else
             {
                 kernel = accelerator.LoadKernel<
-                    ArrayView<T>,
-                    ArrayView<T>,
+                    ArrayView1D<T, TStrideIn>,
+                    ArrayView1D<T, TStrideOut>,
                     SequentialGroupExecutor,
                     VariableView<T>,
                     Index1D>(
                     SinglePassScanKernel<
                         T,
+                        TStrideIn,
+                        TStrideOut,
                         TScanOperation,
                         ExclusiveScanImplementation<T,
                         TScanOperation>>);
@@ -658,6 +710,7 @@ namespace ILGPU.Algorithms
         /// Performs the first pass in the scope of a multi-pass scan.
         /// </summary>
         /// <typeparam name="T">The element type.</typeparam>
+        /// <typeparam name="TStrideIn">The stride of the input view.</typeparam>
         /// <typeparam name="TScanOperation">The scan operation.</typeparam>
         /// <typeparam name="TGroupScanImplementation">
         /// The actual group-scan implementation that provides the required group-level
@@ -670,21 +723,24 @@ namespace ILGPU.Algorithms
         /// </param>
         internal static void MultiPassScanKernel1<
             T,
+            TStrideIn,
             TScanOperation,
             TGroupScanImplementation>(
-            ArrayView<T> input,
+            ArrayView1D<T, TStrideIn> input,
             ArrayView<T> rightBoundaries,
             Index1D numIterationsPerGroup)
             where T : unmanaged
+            where TStrideIn : struct, IStride1D
             where TScanOperation : struct, IScanReduceOperation<T>
             where TGroupScanImplementation :
                 struct,
                 IScanImplementation<T, TScanOperation>
         {
-            var tileInfo = new TileInfo<T>(input, numIterationsPerGroup);
+            var tileInfo = new TileInfo(input.IntLength, numIterationsPerGroup);
 
             T rightBoundary = ComputeTileRightBoundary<
                 T,
+                TStrideIn,
                 TScanOperation,
                 TGroupScanImplementation>(
                 tileInfo,
@@ -698,6 +754,8 @@ namespace ILGPU.Algorithms
         /// Performs the second pass in the scope of a multi-pass scan.
         /// </summary>
         /// <typeparam name="T">The element type.</typeparam>
+        /// <typeparam name="TStrideIn">The stride of the input view.</typeparam>
+        /// <typeparam name="TStrideOut">The stride of the output view.</typeparam>
         /// <typeparam name="TScanOperation">The scan operation.</typeparam>
         /// <typeparam name="TGroupScanImplementation">
         /// The actual group-scan implementation that provides the required group-level
@@ -711,19 +769,23 @@ namespace ILGPU.Algorithms
         /// </param>
         internal static void MultiPassScanKernel2<
             T,
+            TStrideIn,
+            TStrideOut,
             TScanOperation,
             TGroupScanImplementation>(
-            ArrayView<T> input,
+            ArrayView1D<T, TStrideIn> input,
             ArrayView<T> rightBoundaries,
-            ArrayView<T> output,
+            ArrayView1D<T, TStrideOut> output,
             Index1D numIterationsPerGroup)
             where T : unmanaged
+            where TStrideIn : struct, IStride1D
+            where TStrideOut : struct, IStride1D
             where TScanOperation : struct, IScanReduceOperation<T>
             where TGroupScanImplementation :
                 struct,
                 IScanImplementation<T, TScanOperation>
         {
-            var tileInfo = new TileInfo<T>(input, numIterationsPerGroup);
+            var tileInfo = new TileInfo(input.IntLength, numIterationsPerGroup);
 
             TScanOperation scanOperation = default;
             TGroupScanImplementation groupScan = default;
@@ -734,7 +796,12 @@ namespace ILGPU.Algorithms
             var scannedLeftBoundaries = groupScan.Scan(localRightBoundary);
             T leftBoundary = Group.Broadcast(scannedLeftBoundaries, Grid.IdxX);
 
-            ComputeTileScan<T, TScanOperation, TGroupScanImplementation>(
+            ComputeTileScan<
+                T,
+                TStrideIn,
+                TStrideOut,
+                TScanOperation,
+                TGroupScanImplementation>(
                 tileInfo,
                 input,
                 output,
@@ -745,40 +812,50 @@ namespace ILGPU.Algorithms
         /// Creates a new multi pass scan.
         /// </summary>
         /// <typeparam name="T">The element type.</typeparam>
+        /// <typeparam name="TStrideIn">The stride of the input view.</typeparam>
+        /// <typeparam name="TStrideOut">The stride of the output view.</typeparam>
         /// <typeparam name="TScanOperation">The scan operation.</typeparam>
         /// <param name="accelerator">The accelerator.</param>
         /// <param name="kind">The scan kind.</param>
         /// <returns>The created scan operation.</returns>
-        private static Scan<T> CreateMultiPassScan<T, TScanOperation>(
+        private static Scan<T, TStrideIn, TStrideOut> CreateMultiPassScan<
+            T,
+            TStrideIn,
+            TStrideOut,
+            TScanOperation>(
             Accelerator accelerator,
             ScanKind kind)
             where T : unmanaged
+            where TStrideIn : struct, IStride1D
+            where TStrideOut : struct, IStride1D
             where TScanOperation : struct, IScanReduceOperation<T>
         {
             var initializer = accelerator.CreateInitializer<T, Stride1D.Dense>();
 
-            Action<AcceleratorStream, KernelConfig, ArrayView<T>,
+            Action<AcceleratorStream, KernelConfig, ArrayView1D<T, TStrideIn>,
                 ArrayView<T>, Index1D> pass1Kernel;
-            Action<AcceleratorStream, KernelConfig, ArrayView<T>,
-                ArrayView<T>, ArrayView<T>, Index1D> pass2Kernel;
+            Action<AcceleratorStream, KernelConfig, ArrayView1D<T, TStrideIn>,
+                ArrayView<T>, ArrayView1D<T, TStrideOut>, Index1D> pass2Kernel;
             if (kind == ScanKind.Inclusive)
             {
-                pass1Kernel = accelerator.LoadKernel<ArrayView<T>, ArrayView<T>, Index1D>(
-                    MultiPassScanKernel1<T, TScanOperation,
+                pass1Kernel = accelerator.LoadKernel<
+                    ArrayView1D<T, TStrideIn>, ArrayView<T>, Index1D>(
+                    MultiPassScanKernel1<T, TStrideIn, TScanOperation,
                         InclusiveScanImplementation<T, TScanOperation>>);
-                pass2Kernel = accelerator.LoadKernel<ArrayView<T>, ArrayView<T>,
-                    ArrayView<T>, Index1D>(
-                    MultiPassScanKernel2<T, TScanOperation,
+                pass2Kernel = accelerator.LoadKernel<ArrayView1D<T, TStrideIn>,
+                    ArrayView<T>, ArrayView1D<T, TStrideOut>, Index1D>(
+                    MultiPassScanKernel2<T, TStrideIn, TStrideOut, TScanOperation,
                         InclusiveScanImplementation<T, TScanOperation>>);
             }
             else
             {
-                pass1Kernel = accelerator.LoadKernel<ArrayView<T>, ArrayView<T>, Index1D>(
-                    MultiPassScanKernel1<T, TScanOperation,
+                pass1Kernel = accelerator.LoadKernel<
+                    ArrayView1D<T, TStrideIn>, ArrayView<T>, Index1D>(
+                    MultiPassScanKernel1<T, TStrideIn, TScanOperation,
                         ExclusiveScanImplementation<T, TScanOperation>>);
-                pass2Kernel = accelerator.LoadKernel<ArrayView<T>, ArrayView<T>,
-                    ArrayView<T>, Index1D>(
-                    MultiPassScanKernel2<T, TScanOperation,
+                pass2Kernel = accelerator.LoadKernel<ArrayView1D<T, TStrideIn>,
+                    ArrayView<T>, ArrayView1D<T, TStrideOut>, Index1D>(
+                    MultiPassScanKernel2<T, TStrideIn, TStrideOut, TScanOperation,
                         ExclusiveScanImplementation<T, TScanOperation>>);
             }
 
@@ -841,54 +918,42 @@ namespace ILGPU.Algorithms
         /// Creates a new scan operation.
         /// </summary>
         /// <typeparam name="T">The underlying type of the scan operation.</typeparam>
+        /// <typeparam name="TStrideIn">The stride of the input view.</typeparam>
+        /// <typeparam name="TStrideOut">The stride of the output view.</typeparam>
         /// <typeparam name="TScanOperation">The type of the scan operation.</typeparam>
         /// <param name="accelerator">The accelerator.</param>
         /// <param name="kind">The scan kind.</param>
         /// <returns>The created scan handler.</returns>
-        public static Scan<T> CreateScan<T, TScanOperation>(
+        public static Scan<T, TStrideIn, TStrideOut> CreateScan<
+            T,
+            TStrideIn,
+            TStrideOut,
+            TScanOperation>(
             this Accelerator accelerator,
             ScanKind kind)
             where T : unmanaged
+            where TStrideIn : struct, IStride1D
+            where TStrideOut : struct, IStride1D
             where TScanOperation : struct, IScanReduceOperation<T>
         {
             return accelerator.AcceleratorType switch
             {
                 // We use a single-grouped kernel
                 AcceleratorType.CPU =>
-                    CreateSingleGroupScan<T, TScanOperation>(accelerator, kind),
+                    CreateSingleGroupScan<T, TStrideIn, TStrideOut, TScanOperation>(
+                        accelerator,
+                        kind),
                 AcceleratorType.OpenCL =>
-                    CreateMultiPassScan<T, TScanOperation>(accelerator, kind),
+                    CreateMultiPassScan<T, TStrideIn, TStrideOut, TScanOperation>(
+                        accelerator,
+                        kind),
                 AcceleratorType.Cuda =>
-                    CreateSinglePassScan<T, TScanOperation>(accelerator, kind),
+                    CreateSinglePassScan<T, TStrideIn, TStrideOut, TScanOperation>(
+                        accelerator,
+                        kind),
                 _ => throw new NotSupportedException(),
             };
         }
-
-        /// <summary>
-        /// Creates a new inclusive scan operation.
-        /// </summary>
-        /// <typeparam name="T">The underlying type of the scan operation.</typeparam>
-        /// <typeparam name="TScanOperation">The type of the scan operation.</typeparam>
-        /// <param name="accelerator">The accelerator.</param>
-        /// <returns>The created inclusive scan handler.</returns>
-        public static Scan<T> CreateInclusiveScan<T, TScanOperation>(
-            this Accelerator accelerator)
-            where T : unmanaged
-            where TScanOperation : struct, IScanReduceOperation<T> =>
-            CreateScan<T, TScanOperation>(accelerator, ScanKind.Inclusive);
-
-        /// <summary>
-        /// Creates a new exclusive scan operation.
-        /// </summary>
-        /// <typeparam name="T">The underlying type of the scan operation.</typeparam>
-        /// <typeparam name="TScanOperation">The type of the scan operation.</typeparam>
-        /// <param name="accelerator">The accelerator.</param>
-        /// <returns>The created exclusive scan handler.</returns>
-        public static Scan<T> CreateExclusiveScan<T, TScanOperation>(
-            this Accelerator accelerator)
-            where T : unmanaged
-            where TScanOperation : struct, IScanReduceOperation<T> =>
-            CreateScan<T, TScanOperation>(accelerator, ScanKind.Exclusive);
 
         /// <summary>
         /// Creates a new specialized scan provider that has its own cache.

--- a/Src/ILGPU.Algorithms/TileInfo.cs
+++ b/Src/ILGPU.Algorithms/TileInfo.cs
@@ -16,24 +16,22 @@ namespace ILGPU.Algorithms
     /// <summary>
     /// Contains information about a single scan tile.
     /// </summary>
-    /// <typeparam name="T">The element type.</typeparam>
-    public readonly struct TileInfo<T>
-        where T : unmanaged
+    public readonly struct TileInfo
     {
         /// <summary>
         /// Constructs a new tile information instance.
         /// </summary>
-        /// <param name="input">The input view.</param>
+        /// <param name="inputLength">The input length.</param>
         /// <param name="numIterationsPerGroup">
         /// The number of iterations per group to compute the tile size.
         /// </param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public TileInfo(ArrayView<T> input, Index1D numIterationsPerGroup)
+        public TileInfo(int inputLength, Index1D numIterationsPerGroup)
         {
             TileSize = Group.DimX * numIterationsPerGroup;
             StartIndex = Grid.IdxX * TileSize + Group.IdxX;
             EndIndex = (Grid.IdxX + Index1D.One) * TileSize;
-            MaxLength = XMath.Min(input.IntLength, EndIndex);
+            MaxLength = XMath.Min(inputLength, EndIndex);
         }
 
         /// <summary>

--- a/Src/ILGPU.Algorithms/UniqueExtensions.cs
+++ b/Src/ILGPU.Algorithms/UniqueExtensions.cs
@@ -67,7 +67,7 @@ namespace ILGPU.Algorithms
         {
             TComparisonOperation comparison = default;
             var isFirstGrid = Grid.IdxX == 0;
-            var tileInfo = new TileInfo<T>(input, numIterationsPerGroup);
+            var tileInfo = new TileInfo(input.IntLength, numIterationsPerGroup);
 
             // Sync groups and wait for the current one to become active
             sequentialGroupExecutor.Wait();


### PR DESCRIPTION
The current `Scan` implementation is limited to dense 1D array views. This PR relaxes this restriction and changes the API to support arbitrary stride types. However, this PR also removes two convenience overloads `CreateInclusiveScan` and `CreateExclusiveScan` because they are as verbose as the "non-convenience version": `CreateScan(...., ScanKind.Inclusive)`.