### PR TITLE
Simplified API for copying to/from page locked memory.

### DIFF
--- a/Samples/PinnedMemoryCopy/Program.cs
+++ b/Samples/PinnedMemoryCopy/Program.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                    ILGPU Samples
-//                        Copyright (c) 2021-2023 ILGPU Project
+//                        Copyright (c) 2021-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Program.cs

--- a/Samples/PinnedMemoryCopy/Program.cs
+++ b/Samples/PinnedMemoryCopy/Program.cs
@@ -36,7 +36,7 @@ namespace PinnedMemoryCopy
 
                 // Page locked buffers enable async memory transfers
                 using var scope = accelerator.CreatePageLockFromPinned(array);
-                bufferOnGPU.View.CopyFromPageLockedAsync(stream, scope);
+                bufferOnGPU.View.CopyFrom(stream, scope.ArrayView);
 
                 //
                 // Perform other operations...
@@ -66,7 +66,7 @@ namespace PinnedMemoryCopy
 
             // Page locked buffers enable async memory transfers
             using var scope = accelerator.CreatePageLockFromPinned(array);
-            bufferOnGPU.View.CopyFromPageLockedAsync(stream, scope);
+            bufferOnGPU.View.CopyFrom(stream, scope.ArrayView);
 
             //
             // Perform other operations...
@@ -89,7 +89,7 @@ namespace PinnedMemoryCopy
             using var bufferOnGPU = accelerator.Allocate1D<int>(array.Length);
             var stream = accelerator.DefaultStream;
 
-            bufferOnGPU.View.CopyFromPageLockedAsync(stream, array);
+            bufferOnGPU.View.CopyFrom(stream, array.ArrayView);
 
             //
             // Perform other operations...
@@ -99,7 +99,7 @@ namespace PinnedMemoryCopy
             stream.Synchronize();
 
             // Retrieve the results into an existing page locked array
-            bufferOnGPU.View.CopyToPageLockedAsync(stream, array);
+            bufferOnGPU.View.CopyTo(stream, array.ArrayView);
 
             // Retrieve the results into a new array
             // Rely on disabled (default) or automatic page locking behavior

--- a/Src/ILGPU.Algorithms/Optimization/IOptimizer.cs
+++ b/Src/ILGPU.Algorithms/Optimization/IOptimizer.cs
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------------------------
 //                                   ILGPU Algorithms
-//                           Copyright (c) 2023 ILGPU Project
+//                        Copyright (c) 2023-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: IOptimizer.cs

--- a/Src/ILGPU.Algorithms/Optimization/IOptimizer.cs
+++ b/Src/ILGPU.Algorithms/Optimization/IOptimizer.cs
@@ -230,7 +230,9 @@ namespace ILGPU.Algorithms.Optimization
         /// </summary>
         /// <param name="data">The data to load the particles to.</param>
         public void LoadParticles(PageLockedArray2D<TNumericType> data) =>
-            Optimizer.Engine.PositionsView.DataView.CopyToPageLockedAsync(Stream, data);
+            Optimizer.Engine.PositionsView.DataView.BaseView.CopyTo(
+                Stream,
+                data.ArrayView);
 
         /// <summary>
         /// Loads all particle positions and converts them into a 2D array.

--- a/Src/ILGPU.Algorithms/Optimization/OptimizationEngine.cs
+++ b/Src/ILGPU.Algorithms/Optimization/OptimizationEngine.cs
@@ -13,6 +13,7 @@ using ILGPU.Algorithms.ScanReduceOperations;
 using ILGPU.Algorithms.Vectors;
 using ILGPU.Runtime;
 using ILGPU.Util;
+using ILGPU;
 using System;
 using System.Diagnostics;
 using System.Numerics;
@@ -396,9 +397,9 @@ namespace ILGPU.Algorithms.Optimization
                 boundsElementBufferCPU[i, 1] = upperBounds[i];
             }
             
-            boundsElementView.DataView.CopyFromPageLockedAsync(
+            boundsElementView.DataView.BaseView.CopyFrom(
                 stream,
-                boundsElementBufferCPU);
+                boundsElementBufferCPU.ArrayView);
             
             ConvertToVectorizedView(
                 stream,
@@ -453,7 +454,7 @@ namespace ILGPU.Algorithms.Optimization
             AcceleratorStream stream,
             ArrayView<TElementType> parameters)
         {
-            parameters.CopyToPageLockedAsync(stream, parametersCPU);
+            parameters.CopyTo(stream, parametersCPU.ArrayView);
             stream.Synchronize();
         }
 
@@ -528,8 +529,8 @@ namespace ILGPU.Algorithms.Optimization
             resultEvalBufferCPU[0] = bestResult;
 
             // Copy position and best result to GPU buffers
-            resultElementView.CopyFromPageLockedAsync(stream, resultElementBufferCPU);
-            resultEvalView.BaseView.CopyFromPageLockedAsync(stream, resultEvalBufferCPU);
+            resultElementView.CopyFrom(stream, resultElementBufferCPU.ArrayView);
+            resultEvalView.BaseView.CopyFrom(stream, resultEvalBufferCPU.ArrayView);
 
             // Convert our best result view
             ConvertToVectorizedView(
@@ -613,12 +614,12 @@ namespace ILGPU.Algorithms.Optimization
             OptimizationResultView<TElementType, TEvalType> resultView)
         {
             // Copy result to CPU to group by range of numerical values
-            resultView.PositionView.CopyToPageLockedAsync(
+            resultView.PositionView.CopyTo(
                 stream,
-                resultElementBufferCPU);
-            resultView.ResultView.BaseView.CopyToPageLockedAsync(
+                resultElementBufferCPU.ArrayView);
+            resultView.ResultView.BaseView.CopyTo(
                 stream,
-                resultEvalBufferCPU);
+                resultEvalBufferCPU.ArrayView);
 
             // Return the actual result
             return new OptimizationResult<TElementType, TEvalType>(

--- a/Src/ILGPU.Algorithms/Optimization/OptimizationEngine.cs
+++ b/Src/ILGPU.Algorithms/Optimization/OptimizationEngine.cs
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------------------------
 //                                   ILGPU Algorithms
-//                           Copyright (c) 2023 ILGPU Project
+//                        Copyright (c) 2023-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: OptimizationEngine.cs

--- a/Src/ILGPU.Tests/PageLockedMemory.cs
+++ b/Src/ILGPU.Tests/PageLockedMemory.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2021-2023 ILGPU Project
+//                        Copyright (c) 2021-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: PageLockedMemory.cs

--- a/Src/ILGPU.Tests/PageLockedMemory.cs
+++ b/Src/ILGPU.Tests/PageLockedMemory.cs
@@ -59,10 +59,10 @@ namespace ILGPU.Tests
                 using var buffer = Accelerator.Allocate1D<int>(array.Length);
                 using var scope = Accelerator.CreatePageLockFromPinned(array);
 
-                buffer.View.CopyFromPageLockedAsync(scope);
+                buffer.View.CopyFrom(scope.ArrayView);
                 Execute(buffer.Length, buffer.View);
 
-                buffer.View.CopyToPageLockedAsync(scope);
+                buffer.View.CopyTo(scope.ArrayView);
                 Accelerator.Synchronize();
                 Verify1D(array, expected);
             }
@@ -81,10 +81,10 @@ namespace ILGPU.Tests
             using var buffer = Accelerator.Allocate1D<int>(array.Length);
             using var scope = Accelerator.CreatePageLockFromPinned(array);
 
-            buffer.View.CopyFromPageLockedAsync(scope);
+            buffer.View.CopyFrom(scope.ArrayView);
             Execute(buffer.Length, buffer.View);
 
-            buffer.View.CopyToPageLockedAsync(scope);
+            buffer.View.CopyTo(scope.ArrayView);
             Accelerator.Synchronize();
             Verify1D(array, expected);
         }
@@ -107,14 +107,14 @@ namespace ILGPU.Tests
             using var buff = Accelerator.Allocate1D<long>(Length);
 
             // Start copying, create the expected array in the meantime
-            buff.View.CopyFromPageLockedAsync(array);
+            buff.View.CopyFrom(array.ArrayView);
             var expected = Enumerable.Repeat(constant - 5, Length).ToArray();
             Accelerator.Synchronize();
 
             Execute(array.Extent.ToIntIndex(), buff.View);
             Accelerator.Synchronize();
 
-            buff.View.CopyToPageLockedAsync(array);
+            buff.View.CopyTo(array.ArrayView);
             Accelerator.Synchronize();
 
             Assert.Equal(expected.Length, array.Length);
@@ -132,7 +132,7 @@ namespace ILGPU.Tests
                 array[i] = 10;
 
             using var buff = Accelerator.Allocate1D<long>(Length);
-            buff.View.CopyFromPageLockedAsync(array);
+            buff.View.CopyFrom(array.ArrayView);
 
             var expected = new int[Length];
             for (int i = 0; i < Length; i++)

--- a/Src/ILGPU/Runtime/ArrayViewExtensions.Generated.tt
+++ b/Src/ILGPU/Runtime/ArrayViewExtensions.Generated.tt
@@ -712,6 +712,7 @@ namespace ILGPU.Runtime
         /// <param name="pageLockScope">The page locked memory.</param>
         /// <remarks>This method is not supported on accelerators.</remarks>
         [NotInsideKernel]
+        [Obsolete("Use PageLockScope.ArrayView instead")]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void CopyToPageLockedAsync<T>(
             this <#= viewName #> source,
@@ -729,6 +730,7 @@ namespace ILGPU.Runtime
         /// <param name="pageLockScope">The page locked memory.</param>
         /// <remarks>This method is not supported on accelerators.</remarks>
         [NotInsideKernel]
+        [Obsolete("Use PageLockScope.ArrayView instead")]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void CopyToPageLockedAsync<T>(
             this <#= viewName #> source,
@@ -746,6 +748,7 @@ namespace ILGPU.Runtime
         /// <param name="pageLockScope">The page locked memory.</param>
         /// <remarks>This method is not supported on accelerators.</remarks>
         [NotInsideKernel]
+        [Obsolete("Use PageLockScope.ArrayView instead")]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void CopyFromPageLockedAsync<T>(
             this <#= viewName #> target,
@@ -763,6 +766,7 @@ namespace ILGPU.Runtime
         /// <param name="pageLockScope">The page locked memory.</param>
         /// <remarks>This method is not supported on accelerators.</remarks>
         [NotInsideKernel]
+        [Obsolete("Use PageLockScope.ArrayView instead")]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void CopyFromPageLockedAsync<T>(
             this <#= viewName #> target,
@@ -792,6 +796,7 @@ namespace ILGPU.Runtime
         /// This method is not supported on accelerators.
         /// </remarks>
         [NotInsideKernel]
+        [Obsolete("Use PageLockScope.ArrayView instead")]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void CopyToPageLockedAsync<T>(
             this <#= typeName #><T, <#= strideTypeName #>.<#= strideName #>> source,
@@ -812,6 +817,7 @@ namespace ILGPU.Runtime
         /// This method is not supported on accelerators.
         /// </remarks>
         [NotInsideKernel]
+        [Obsolete("Use PageLockScope.ArrayView instead")]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void CopyToPageLockedAsync<T>(
             this <#= typeName #><T, <#= strideTypeName #>.<#= strideName #>> source,
@@ -832,6 +838,7 @@ namespace ILGPU.Runtime
         /// This method is not supported on accelerators.
         /// </remarks>
         [NotInsideKernel]
+        [Obsolete("Use PageLockScope.ArrayView instead")]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void CopyFromPageLockedAsync<T>(
             this <#= typeName #><T, <#= strideTypeName #>.<#= strideName #>> target,
@@ -855,6 +862,7 @@ namespace ILGPU.Runtime
         /// This method is not supported on accelerators.
         /// </remarks>
         [NotInsideKernel]
+        [Obsolete("Use PageLockScope.ArrayView instead")]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void CopyFromPageLockedAsync<T>(
             this <#= typeName #><T, <#= strideTypeName #>.<#= strideName #>> target,

--- a/Src/ILGPU/Runtime/ArrayViewExtensions.Generated.tt
+++ b/Src/ILGPU/Runtime/ArrayViewExtensions.Generated.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2016-2021 ILGPU Project
+//                        Copyright (c) 2016-2023 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: ArrayViewExtensions.Generated.tt/ArrayViewExtensions.Generated.cs
@@ -915,7 +915,7 @@ namespace ILGPU.Runtime
                 .AllocatePageLocked<#= dimension #>D<T>(view.Extent);
 
             // Copy the data
-            view.CopyToPageLockedAsync(stream, result);
+            view.BaseView.CopyTo(stream, result.ArrayView);
             stream.Synchronize();
 
             return result;

--- a/Src/ILGPU/Runtime/ArrayViewExtensions.Generated.tt
+++ b/Src/ILGPU/Runtime/ArrayViewExtensions.Generated.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2016-2023 ILGPU Project
+//                        Copyright (c) 2016-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: ArrayViewExtensions.Generated.tt/ArrayViewExtensions.Generated.cs

--- a/Src/ILGPU/Runtime/ArrayViewExtensions.cs
+++ b/Src/ILGPU/Runtime/ArrayViewExtensions.cs
@@ -624,7 +624,10 @@ namespace ILGPU.Runtime
                 using var pageLockScope = accelerator.CreatePageLockFromPinned<T>(
                     new IntPtr(Unsafe.AsPointer(ref cpuData)),
                     length);
-                source.CopyToPageLockedAsync(stream, pageLockScope);
+                source.Buffer.CopyTo(
+                    stream,
+                    source.IndexInBytes,
+                    pageLockScope.ArrayView.Cast<byte>());
             }
             else
             {
@@ -694,7 +697,10 @@ namespace ILGPU.Runtime
                 using var pageLockScope = accelerator.CreatePageLockFromPinned<T>(
                     new IntPtr(Unsafe.AsPointer(ref cpuData)),
                     length);
-                target.CopyFromPageLockedAsync(pageLockScope);
+                target.Buffer.CopyFrom(
+                    stream,
+                    pageLockScope.ArrayView.Cast<byte>(),
+                    target.IndexInBytes);
             }
             else
             {
@@ -1678,7 +1684,7 @@ namespace ILGPU.Runtime
             var result = accelerator.AllocatePageLocked1D<T>(
                 view.Length,
                 uninitialized: true);
-            view.CopyToPageLockedAsync(stream, result);
+            view.CopyTo(stream, result.ArrayView);
             stream.Synchronize();
             return result;
         }

--- a/Src/ILGPU/Runtime/ArrayViewExtensions.cs
+++ b/Src/ILGPU/Runtime/ArrayViewExtensions.cs
@@ -1423,6 +1423,7 @@ namespace ILGPU.Runtime
         /// <param name="pageLockScope">The page locked memory.</param>
         /// <remarks>This method is not supported on accelerators.</remarks>
         [NotInsideKernel]
+        [Obsolete("Use PageLockScope.ArrayView instead")]
         public static void CopyToPageLockedAsync<T, TView>(
             this TView source,
             AcceleratorStream stream,
@@ -1459,6 +1460,7 @@ namespace ILGPU.Runtime
         /// <param name="pageLockScope">The page locked memory.</param>
         /// <remarks>This method is not supported on accelerators.</remarks>
         [NotInsideKernel]
+        [Obsolete("Use PageLockScope.ArrayView instead")]
         public static void CopyFromPageLockedAsync<T, TView>(
             this TView target,
             AcceleratorStream stream,
@@ -1494,6 +1496,7 @@ namespace ILGPU.Runtime
         /// <param name="pageLockScope">The page locked memory.</param>
         /// <remarks>This method is not supported on accelerators.</remarks>
         [NotInsideKernel]
+        [Obsolete("Use PageLockScope.ArrayView instead")]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void CopyToPageLockedAsync<T, TView>(
             this TView source,
@@ -1515,6 +1518,7 @@ namespace ILGPU.Runtime
         /// <param name="pageLockScope">The page locked memory.</param>
         /// <remarks>This method is not supported on accelerators.</remarks>
         [NotInsideKernel]
+        [Obsolete("Use PageLockScope.ArrayView instead")]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void CopyFromPageLockedAsync<T, TView>(
             this TView target,
@@ -1537,6 +1541,7 @@ namespace ILGPU.Runtime
         /// <param name="pageLockedArray">The page locked memory.</param>
         /// <remarks>This method is not supported on accelerators.</remarks>
         [NotInsideKernel]
+        [Obsolete("Use PageLockScope.ArrayView instead")]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void CopyToPageLockedAsync<T, TView>(
             this TView source,
@@ -1546,7 +1551,7 @@ namespace ILGPU.Runtime
             where T : unmanaged =>
             source.CopyToPageLockedAsync(
                 stream,
-                pageLockedArray.Scope);
+                pageLockedArray.Scope.AsNotNull());
 
         /// <summary>
         /// Copies from the page locked memory into the given target view without
@@ -1559,6 +1564,7 @@ namespace ILGPU.Runtime
         /// <param name="pageLockedArray">The page locked memory.</param>
         /// <remarks>This method is not supported on accelerators.</remarks>
         [NotInsideKernel]
+        [Obsolete("Use PageLockScope.ArrayView instead")]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void CopyFromPageLockedAsync<T, TView>(
             this TView target,
@@ -1568,7 +1574,7 @@ namespace ILGPU.Runtime
             where T : unmanaged =>
             target.CopyFromPageLockedAsync(
                 stream,
-                pageLockedArray.Scope);
+                pageLockedArray.Scope.AsNotNull());
 
         /// <summary>
         /// Copies from the source view into the given page locked memory without
@@ -1580,13 +1586,14 @@ namespace ILGPU.Runtime
         /// <param name="pageLockedArray">The page locked memory.</param>
         /// <remarks>This method is not supported on accelerators.</remarks>
         [NotInsideKernel]
+        [Obsolete("Use PageLockScope.ArrayView instead")]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void CopyToPageLockedAsync<T, TView>(
             this TView source,
             PageLockedArray<T> pageLockedArray)
             where TView : IContiguousArrayView<T>
             where T : unmanaged =>
-            source.CopyToPageLockedAsync(pageLockedArray.Scope);
+            source.CopyToPageLockedAsync(pageLockedArray.Scope.AsNotNull());
 
         /// <summary>
         /// Copies from the page locked memory into the given target view without
@@ -1598,13 +1605,14 @@ namespace ILGPU.Runtime
         /// <param name="pageLockedArray">The page locked memory.</param>
         /// <remarks>This method is not supported on accelerators.</remarks>
         [NotInsideKernel]
+        [Obsolete("Use PageLockScope.ArrayView instead")]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void CopyFromPageLockedAsync<T, TView>(
             this TView target,
             PageLockedArray<T> pageLockedArray)
             where TView : IContiguousArrayView<T>
             where T : unmanaged =>
-            target.CopyFromPageLockedAsync(pageLockedArray.Scope);
+            target.CopyFromPageLockedAsync(pageLockedArray.Scope.AsNotNull());
 
         #endregion
 

--- a/Src/ILGPU/Runtime/ArrayViewExtensions.cs
+++ b/Src/ILGPU/Runtime/ArrayViewExtensions.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2021-2023 ILGPU Project
+//                        Copyright (c) 2021-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: ArrayViewExtensions.cs

--- a/Src/ILGPU/Runtime/Cuda/CudaPageLockScope.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaPageLockScope.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2021-2023 ILGPU Project
+//                        Copyright (c) 2021-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: CudaPageLockScope.cs

--- a/Src/ILGPU/Runtime/Cuda/CudaPageLockScope.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaPageLockScope.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2023 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: CudaPageLockScope.cs
@@ -32,14 +32,31 @@ namespace ILGPU.Runtime
             CudaAccelerator accelerator,
             IntPtr hostPtr,
             long numElements)
-            : base(accelerator, numElements)
+            : base(
+                  accelerator,
+                  GetAddrOfLockedObject(accelerator, hostPtr, numElements),
+                  numElements)
+        {
+            HostPtr = hostPtr;
+        }
+
+        /// <summary>
+        /// Registers the page lock.
+        /// </summary>
+        /// <param name="accelerator">The associated accelerator.</param>
+        /// <param name="hostPtr">The host buffer pointer to page lock.</param>
+        /// <param name="numElements">The number of elements in the buffer.</param>
+        /// <returns>The page locked address.</returns>
+        private static IntPtr GetAddrOfLockedObject(
+            CudaAccelerator accelerator,
+            IntPtr hostPtr,
+            long numElements)
         {
             if (!accelerator.Device.SupportsMappingHostMemory)
             {
                 throw new NotSupportedException(
                     RuntimeErrorMessages.NotSupportedPageLock);
             }
-            HostPtr = hostPtr;
 
             bool supportsHostPointer = accelerator
                 .Device
@@ -51,17 +68,18 @@ namespace ILGPU.Runtime
                 flags |= MemHostRegisterFlags.CU_MEMHOSTREGISTER_DEVICEMAP;
 
             // Perform the memory registration.
+            var lengthInBytes = numElements * Interop.SizeOf<T>();
             CudaException.ThrowIfFailed(
                 CurrentAPI.MemHostRegister(
                     hostPtr,
-                    new IntPtr(LengthInBytes),
+                    new IntPtr(lengthInBytes),
                     flags));
 
             // Check whether we have to determine the actual device pointer or are able
             // to reuse the host pointer for all operations.
             if (supportsHostPointer)
             {
-                AddrOfLockedObject = hostPtr;
+                return hostPtr;
             }
             else
             {
@@ -70,7 +88,7 @@ namespace ILGPU.Runtime
                         out IntPtr devicePtr,
                         hostPtr,
                         0));
-                AddrOfLockedObject = devicePtr;
+                return devicePtr;
             }
         }
 
@@ -80,9 +98,12 @@ namespace ILGPU.Runtime
         private IntPtr HostPtr { get; }
 
         /// <inheritdoc/>
-        protected override void DisposeAcceleratorObject(bool disposing) =>
+        protected override void DisposeAcceleratorObject(bool disposing)
+        {
             CudaException.VerifyDisposed(
                 disposing,
                 CurrentAPI.MemHostUnregister(HostPtr));
+            base.DisposeAcceleratorObject(disposing);
+        }
     }
 }

--- a/Src/ILGPU/Runtime/PageLockScope.cs
+++ b/Src/ILGPU/Runtime/PageLockScope.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2021-2023 ILGPU Project
+//                        Copyright (c) 2021-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: PageLockScope.cs

--- a/Src/ILGPU/Runtime/PageLockScope.cs
+++ b/Src/ILGPU/Runtime/PageLockScope.cs
@@ -68,7 +68,7 @@ namespace ILGPU.Runtime
         /// <summary>
         /// Returns the memory buffer wrapper of the .Net array.
         /// </summary>
-        private MemoryBuffer MemoryBuffer { get; set; }
+        private MemoryBuffer? MemoryBuffer { get; set; }
 
         /// <summary>
         /// Returns the array view of the underlying .Net array.

--- a/Src/ILGPU/Runtime/PageLockedArrays.cs
+++ b/Src/ILGPU/Runtime/PageLockedArrays.cs
@@ -36,8 +36,7 @@ namespace ILGPU.Runtime
         /// <summary>
         /// Returns the page locking scope that includes the underlying array.
         /// </summary>
-        protected internal PageLockScope<T> Scope { get; private set; } =
-            Utilities.InitNotNullable<PageLockScope<T>>();
+        protected internal PageLockScope<T>? Scope { get; private set; }
 
         /// <summary>
         /// Returns the array view of the underlying .Net array.

--- a/Src/ILGPU/Runtime/PageLockedArrays.cs
+++ b/Src/ILGPU/Runtime/PageLockedArrays.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2021-2023 ILGPU Project
+//                        Copyright (c) 2021-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: PageLockedArrays.cs


### PR DESCRIPTION
Fixes #691.

Removes the various CopyFrom/CopyToPageLockedAsync methods in favour of the more generic CopyTo/CopyFrom ArrayView methods. This allows copying to/from a subset of the page locked array without adding a lot of extra to methods specifically support it.

`PageLockedScoped` now exposes an `ArrayView` property that can be used to interact with the existing CopyFrom/CopyTo ArrayView methods.