### PR TITLE
Fixed issue in InferAddressSpaces

### DIFF
--- a/Src/ILGPU/IR/Transformations/InferAddressSpaces.cs
+++ b/Src/ILGPU/IR/Transformations/InferAddressSpaces.cs
@@ -231,7 +231,7 @@ namespace ILGPU.IR.Transformations
                     return false;
                 case NewView _:
                 case SubViewValue _:
-                case PointerCast _:
+                case BaseAddressSpaceCast _:
                 case LoadElementAddress _:
                 case LoadFieldAddress _:
                     data.Push(value);


### PR DESCRIPTION
This PR fixes an issue in the `InferAddressSpaces` transformation used in debug builds. The issue was related to the invalid removal of `AddressSpaceCast` operations in the presence of view-based address-space casts. 