### PR TITLE
Loop unroll fixes

### DIFF
--- a/Src/ILGPU/IR/Analyses/LoopInfo.cs
+++ b/Src/ILGPU/IR/Analyses/LoopInfo.cs
@@ -676,7 +676,8 @@ namespace ILGPU.IR.Analyses
             }
 
             // Check for unsupported loops
-            if (UpdateOperation.Kind != BinaryArithmeticKind.Add && UpdateOperation.Kind != BinaryArithmeticKind.Sub ||
+            if (UpdateOperation.Kind != BinaryArithmeticKind.Add &&
+                UpdateOperation.Kind != BinaryArithmeticKind.Sub ||
                 intBounds.update == 0)
             {
                 return null;

--- a/Src/ILGPU/IR/Transformations/LoopUnrolling.cs
+++ b/Src/ILGPU/IR/Transformations/LoopUnrolling.cs
@@ -499,8 +499,10 @@ namespace ILGPU.IR.Transformations
             // Try to compute a constant (compile-time known) trip count
             var tripCount = bounds.TryGetTripCount(out var _);
             if (!tripCount.HasValue ||
-                bounds.UpdateOperation.Kind != BinaryArithmeticKind.Add && bounds.UpdateOperation.Kind != BinaryArithmeticKind.Sub)
+                bounds.UpdateOperation.Kind != BinaryArithmeticKind.Add
+                /*&& bounds.UpdateOperation.Kind != BinaryArithmeticKind.Sub*/) 
             {
+                // TODO fix issue with Sub
                 return false;
             }
 


### PR DESCRIPTION
fixed problems with Loop Unrolling:
- fixed handling of CompareKind.LessEqual
- fixed handling of CompareKind.Equal
- fixed problem with UpdateValues other than 1

improved Loop Unrolling:
- now supporting negative UpdateValues
- now supporting CompareKind.NotEqual
- now supporting CompareKind.GreaterThan
- now supporting CompareKind.GreaterEqual
- omitting loop when not entered at all

open issues:
- critical: do not unroll when iter value is modified inside the loop
- optional: add support for ushort, short, byte, sbyte iter types