### PR TITLE
Improved performance of the DCE transformation.

### DIFF
--- a/Src/ILGPU/Util/InlineList.cs
+++ b/Src/ILGPU/Util/InlineList.cs
@@ -321,6 +321,16 @@ namespace ILGPU.Util
         }
 
         /// <summary>
+        /// Pops an element from the back of this list.
+        /// </summary>
+        public T Pop()
+        {
+            var element = items[Count - 1];
+            --Count;
+            return element;
+        }
+
+        /// <summary>
         /// Reverses all items in this list.
         /// </summary>
         public void Reverse() => Array.Reverse(items);


### PR DESCRIPTION
This PR improves the performance of the dead-code-elimination transformation. Note that we do not need to handle `LanguageEmitValue`s explicitly as they inherit from the `MemoryValue` class.