### PR TITLE
Adds Hgemm, which is gemm with ILGPU's Half type

### DIFF
--- a/Src/ILGPU.Algorithms/Runtime/Cuda/CuBlasMappings.ttinclude
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/CuBlasMappings.ttinclude
@@ -19,7 +19,8 @@ public static readonly (string, string)[] CuBlasTypes = new (string, string)[]
     ("float", "float"),
     ("double", "double"),
     ("Float2", "float"),
-    ("Double2", "double")
+    ("Double2", "double"),
+    ("Half", "half"),
 };
 
 // Level 1
@@ -248,6 +249,7 @@ public static readonly string[] Gemm = new string[]
     "Dgemm_v2",
     "Cgemm_v2",
     "Zgemm_v2",
+    "Hgemm",
 };
 
 public static readonly string[] Symm = new string[]


### PR DESCRIPTION
For #654.

Note that when I tried to use `Hgemm_v2`, I got `Unable to find an entry point named 'cublasHgemm_v2' in DLL 'cublas64_11'`, but `Hgemm` worked fine.

I've tested this on a T4 GPU, comparing multiplying an 8192 x 8192 matrix by another one. The average timings were (after a first few executions to "warm up" the GPU):
Matrices of floats: 0.25s
Matrics of halfs: 0.04s
That's about a 6x improvement. The T4 is rated for 5TFlop/s, or 40TFlop/s using the tensor core. A 6x improvement suggests that the tensor core is in use.

