### PR TITLE
Fixed invalid thread configuration in CPU runtime

### DIFF
--- a/Src/ILGPU.Tests.CPU/ILGPU.Tests.CPU.csproj
+++ b/Src/ILGPU.Tests.CPU/ILGPU.Tests.CPU.csproj
@@ -15,6 +15,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <LangVersion>latest</LangVersion>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>

--- a/Src/ILGPU.Tests.CPU/RuntimeTests.cs
+++ b/Src/ILGPU.Tests.CPU/RuntimeTests.cs
@@ -1,0 +1,97 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                           Copyright (c) 2021 ILGPU Project
+//                                    www.ilgpu.net
+//
+// File: RuntimeTests.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details.
+// ---------------------------------------------------------------------------------------
+
+using ILGPU.Runtime;
+using ILGPU.Runtime.CPU;
+using Xunit;
+
+namespace ILGPU.Tests.CPU
+{
+    public class CPURuntimeTests
+    {
+        internal static void TestCustomDeviceSetup_ImplicitKernel(
+            Index1D index,
+            ArrayView<int> data)
+        {
+            data[index] = index;
+        }
+
+        internal static void TestCustomDeviceSetup_ExplicitKernel(ArrayView<int> data)
+        {
+            var globalIndex = Grid.GlobalIndex.X;
+            data[globalIndex] = globalIndex;
+        }
+
+        [Theory]
+        [InlineData(2, 1, 1)]
+        [InlineData(4, 4, 1)]
+        [InlineData(2, 1, 64)]
+        [InlineData(2, 16, 2)]
+        [InlineData(2, 32, 64)]
+        [InlineData(32, 8, 1)] // AMD default
+        [InlineData(32, 8, 16)]
+        [InlineData(64, 4, 1)] // Legacy AMD default
+        [InlineData(64, 4, 4)]
+        [InlineData(16, 8, 1)] // Intel default
+        [InlineData(16, 8, 8)]
+        [InlineData(32, 32, 1)] // Nvidia default
+        [InlineData(32, 32, 4)]
+        public void TestCustomDeviceSetup(
+            int numThreadsPerWarp,
+            int numWarpsPerMultiprocessor,
+            int numMultiprocessors)
+        {
+            // Create a custom CPU device and register it with the context pipeline
+            var customDevice = new CPUDevice(
+                numThreadsPerWarp,
+                numWarpsPerMultiprocessor,
+                numMultiprocessors);
+            using var context = Context.Create(builder =>
+                builder.Assertions().CPU(customDevice));
+
+            // Spawn a new accelerator and invoke a simple sequence kernel to check
+            // whether all threads are actually executed
+            using var accl = context.CreateCPUAccelerator(0);
+
+            // Compute the total number of parallel threads
+            int numParallelThreads =
+                numThreadsPerWarp *
+                numWarpsPerMultiprocessor *
+                numMultiprocessors;
+            Assert.Equal(numParallelThreads, accl.NumThreads);
+            Assert.Equal(numParallelThreads, accl.MaxNumThreads);
+
+            // Allocate a buffer for IO purposes
+            using var buff = accl.Allocate1D<int>(numParallelThreads);
+
+            // Validate the implicit kernel
+            var implicitKernel = accl.LoadAutoGroupedStreamKernel<
+                Index1D,
+                ArrayView<int>>(TestCustomDeviceSetup_ImplicitKernel);
+            buff.MemSetToZero();
+            implicitKernel(buff.IntExtent, buff.View);
+            var implicitData = buff.GetAsArray1D();
+            for (int i = 0; i < implicitData.Length; ++i)
+                Assert.Equal(implicitData[i], i);
+
+            // Validate the explicit kernel
+            var explicitKernel = accl.LoadStreamKernel<ArrayView<int>>(
+                TestCustomDeviceSetup_ExplicitKernel);
+            buff.MemSetToZero();
+            explicitKernel(
+                (numMultiprocessors, numThreadsPerWarp * numWarpsPerMultiprocessor),
+                buff.View);
+            var explicitData = buff.GetAsArray1D();
+            for (int i = 0; i < explicitData.Length; ++i)
+                Assert.Equal(explicitData[i], i);
+        }
+    }
+}

--- a/Src/ILGPU/Runtime/CPU/CPUDevice.cs
+++ b/Src/ILGPU/Runtime/CPU/CPUDevice.cs
@@ -253,7 +253,7 @@ namespace ILGPU.Runtime.CPU
             MaxGridSize = new Index3D(int.MaxValue, ushort.MaxValue, ushort.MaxValue);
             MaxSharedMemoryPerGroup = int.MaxValue;
             MaxConstantMemory = int.MaxValue;
-            NumThreads = MaxNumThreads * numMultiprocessors;
+            NumThreads = MaxNumThreads;
         }
 
         /// <summary>

--- a/Src/ILGPU/Runtime/CPU/CPUMultiprocessor.cs
+++ b/Src/ILGPU/Runtime/CPU/CPUMultiprocessor.cs
@@ -150,7 +150,7 @@ namespace ILGPU.Runtime.CPU
             {
                 int globalThreadIdx = ProcessorIndex * MaxNumThreadsPerMultiprocessor
                     + threadIdx;
-                threads[globalThreadIdx].Start(globalThreadIdx);
+                threads[threadIdx].Start(globalThreadIdx);
             });
             maxNumLaunchedThreadsPerGroup = groupSize;
 


### PR DESCRIPTION
This PR fixes two small issue in the scope of the `CPU` runtime by touching the `CPUDevice` and `CPUMultiprocessor` classes. It also adds several runtime-related to cases to reproduce these issues.