### PR TITLE
Fixed radix sort on floating point data types.

### DIFF
--- a/Src/ILGPU.Algorithms.Tests/Generic/AlgorithmsTestData.tt
+++ b/Src/ILGPU.Algorithms.Tests/Generic/AlgorithmsTestData.tt
@@ -292,18 +292,20 @@ namespace ILGPU.Algorithms.Tests
     #region Xunit RadixSortOperations Structures
 
 <#  
-    foreach (var type in IntTypes) { 
+    foreach (var type in AtomicNumericTypes) { 
 #>
     internal readonly struct XunitAscending<#=type.Name #>
         : IRadixSortOperation<<#= type.Type #>>, IXunitSerializable
     {
-        public int NumBits => sizeof(<#= type.Type #>) * 8;
+        public int NumBits =>
+            default(Ascending<#= type.Name #>).NumBits;
 
-        public <#= type.Type #> DefaultValue => 0;
+        public <#= type.Type #> DefaultValue =>
+            default(Ascending<#= type.Name #>).DefaultValue;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int ExtractRadixBits(<#= type.Type #> value, int shift, int bitMask) =>
-            (int)(value >> shift) & bitMask;
+            default(Ascending<#=type.Name #>).ExtractRadixBits(value, shift, bitMask);
 
         public void Deserialize(IXunitSerializationInfo info) { }
 
@@ -313,16 +315,15 @@ namespace ILGPU.Algorithms.Tests
     internal readonly struct XunitDescending<#= type.Name #>
         : IRadixSortOperation<<#= type.Type #>>, IXunitSerializable
     {
-        public int NumBits => sizeof(<#= type.Type #>) * 8;
+        public int NumBits =>
+            default(Descending<#= type.Name #>).NumBits;
 
-        public <#= type.Type #> DefaultValue => 0;
+        public <#= type.Type #> DefaultValue =>
+            default(Descending<#= type.Name #>).DefaultValue;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int ExtractRadixBits(<#= type.Type #> value, int shift, int bitMask)
-        {
-            Ascending<#= type.Name #> operation = default;
-            return (~operation.ExtractRadixBits(value, shift, bitMask)) & bitMask;
-        }
+        public int ExtractRadixBits(<#= type.Type #> value, int shift, int bitMask) =>
+            default(Descending<#=type.Name #>).ExtractRadixBits(value, shift, bitMask);
 
         public void Deserialize(IXunitSerializationInfo info) { }
 

--- a/Src/ILGPU.Algorithms.Tests/RadixSortExtensionTests.tt
+++ b/Src/ILGPU.Algorithms.Tests/RadixSortExtensionTests.tt
@@ -41,7 +41,7 @@ namespace ILGPU.Algorithms.Tests
             // Type, RadixSortOperation, Sequencer, Start of Sequencer,
             // StepSize of Sequencer, BufferLength
 <#
-        var types = AtomicIntTypes;
+        var types = AtomicNumericTypes;
         foreach (var type in types) {
             foreach (var size in ArraySizes) {
 #>

--- a/Src/ILGPU.Algorithms/RadixSortOperations.tt
+++ b/Src/ILGPU.Algorithms/RadixSortOperations.tt
@@ -83,11 +83,12 @@ namespace ILGPU.Algorithms.RadixSortOperations
             var bits = value ^ (1 << (NumBits - 1));
 <# } else if (type.IsFloat && type.Name == "Half") { #>
             var signMask = 1U << (NumBits - 1);
-            var onesComplementMask = (uint)~(Interop.FloatAsInt(value) >> (NumBits - 1));
+            var onesComplementMask =
+                ((uint)~(Interop.FloatAsInt(value)) >> (NumBits - 1));
             var bits = Interop.FloatAsInt(value) ^ (signMask | onesComplementMask);
 <# } else if (type.IsFloat) { #>
             var signMask = 1<#= type.Name == "Double" ? "UL" : "U" #> << (NumBits - 1);
-            var onesComplementMask = ~(Interop.FloatAsInt(value) >> (NumBits - 1));
+            var onesComplementMask = (~(Interop.FloatAsInt(value)) >> (NumBits - 1));
             var bits = Interop.FloatAsInt(value) ^ (signMask | onesComplementMask);
 <# } else { #>
             var bits = value;


### PR DESCRIPTION
Fixes https://github.com/m4rs-mt/ILGPU/issues/642.

Fixed issue with order of the bit flipping.
Also changed the unit tests to use the actual radix sort operations, and also to test floats.