### PR TITLE
Added AMD printf OpenCL extension.

### DIFF
--- a/Src/ILGPU/Context.Builder.cs
+++ b/Src/ILGPU/Context.Builder.cs
@@ -72,7 +72,8 @@ namespace ILGPU
             /// auto-assertion mode via <see cref="AutoAssertions"/>.
             /// </summary>
             /// <returns>The current builder instance.</returns>
-            public Builder Default() => AllAccelerators().AutoAssertions();
+            public Builder Default() =>
+                AllAccelerators().AutoAssertions().AutoIOOperations();
 
             /// <summary>
             /// Enables all supported accelerators.

--- a/Src/ILGPU/ContextProperties.cs
+++ b/Src/ILGPU/ContextProperties.cs
@@ -434,6 +434,7 @@ namespace ILGPU
                             : DebugSymbolsMode.Disabled
                         : DebugSymbolsMode,
                 EnableAssertions = EnableAssertions,
+                EnableIOOperations = EnableIOOperations,
                 EnableKernelInformation = EnableKernelInformation,
                 EnableVerifier = EnableVerifier,
                 EnableParallelCodeGenerationInFrontend =

--- a/Src/ILGPU/IR/Transformations/AcceleratorSpecializer.cs
+++ b/Src/ILGPU/IR/Transformations/AcceleratorSpecializer.cs
@@ -215,7 +215,7 @@ namespace ILGPU.IR.Transformations
             SpecializerData data,
             WriteToOutput value)
         {
-            if (data.EnableAssertions)
+            if (data.EnableIOOperations)
                 data.ToImplement.Add(value);
             else
                 context.Remove(value);

--- a/Src/ILGPU/Static/Capabilities.xml
+++ b/Src/ILGPU/Static/Capabilities.xml
@@ -44,6 +44,14 @@
         <OpenCL manual="true" />
     </Capability>
 
+    <Capability Name="AMD_Printf">
+        <Summary>Supports AMD printf.</Summary>
+        <FeatureName>AMD printf extension</FeatureName>
+        <OpenCL>
+            <Extension>cl_amd_printf</Extension>
+        </OpenCL>
+    </Capability>
+
     <Capability Name="Int64_Atomics">
         <Summary>Supports 64-bit Atomics.</Summary>
         <FeatureName>64-bit atomics extension</FeatureName>


### PR DESCRIPTION
Experiment to fix a user-reported issue regarding missing printf output on AMD.