### PR TITLE
Improved Atomics Performance

### DIFF
--- a/Samples/AdvancedAtomics/Program.cs
+++ b/Samples/AdvancedAtomics/Program.cs
@@ -43,6 +43,17 @@ namespace AdvancedAtomics
         {
             return Atomic.CompareExchange(ref target, compare, value);
         }
+
+        /// <summary>
+        /// Returns true if both operands represent the same value.
+        /// </summary>
+        /// <param name="left">The left operand.</param>
+        /// <param name="right">The right operand.</param>
+        /// <returns>True, if both operands represent the same value.</returns>
+        public bool IsSame(double first, double second)
+        {
+            return first == second;
+        }
     }
 
     /// <summary>

--- a/Src/ILGPU/Atomic.cs
+++ b/Src/ILGPU/Atomic.cs
@@ -33,6 +33,14 @@ namespace ILGPU
             /// <param name="value">The target value.</param>
             /// <returns>The old value.</returns>
             T CompareExchange(ref T target, T compare, T value);
+
+            /// <summary>
+            /// Returns true if both operands represent the same value.
+            /// </summary>
+            /// <param name="left">The left operand.</param>
+            /// <param name="right">The right operand.</param>
+            /// <returns>True, if both operands represent the same value.</returns>
+            bool IsSame(T left, T right);
         }
 
         /// <summary>
@@ -110,9 +118,9 @@ namespace ILGPU
         public static float Exchange(ref float target, float value)
         {
             var result = Exchange(
-                ref Unsafe.As<float, int>(ref target),
-                Unsafe.As<float, int>(ref value));
-            return Unsafe.As<int, float>(ref result);
+                ref Unsafe.As<float, uint>(ref target),
+                Interop.FloatAsInt(value));
+            return Interop.IntAsFloat(result);
         }
 
         /// <summary>
@@ -125,9 +133,9 @@ namespace ILGPU
         public static double Exchange(ref double target, double value)
         {
             var result = Exchange(
-                ref Unsafe.As<double, long>(ref target),
-                Unsafe.As<double, long>(ref value));
-            return Unsafe.As<long, double>(ref result);
+                ref Unsafe.As<double, ulong>(ref target),
+                Interop.FloatAsInt(value));
+            return Interop.IntAsFloat(result);
         }
 
         /// <summary>
@@ -196,10 +204,10 @@ namespace ILGPU
             float value)
         {
             var result = CompareExchange(
-                ref Unsafe.As<float, int>(ref target),
-                Unsafe.As<float, int>(ref compare),
-                Unsafe.As<float, int>(ref value));
-            return Unsafe.As<int, float>(ref result);
+                ref Unsafe.As<float, uint>(ref target),
+                Interop.FloatAsInt(compare),
+                Interop.FloatAsInt(value));
+            return Interop.IntAsFloat(result);
         }
 
         /// <summary>
@@ -216,10 +224,10 @@ namespace ILGPU
             double value)
         {
             var result = CompareExchange(
-                ref Unsafe.As<double, long>(ref target),
-                Unsafe.As<double, long>(ref compare),
-                Unsafe.As<double, long>(ref value));
-            return Unsafe.As<long, double>(ref result);
+                ref Unsafe.As<double, ulong>(ref target),
+                Interop.FloatAsInt(compare),
+                Interop.FloatAsInt(value));
+            return Interop.IntAsFloat(result);
         }
 
         /// <summary>
@@ -266,7 +274,7 @@ namespace ILGPU
             T value,
             TOperation operation,
             TCompareExchangeOperation compareExchangeOperation)
-            where T : unmanaged, IEquatable<T>
+            where T : unmanaged
             where TOperation : struct, AtomicOperations.IAtomicOperation<T>
             where TCompareExchangeOperation :
                 struct,
@@ -284,7 +292,7 @@ namespace ILGPU
                     expected,
                     newValue);
             }
-            while (!expected.Equals(current));
+            while (!compareExchangeOperation.IsSame(expected, current));
 
             return current;
         }

--- a/Src/ILGPU/AtomicFunctions.tt
+++ b/Src/ILGPU/AtomicFunctions.tt
@@ -49,11 +49,21 @@ namespace ILGPU
             /// <param name="compare">The expected comparison value.</param>
             /// <param name="value">The target value.</param>
             /// <returns>The old value.</returns>
-            public <#= type.Type #> CompareExchange(
+            public readonly <#= type.Type #> CompareExchange(
                 ref <#= type.Type #> target,
                 <#= type.Type #> compare,
                 <#= type.Type #> value) =>
                 Atomic.CompareExchange(ref target, compare, value);
+
+            /// <summary>
+            /// Returns true if both operands represent the same value.
+            /// </summary>
+            /// <param name="left">The left operand.</param>
+            /// <param name="right">The right operand.</param>
+            /// <returns>True, if both operands represent the same value.</returns>
+            public readonly bool IsSame(
+                <#= type.Type #> left,
+                <#= type.Type #> right) => left == right;
         }
 
 <#      } #>
@@ -83,7 +93,7 @@ namespace ILGPU
 <#      foreach (var type in atomicUnsignedIntAndFloatTypes) { #>
         struct Add<#= type.Name #> : AtomicOperations.IAtomicOperation<<#= type.Type #>>
         {
-            public <#= type.Type #> Operation(
+            public readonly <#= type.Type #> Operation(
                 <#= type.Type #> current,
                 <#= type.Type #> value) =>
                 current + value;
@@ -122,9 +132,7 @@ namespace ILGPU
         /// <param name="value">The value to add.</param>
         /// <returns>The old value that was stored at the target location.</returns>
         [CLSCompliant(false)]
-<#          if (type.Type != "double") { #>
         [AtomicIntrinsic(AtomicIntrinsicKind.Add, AtomicFlags.None)]
-<#          } #>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static <#= type.Type #> Add(
             ref <#= type.Type #> target,
@@ -144,7 +152,7 @@ namespace ILGPU
 <#      foreach (var type in AtomicNumericTypes) { #>
         struct Max<#= type.Name #> : AtomicOperations.IAtomicOperation<<#= type.Type #>>
         {
-            public <#= type.Type #> Operation(
+            public readonly <#= type.Type #> Operation(
                 <#= type.Type #> current,
                 <#= type.Type #> value) =>
                 IntrinsicMath.Max(current, value);
@@ -182,7 +190,7 @@ namespace ILGPU
 <#      foreach (var type in AtomicNumericTypes) { #>
         struct Min<#= type.Name #> : AtomicOperations.IAtomicOperation<<#= type.Type #>>
         {
-            public <#= type.Type #> Operation(
+            public readonly <#= type.Type #> Operation(
                 <#= type.Type #> current,
                 <#= type.Type #> value) =>
                 IntrinsicMath.Min(current, value);
@@ -220,7 +228,7 @@ namespace ILGPU
 <#      foreach (var type in AtomicIntTypes) { #>
         struct And<#= type.Name #> : AtomicOperations.IAtomicOperation<<#= type.Type #>>
         {
-            public <#= type.Type #> Operation(
+            public readonly <#= type.Type #> Operation(
                 <#= type.Type #> current,
                 <#= type.Type #> value) =>
                 current & value;
@@ -259,7 +267,7 @@ namespace ILGPU
 <#      foreach (var type in AtomicIntTypes) { #>
         struct Or<#= type.Name #> : AtomicOperations.IAtomicOperation<<#= type.Type #>>
         {
-            public <#= type.Type #> Operation(
+            public readonly <#= type.Type #> Operation(
                 <#= type.Type #> current,
                 <#= type.Type #> value) =>
                 current | value;
@@ -298,7 +306,7 @@ namespace ILGPU
 <#      foreach (var type in AtomicIntTypes) { #>
         struct Xor<#= type.Name #> : AtomicOperations.IAtomicOperation<<#= type.Type #>>
         {
-            public <#= type.Type #> Operation(
+            public readonly <#= type.Type #> Operation(
                 <#= type.Type #> current,
                 <#= type.Type #> value) =>
                 current ^ value;


### PR DESCRIPTION
This PR refines some implementation details of the currently implemented `Atomic.Add`, `Atomic.Exchange` and `Atomic.CompareExchange` operations to improve performance. This issue with the old implementations was that they introduced temporary local-memory allocations which could not be removed by our optimization pipeline, since they relied on unsafe pointer casts which cannot be removed in general.

This PR also adds a new `IsSame` method to the `IAtomicOperations` interface. Its purpose is to avoid calls to `float.Equals` and `double.Equals` in software-implemented `MakeAtomic` while loops.

In addition, this PR adds a missing `Intrinsic` attribute to the `Atomic.Add(ref double, double)` function, which could not be mapped to an efficient intrinsic equivalent on the latest Nvidia GPUs.