### PR TITLE
Fixed invalid peer-access implementation(s).

### DIFF
--- a/Src/ILGPU/InstanceId.cs
+++ b/Src/ILGPU/InstanceId.cs
@@ -10,6 +10,7 @@
 // ---------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
@@ -17,6 +18,26 @@ namespace ILGPU
 {
     internal readonly struct InstanceId : IEquatable<InstanceId>
     {
+        #region Nested Types
+
+        /// <summary>
+        /// Compares instance id.
+        /// </summary>
+        public readonly struct Comparer : IEqualityComparer<InstanceId>
+        {
+            /// <summary>
+            /// Returns true if both instance ids represent the same value.
+            /// </summary>
+            public readonly bool Equals(InstanceId x, InstanceId y) => x == y;
+
+            /// <summary>
+            /// Returns the hash code of the given instance id.
+            /// </summary>
+            public readonly int GetHashCode(InstanceId obj) => obj.GetHashCode();
+        }
+
+        #endregion
+
         #region Static
 
         /// <summary>
@@ -68,7 +89,7 @@ namespace ILGPU
         /// </summary>
         /// <param name="other">The other id.</param>
         /// <returns>True, if the given id is equal to this id.</returns>
-        public bool Equals(InstanceId other) => this == other;
+        public readonly bool Equals(InstanceId other) => this == other;
 
         #endregion
 
@@ -79,14 +100,14 @@ namespace ILGPU
         /// </summary>
         /// <param name="obj">The other object.</param>
         /// <returns>True, if the given object is equal to this id.</returns>
-        public override bool Equals(object obj) =>
+        public readonly override bool Equals(object obj) =>
             obj is InstanceId id && id == this;
 
         /// <summary>
         /// Returns the hash code of this id.
         /// </summary>
         /// <returns>The hash code of this id.</returns>
-        public override int GetHashCode() => Value.GetHashCode();
+        public readonly override int GetHashCode() => Value.GetHashCode();
 
         /// <summary>
         /// Returns the string representation of the <see cref="Value"/> property.
@@ -94,7 +115,7 @@ namespace ILGPU
         /// <returns>
         /// The string representation of the <see cref="Value"/> property.
         /// </returns>
-        public override string ToString() => Value.ToString();
+        public readonly override string ToString() => Value.ToString();
 
         #endregion
 

--- a/Src/ILGPU/Runtime/CPU/CPUAccelerator.cs
+++ b/Src/ILGPU/Runtime/CPU/CPUAccelerator.cs
@@ -251,7 +251,7 @@ namespace ILGPU.Runtime.CPU
             }
         }
 
-        /// <summary cref="Accelerator.DisablePeerAccess(Accelerator)"/>
+        /// <summary cref="Accelerator.DisablePeerAccessInternal(Accelerator)"/>
         protected override void DisablePeerAccessInternal(
             Accelerator otherAccelerator) =>
             Debug.Assert(

--- a/Src/ILGPU/Runtime/Cuda/CudaAccelerator.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaAccelerator.cs
@@ -491,9 +491,6 @@ namespace ILGPU.Runtime.Cuda
         /// <summary cref="Accelerator.EnablePeerAccessInternal(Accelerator)"/>
         protected override void EnablePeerAccessInternal(Accelerator otherAccelerator)
         {
-            if (HasPeerAccess(otherAccelerator))
-                return;
-
             if (!(otherAccelerator is CudaAccelerator cudaAccelerator))
             {
                 throw new InvalidOperationException(
@@ -507,9 +504,6 @@ namespace ILGPU.Runtime.Cuda
         /// <summary cref="Accelerator.DisablePeerAccessInternal(Accelerator)"/>
         protected override void DisablePeerAccessInternal(Accelerator otherAccelerator)
         {
-            if (!HasPeerAccess(otherAccelerator))
-                return;
-
             var cudaAccelerator = otherAccelerator as CudaAccelerator;
             Debug.Assert(cudaAccelerator != null, "Invalid EnablePeerAccess method");
 

--- a/Src/ILGPU/Runtime/Cuda/CudaMemoryBuffer.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaMemoryBuffer.cs
@@ -35,16 +35,11 @@ namespace ILGPU.Runtime.Cuda
             in ArrayView<T> targetView)
             where T : unmanaged
         {
-            if (stream is null)
-                throw new ArgumentNullException(nameof(stream));
-
             if (targetView.GetAcceleratorType() != AcceleratorType.Cuda)
             {
                 throw new NotSupportedException(
                     RuntimeErrorMessages.NotSupportedTargetAccelerator);
             }
-
-            var binding = stream.Accelerator.BindScoped();
 
             CudaException.ThrowIfFailed(
                 CurrentAPI.Memset(
@@ -52,8 +47,6 @@ namespace ILGPU.Runtime.Cuda
                     value,
                     new IntPtr(targetView.LengthInBytes),
                     stream));
-
-            binding.Recover();
         }
 
         /// <summary>
@@ -69,11 +62,6 @@ namespace ILGPU.Runtime.Cuda
             in ArrayView<T> targetView)
             where T : unmanaged
         {
-            if (stream is null)
-                throw new ArgumentNullException(nameof(stream));
-
-            using var binding = stream.Accelerator.BindScoped();
-
             var sourceType = sourceView.GetAcceleratorType();
             var targetType = targetView.GetAcceleratorType();
 


### PR DESCRIPTION
This PR refines the implementations of the `EnablePeerAccess` and `DisablePeerAccess` methods on the main `Accelerator` and the `CudaAccelerator` classes, Furthermore, it fixes a few issues related to the registering and unregistering of peer accesses.

This PR also contains some performance optimizations of the `CudaMemoryBuffer` class, affecting the `CudaMemSet` and `CudaCopy` methods.

Fixes #660.