### PR TITLE
Loop unroll fixes

### DIFF
--- a/Src/ILGPU/IR/Analyses/LoopInfo.cs
+++ b/Src/ILGPU/IR/Analyses/LoopInfo.cs
@@ -675,24 +675,83 @@ namespace ILGPU.IR.Analyses
                 return null;
             }
 
-            // Check for simple loops
-            if (
-                UpdateOperation.Kind != BinaryArithmeticKind.Add ||
-                intBounds.update < 1 ||
-                BreakOperation.Kind != CompareKind.Equal &&
-                BreakOperation.Kind != CompareKind.LessEqual &&
-                BreakOperation.Kind != CompareKind.LessThan)
+            // Check for unsupported loops
+            if (UpdateOperation.Kind != BinaryArithmeticKind.Add && UpdateOperation.Kind != BinaryArithmeticKind.Sub ||
+                intBounds.update == 0)
             {
                 return null;
             }
 
-            // Compute the actual trip count
-            int baseExtent = (int)intBounds.@break - (int)intBounds.init;
-            int tripCount = baseExtent / (int)intBounds.update;
-            if (BreakOperation.Kind == CompareKind.LessEqual)
-                ++tripCount;
+            int initVal = intBounds.init.Value;
+            int breakVal = intBounds.@break.Value;
 
-            return tripCount;
+            int update = intBounds.update.Value;
+            if (UpdateOperation.Kind == BinaryArithmeticKind.Sub)
+            {
+                update *= -1;
+            }
+
+            // Check if loop is entered at all
+            bool loopIsEntered;
+            switch (BreakOperation.Kind)
+            {
+                case CompareKind.Equal:
+                    loopIsEntered = initVal == breakVal;
+                    break;
+                case CompareKind.NotEqual:
+                    loopIsEntered = initVal != breakVal;
+                    break;
+                case CompareKind.GreaterEqual:
+                    loopIsEntered = initVal >= breakVal;
+                    break;
+                case CompareKind.GreaterThan:
+                    loopIsEntered = initVal > breakVal;
+                    break;
+                case CompareKind.LessEqual:
+                    loopIsEntered = initVal <= breakVal;
+                    break;
+                case CompareKind.LessThan:
+                    loopIsEntered = initVal < breakVal;
+                    break;
+                default:
+                    return null;
+            }
+
+            if (!loopIsEntered)
+            {
+                return 0;
+            }
+
+            // Special Case for CompareKind.Equal: can only be true, once
+            if (BreakOperation.Kind == CompareKind.Equal)
+            {
+                return 1;
+            }
+
+            // Determine lastVal (might not be hit exactly)
+            int lastVal;
+            if (BreakOperation.Kind == CompareKind.LessThan ||
+                BreakOperation.Kind == CompareKind.GreaterThan ||
+                BreakOperation.Kind == CompareKind.NotEqual)
+            {
+                lastVal = update > 0 ? breakVal - 1 : breakVal + 1;
+            }
+            else
+            {
+                lastVal = breakVal;
+            }
+
+            // Compute the number of steps
+            int stepCount = (lastVal - initVal) / update;
+
+            // if stepCount is less than zero, it's probably an infinite loop
+            if (stepCount < 0)
+            {
+                return null;
+            }
+
+            // the trip count is one more than the step count
+            return stepCount + 1;
         }
 
         #endregion

--- a/Src/ILGPU/IR/Analyses/LoopInfo.cs
+++ b/Src/ILGPU/IR/Analyses/LoopInfo.cs
@@ -676,7 +676,8 @@ namespace ILGPU.IR.Analyses
             }
 
             // Check for unsupported loops
-            if (UpdateOperation.Kind != BinaryArithmeticKind.Add && UpdateOperation.Kind != BinaryArithmeticKind.Sub ||
+            if (UpdateOperation.Kind != BinaryArithmeticKind.Add &&
+                UpdateOperation.Kind != BinaryArithmeticKind.Sub ||
                 intBounds.update == 0)
             {
                 return null;

--- a/Src/ILGPU/IR/Analyses/LoopInfo.cs
+++ b/Src/ILGPU/IR/Analyses/LoopInfo.cs
@@ -688,9 +688,7 @@ namespace ILGPU.IR.Analyses
 
             int update = intBounds.update.Value;
             if (UpdateOperation.Kind == BinaryArithmeticKind.Sub)
-            {
                 update *= -1;
-            }
 
             // Check if loop is entered at all
             bool loopIsEntered;
@@ -719,15 +717,11 @@ namespace ILGPU.IR.Analyses
             }
 
             if (!loopIsEntered)
-            {
                 return 0;
-            }
 
             // Special Case for CompareKind.Equal: can only be true, once
             if (BreakOperation.Kind == CompareKind.Equal)
-            {
                 return 1;
-            }
 
             // Determine lastVal (might not be hit exactly)
             int lastVal;
@@ -745,13 +739,11 @@ namespace ILGPU.IR.Analyses
             // Compute the number of steps
             int stepCount = (lastVal - initVal) / update;
 
-            // if stepCount is less than zero, it's probably an infinite loop
+            // If stepCount is less than zero, it's probably an infinite loop
             if (stepCount < 0)
-            {
                 return null;
-            }
 
-            // the trip count is one more than the step count
+            // The trip count is one more than the step count
             return stepCount + 1;
         }
 

--- a/Src/ILGPU/IR/Transformations/LoopUnrolling.cs
+++ b/Src/ILGPU/IR/Transformations/LoopUnrolling.cs
@@ -499,8 +499,10 @@ namespace ILGPU.IR.Transformations
             // Try to compute a constant (compile-time known) trip count
             var tripCount = bounds.TryGetTripCount(out var _);
             if (!tripCount.HasValue ||
-                bounds.UpdateOperation.Kind != BinaryArithmeticKind.Add && bounds.UpdateOperation.Kind != BinaryArithmeticKind.Sub)
+                bounds.UpdateOperation.Kind != BinaryArithmeticKind.Add
+                /*&& bounds.UpdateOperation.Kind != BinaryArithmeticKind.Sub*/) 
             {
+                // TODO fix issue with Sub
                 return false;
             }
 


### PR DESCRIPTION
fixed problems with Loop Unrolling:
- fixed handling of CompareKind.LessEqual
- fixed handling of CompareKind.Equal
- fixed problem with UpdateValues other than 1

improved Loop Unrolling:
- now supporting negative UpdateValues
- now supporting CompareKind.NotEqual
- now supporting CompareKind.GreaterThan
- now supporting CompareKind.GreaterEqual
- omitting loop when not entered at all

open issues:
- critical: do not unroll when iter value is modified inside the loop
- optional: add support for ushort, short, byte, sbyte iter types