### PR TITLE
Added special case for copying memory between Cuda peer accelerators.

### DIFF
--- a/Src/ILGPU/Runtime/Cuda/CudaAPI.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaAPI.cs
@@ -372,10 +372,10 @@ namespace ILGPU.Runtime.Cuda
         /// <param name="destination">The destination.</param>
         /// <param name="source">The source.</param>
         /// <param name="length">The number of bytes to copy.</param>
-        /// <returns>The error status.</returns>
         /// <param name="stream">
         /// The accelerator stream for asynchronous processing.
         /// </param>
+        /// <returns>The error status.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public CudaError MemcpyAsync(
             IntPtr destination,
@@ -388,6 +388,37 @@ namespace ILGPU.Runtime.Cuda
                 destination,
                 source,
                 length,
+                cudaStream?.StreamPtr ?? IntPtr.Zero);
+        }
+
+        /// <summary>
+        /// Performs a memory-copy operation between peers.
+        /// </summary>
+        /// <param name="dstDevice">The destination device.</param>
+        /// <param name="dstContext">The destination context.</param>
+        /// <param name="srcDevice">The source device.</param>
+        /// <param name="srcContext">The source context.</param>
+        /// <param name="byteCount">The number of bytes to copy.</param>
+        /// <param name="stream">
+        /// The accelerator stream for asynchronous processing.
+        /// </param>
+        /// <returns>The error status.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public CudaError MemcpyPeerAsync(
+            IntPtr dstDevice,
+            IntPtr dstContext,
+            IntPtr srcDevice,
+            IntPtr srcContext,
+            IntPtr byteCount,
+            AcceleratorStream stream)
+        {
+            var cudaStream = stream as CudaStream;
+            return cuMemcpyPeerAsync(
+                dstDevice,
+                dstContext,
+                srcDevice,
+                srcContext,
+                byteCount,
                 cudaStream?.StreamPtr ?? IntPtr.Zero);
         }
 

--- a/Src/ILGPU/Runtime/Cuda/CudaAPI.xml
+++ b/Src/ILGPU/Runtime/Cuda/CudaAPI.xml
@@ -107,6 +107,14 @@
         <Parameter Name="length" Type="IntPtr" />
         <Parameter Name="stream" Type="IntPtr" />
     </Import>
+    <Import Name="cuMemcpyPeerAsync">
+        <Parameter Name="dstDevice" Type="IntPtr" />
+        <Parameter Name="dstContext" Type="IntPtr" />
+        <Parameter Name="srcDevice" Type="IntPtr" />
+        <Parameter Name="srcContext" Type="IntPtr" />
+        <Parameter Name="byteCount" Type="IntPtr" />
+        <Parameter Name="stream" Type="IntPtr" />
+    </Import>
     <Import Name="cuMemsetD8Async">
         <Parameter Name="destinationDevice" Type="IntPtr" />
         <Parameter Name="value" Type="byte" />


### PR DESCRIPTION
Fixes #660.

When using the standard memory copy between peer accelerators, even though the function infers that we are copying from device to device, it does not appear to take advantage of NVLink. This code path uses the explicit peer copy operation to workaround the issue.