### PR TITLE
Added LibDevice bindings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -246,6 +246,8 @@ ModelManifest.xml
 # Ignore specific template outputs
 Src/ILGPU/AtomicFunctions.cs
 Src/ILGPU/Backends/PTX/PTXIntrinsics.Generated.cs
+Src/ILGPU/Backends/PTX/PTXLibDeviceMethods.cs
+Src/ILGPU/Backends/PTX/PTXLibDeviceNvvm.cs
 Src/ILGPU/Frontend/Intrinsic/RemappedIntrinsics.Generated.cs
 Src/ILGPU/HalfConversion.cs
 Src/ILGPU/IR/Construction/ArithmeticOperations.cs
@@ -259,6 +261,7 @@ Src/ILGPU/Memory.cs
 Src/ILGPU/Runtime/ArrayViewExtensions.Generated.cs
 Src/ILGPU/Runtime/ArrayViews.cs
 Src/ILGPU/Runtime/Cuda/CudaAsm.Generated.cs
+Src/ILGPU/Runtime/Cuda/LibDevice.cs
 Src/ILGPU/Runtime/KernelLoaders.cs
 Src/ILGPU/Runtime/MemoryBuffers.cs
 Src/ILGPU/Runtime/PageLockedArrays.Generated.cs

--- a/Samples/ILGPU.Samples.sln
+++ b/Samples/ILGPU.Samples.sln
@@ -119,6 +119,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AlgorithmsCuFFT", "Algorith
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AlgorithmsNvJpeg", "AlgorithmsNvJpeg\AlgorithmsNvJpeg.csproj", "{9CB52A85-9ACB-4B7E-95C5-75E9023EF5EC}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LibDeviceKernel", "LibDeviceKernel\LibDeviceKernel.csproj", "{029C809E-4EBF-4437-A4B2-BA7E14A9C023}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -335,6 +337,10 @@ Global
 		{9CB52A85-9ACB-4B7E-95C5-75E9023EF5EC}.DebugVerification|Any CPU.Build.0 = Debug|Any CPU
 		{9CB52A85-9ACB-4B7E-95C5-75E9023EF5EC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9CB52A85-9ACB-4B7E-95C5-75E9023EF5EC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{029C809E-4EBF-4437-A4B2-BA7E14A9C023}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{029C809E-4EBF-4437-A4B2-BA7E14A9C023}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{029C809E-4EBF-4437-A4B2-BA7E14A9C023}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{029C809E-4EBF-4437-A4B2-BA7E14A9C023}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -395,6 +401,7 @@ Global
 		{9E90DBE0-1BD4-4F23-8923-833962A4E741} = {25BA2234-5778-40BC-9386-9CE87AB87D1F}
 		{5FE4D2B9-32C7-4E45-B9E2-B2FE270BF692} = {25BA2234-5778-40BC-9386-9CE87AB87D1F}
 		{9CB52A85-9ACB-4B7E-95C5-75E9023EF5EC} = {25BA2234-5778-40BC-9386-9CE87AB87D1F}
+		{029C809E-4EBF-4437-A4B2-BA7E14A9C023} = {C1D99632-ED4A-4B08-A14D-4C8DB375934F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {30E502BD-3826-417F-888F-1CE19CF5C6DA}

--- a/Samples/LibDeviceKernel/AssemblyAttributes.cs
+++ b/Samples/LibDeviceKernel/AssemblyAttributes.cs
@@ -1,0 +1,3 @@
+﻿using System;
+
+[assembly: CLSCompliant(true)]

--- a/Samples/LibDeviceKernel/LibDeviceKernel.csproj
+++ b/Samples/LibDeviceKernel/LibDeviceKernel.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net471;netcoreapp3.1;net5.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <LangVersion>8.0</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Src\ILGPU\ILGPU.csproj" />
+  </ItemGroup>
+</Project>

--- a/Samples/LibDeviceKernel/Program.cs
+++ b/Samples/LibDeviceKernel/Program.cs
@@ -1,0 +1,55 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                    ILGPU Samples
+//                           Copyright (c) 2021 ILGPU Project
+//                                    www.ilgpu.net
+//
+// File: Program.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details.
+// ---------------------------------------------------------------------------------------
+
+using ILGPU;
+using ILGPU.Runtime;
+using ILGPU.Runtime.Cuda;
+using System;
+
+namespace LibDeviceKernel
+{
+    class Program
+    {
+        /// <summary>
+        /// A custom kernel using LibDevice functions.
+        /// </summary>
+        public static void KernelWithLibDevice(Index1D index, ArrayView<float> data)
+        {
+            data[index] = LibDevice.Cos(index);
+        }
+
+        static void Main()
+        {
+            // Create default context and enable LibDevice library
+            using var context = Context.Create(builder => builder.Cuda().LibDevice());
+
+            // For each available device...
+            foreach (var device in context)
+            {
+                // Create the associated accelerator
+                using var accelerator = device.CreateAccelerator(context);
+                Console.WriteLine($"Performing operations on {accelerator}");
+
+                using var buffer = accelerator.Allocate1D<float>(64);
+                var kernel = accelerator.LoadAutoGroupedStreamKernel<Index1D, ArrayView<float>>(
+                    KernelWithLibDevice);
+                kernel((int)buffer.Length, buffer.View);
+
+                // Reads data from the GPU buffer into a new CPU array.
+                // Implicitly calls accelerator.DefaultStream.Synchronize() to ensure
+                // that the kernel and memory copy are completed first.
+                var data = buffer.GetAsArray1D();
+                for (int i = 0, e = data.Length; i < e; ++i)
+                    Console.WriteLine($"Data[{i}] = {data[i]}");
+            }
+        }
+    }
+}

--- a/Src/ILGPU/Backends/PTX/PTXBackend.cs
+++ b/Src/ILGPU/Backends/PTX/PTXBackend.cs
@@ -16,6 +16,9 @@ using ILGPU.IR.Analyses;
 using ILGPU.IR.Transformations;
 using ILGPU.Runtime;
 using ILGPU.Runtime.Cuda;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 
 namespace ILGPU.Backends.PTX
@@ -79,11 +82,13 @@ namespace ILGPU.Backends.PTX
         /// <param name="capabilities">The supported capabilities.</param>
         /// <param name="architecture">The target GPU architecture.</param>
         /// <param name="instructionSet">The target GPU instruction set.</param>
+        /// <param name="nvvmAPI">Optional NVVM API instance.</param>
         public PTXBackend(
             Context context,
             CudaCapabilityContext capabilities,
             CudaArchitecture architecture,
-            CudaInstructionSet instructionSet)
+            CudaInstructionSet instructionSet,
+            NvvmAPI nvvmAPI)
             : base(
                   context,
                   capabilities,
@@ -92,6 +97,7 @@ namespace ILGPU.Backends.PTX
         {
             Architecture = architecture;
             InstructionSet = instructionSet;
+            NvvmAPI = nvvmAPI;
 
             InitIntrinsicProvider();
             InitializeKernelTransformers(builder =>
@@ -115,6 +121,18 @@ namespace ILGPU.Backends.PTX
 
                 builder.Add(transformerBuilder.ToTransformer());
             });
+        }
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            if (NvvmAPI != null)
+            {
+                NvvmAPI.Dispose();
+                NvvmAPI = null;
+            }
+
+            base.Dispose(disposing);
         }
 
         #endregion
@@ -142,6 +160,11 @@ namespace ILGPU.Backends.PTX
         /// </summary>
         public new CudaCapabilityContext Capabilities =>
             base.Capabilities as CudaCapabilityContext;
+
+        /// <summary>
+        /// Returns the NVVM API instance (if available).
+        /// </summary>
+        public NvvmAPI NvvmAPI { get; private set; }
 
         #endregion
 
@@ -190,6 +213,8 @@ namespace ILGPU.Backends.PTX
             builder.Append(".address_size ");
             builder.AppendLine((PointerSize * 8).ToString());
             builder.AppendLine();
+
+            GenerateLibDeviceCode(backendContext, builder);
 
             // Creates pointer alignment information in the context of O1 or higher
             var alignments = Context.Properties.OptimizationLevel >= OptimizationLevel.O1
@@ -247,6 +272,93 @@ namespace ILGPU.Backends.PTX
                 ptxAssembly);
         }
 
+        [SuppressMessage(
+            "Globalization",
+            "CA1307:Specify StringComparison",
+            Justification = "string.Replace(string, string, StringComparison) not " +
+            "available in net471")]
+        private unsafe void GenerateLibDeviceCode(
+            in BackendContext backendContext,
+            StringBuilder builder)
+        {
+            if (NvvmAPI == null || backendContext.Count == 0)
+                return;
+
+            // Convert the methods in the context into NVVM.
+            var methods = backendContext.GetEnumerator().AsEnumerable();
+            var nvvmModule = PTXLibDeviceNvvm.GenerateNvvm(methods);
+
+            if (string.IsNullOrEmpty(nvvmModule))
+                return;
+
+            // Create a new NVVM program.
+            var result = NvvmAPI.CreateProgram(out var program);
+
+            try
+            {
+                // Add custom NVVM module.
+                var nvvmModuleBytes = Encoding.ASCII.GetBytes(nvvmModule);
+                fixed (byte* nvvmPtr = nvvmModuleBytes)
+                {
+                    result = NvvmAPI.AddModuleToProgram(
+                        program,
+                        new IntPtr(nvvmPtr),
+                        new IntPtr(nvvmModuleBytes.Length),
+                        null);
+                }
+
+                // Add the LibDevice bit code.
+                if (result == NvvmResult.NVVM_SUCCESS)
+                {
+                    fixed (byte* ptr = NvvmAPI.LibDeviceBytes)
+                    {
+                        result = NvvmAPI.LazyAddModuleToProgram(
+                            program,
+                            new IntPtr(ptr),
+                            new IntPtr(NvvmAPI.LibDeviceBytes.Length),
+                            null);
+                    }
+                }
+
+                // Compile the NVVM into PTX for the backend architecture.
+                if (result == NvvmResult.NVVM_SUCCESS)
+                {
+                    var major = Architecture.Major;
+                    var minor = Architecture.Minor;
+                    var archOption = $"-arch=compute_{major}{minor}";
+                    var archOptionAscii = Encoding.ASCII.GetBytes(archOption);
+                    fixed (byte* archOptionPtr = archOptionAscii)
+                    {
+                        var numOptions = 1;
+                        var optionValues = stackalloc byte[sizeof(void*) * numOptions];
+                        var values = (void**)optionValues;
+                        values[0] = archOptionPtr;
+
+                        result = NvvmAPI.CompileProgram(
+                            program,
+                            numOptions,
+                            new IntPtr(values));
+                    }
+                }
+
+                // Extract the PTX result and comment out the initial declarations.
+                if (result == NvvmResult.NVVM_SUCCESS)
+                {
+                    result = NvvmAPI.GetCompiledResult(program, out var compiledPTX);
+                    var compiledString =
+                        compiledPTX
+                        .Replace(".version", "//.version")
+                        .Replace(".target", "//.target")
+                        .Replace(".address_size", "//.address_size");
+                    builder.Append(compiledString);
+                }
+            }
+            finally
+            {
+                NvvmAPI.DestroyProgram(ref program);
+            }
+        }
+
         #endregion
     }
 
@@ -282,5 +394,15 @@ namespace ILGPU.Backends.PTX
                 properties.OptimizationLevel > OptimizationLevel.O1
                 ? PTXBackendMode.Enhanced
                 : PTXBackendMode.Default);
+
+        /// <summary>
+        /// Convenience method to get an IEnumerable of Method.
+        /// </summary>
+        public static IEnumerable<Method> AsEnumerable(
+            this IEnumerator<(Method, Allocas)> enumerator)
+        {
+            while (enumerator.MoveNext())
+                yield return enumerator.Current.Item1;
+        }
     }
 }

--- a/Src/ILGPU/Backends/PTX/PTXFunctionGenerator.cs
+++ b/Src/ILGPU/Backends/PTX/PTXFunctionGenerator.cs
@@ -80,6 +80,9 @@ namespace ILGPU.Backends.PTX
         /// </summary>
         public override void GenerateHeader(StringBuilder builder)
         {
+            if (PTXLibDeviceMethods.IsLibDeviceMethod(Method))
+                return;
+
             GenerateHeaderDeclaration(builder);
             builder.AppendLine(";");
         }

--- a/Src/ILGPU/Backends/PTX/PTXLibDeviceMethods.tt
+++ b/Src/ILGPU/Backends/PTX/PTXLibDeviceMethods.tt
@@ -1,0 +1,123 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                           Copyright (c) 2021 ILGPU Project
+//                                    www.ilgpu.net
+//
+// File: PTXLibDeviceMethods.tt/PTXLibDeviceMethods.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details.
+// ---------------------------------------------------------------------------------------
+
+<#@ template debug="false" hostspecific="true" language="C#" #>
+<#@ include file="../../Static/TextTransformHelpers.ttinclude" #>
+<#@ include file="../../Static/TypeInformation.ttinclude" #>
+<#@ include file="../../Static/CudaLibDevice.ttinclude" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ output extension=".cs" #>
+<#
+string rootPath = Host.ResolvePath(".");
+var functions = LibDeviceFunctions.Load(rootPath, "../../Static/CudaLibDevice.xml");
+#>
+
+using ILGPU.Frontend;
+using ILGPU.IR;
+using System.Runtime.CompilerServices;
+
+#pragma warning disable IDE1006 // Naming Styles
+
+namespace ILGPU.Backends.PTX
+{
+    /// <summary>
+    /// Contains methods for matching the signature of the Cuda LibDevice functions when
+    /// compiled to PTX.
+    /// </summary>
+    internal static class PTXLibDeviceMethods
+    {
+        internal static bool IsLibDeviceMethod(Method method) =>
+            method.HasSource &&
+            method.Source.DeclaringType == typeof(PTXLibDeviceMethods);
+
+<#
+    foreach (var func in functions)
+    {
+        PushIndent(2);
+        WriteLibDeviceFunction(func);
+        PopIndent();
+    }
+
+#>
+    }
+}
+
+#pragma warning restore IDE1006 // Naming Styles
+<#+
+
+void WriteLibDeviceFunction(LibDeviceFunction func)
+{
+    WriteLine($"[External(\"{LibDeviceConstants.Prefix}{func.Name}\")]");
+    WriteLine("[MethodImpl(MethodImplOptions.AggressiveInlining)]");
+    Write($"internal static ");
+    WriteBinaryType(func.ReturnType);
+    Write(" ");
+    Write(func.Name);
+    WriteLine("(");
+    PushIndent();
+
+    // Write function signature
+    for (int i = 0; i < func.Parameters.Length; i++)
+    {
+        var param = func.Parameters[i];
+        Write(param.FlagsExpression);
+        WriteBinaryType(param.Type);
+        Write($" {param.Name}");
+        if (i < func.Parameters.Length - 1)
+            WriteLine(",");
+    }
+
+    // Write function body
+    var useDefault = func.Parameters.All(x => string.IsNullOrEmpty(x.Flags));
+    if (useDefault)
+    {
+        WriteLine(") => default;");
+        PopIndent();
+        WriteLine();
+    }
+    else
+    {
+        WriteLine(")");
+        PopIndent();
+
+        WriteLine("{");
+        PushIndent();
+
+        for (int j = 0; j < func.Parameters.Length; j++)
+        {
+            var altParam = func.Parameters[j];
+            if (!string.IsNullOrEmpty(altParam.Flags))
+                WriteLine($"{altParam.Name} = default;");
+        }
+
+        if (func.ReturnType != "void")
+            WriteLine("return default;");
+
+        PopIndent();
+        WriteLine("}");
+        WriteLine();
+    }
+}
+
+void WriteBinaryType(string type)
+{
+    if (type == "float")
+        Write("uint");
+    else if (type == "double")
+        Write("ulong");
+    else
+        Write(type);
+}
+
+#>

--- a/Src/ILGPU/Backends/PTX/PTXLibDeviceNvvm.tt
+++ b/Src/ILGPU/Backends/PTX/PTXLibDeviceNvvm.tt
@@ -1,0 +1,170 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                           Copyright (c) 2021 ILGPU Project
+//                                    www.ilgpu.net
+//
+// File: PTXLibDeviceNvvm.tt/PTXLibDeviceNvvm.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details.
+// ---------------------------------------------------------------------------------------
+
+<#@ template debug="false" hostspecific="true" language="C#" #>
+<#@ include file="../../Static/TextTransformHelpers.ttinclude" #>
+<#@ include file="../../Static/TypeInformation.ttinclude" #>
+<#@ include file="../../Static/CudaLibDevice.ttinclude" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ output extension=".cs" #>
+<#
+string rootPath = Host.ResolvePath(".");
+var functions = LibDeviceFunctions.Load(rootPath, "../../Static/CudaLibDevice.xml");
+#>
+
+using ILGPU.IR;
+using System.Collections.Generic;
+using System.Text;
+
+// disable: max_line_length
+
+namespace ILGPU.Backends.PTX
+{
+    /// <summary>
+    /// Contains the NVVM fragments for Cuda LibDevice functions.
+    /// </summary>
+    internal static class PTXLibDeviceNvvm
+    {
+        private const string prefix = @"
+            target triple = ""nvptx64-unknown-cuda""
+            target datalayout = ""e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v32:32:32-v64:64:64-v128:128:128-n16:32:64""";
+
+<#
+    foreach (var func in functions)
+    {
+        PushIndent(2);
+        WriteLibDeviceFunctionNvvm(func);
+        PopIndent();
+    }
+
+#>
+        private static readonly Dictionary<string, string> fragments =
+            new Dictionary<string, string>()
+            {
+<#
+    PushIndent(4);
+    foreach (var func in functions)
+        WriteLine($"{{ \"{func.Name}\", {func.Name} }},");
+    PopIndent();
+#>
+            };
+
+        /// <summary>
+        /// Generates an NVVM module for the Cuda LibDevice functions (if any).
+        /// </summary>
+        /// <param name="methods">The methods to check.</param>
+        /// <returns>The NVVM module, or an empty string.</returns>
+        public static string GenerateNvvm(IEnumerable<Method> methods)
+        {
+            var builder = new StringBuilder();
+            bool addPrefix = true;
+
+            foreach (var method in methods)
+            {
+                if (method.HasSource &&
+                    fragments.TryGetValue(method.Source.Name, out var methodNvvm))
+                {
+                    if (addPrefix)
+                    {
+                        builder.AppendLine(prefix);
+                        addPrefix = false;
+                    }
+
+                    builder.AppendLine(methodNvvm);
+                }
+            }
+
+            return builder.ToString();
+        }
+    }
+}
+<#+
+
+void WriteLibDeviceFunctionNvvm(LibDeviceFunction func)
+{
+    WriteLine($"private const string {func.Name} = @\"");
+    PushIndent();
+
+    Write("declare ");
+    WriteNvvmType(func.ReturnType);
+    Write(" @");
+    Write(func.Name);
+    Write("(");
+    for (int i = 0; i < func.Parameters.Length; i++)
+    {
+        var param = func.Parameters[i];
+        WriteNvvmType(param.Type);
+        Write($" %{param.Name}");
+        if (i < func.Parameters.Length - 1)
+            Write(",");
+        else
+            Write(")");
+        WriteLine();
+    }
+    WriteLine();
+
+    Write("define ");
+    WriteNvvmType(func.ReturnType);
+    Write(" @");
+    Write($"{LibDeviceConstants.Prefix}{func.Name}");
+    Write("(");
+    for (int i = 0; i < func.Parameters.Length; i++)
+    {
+        var param = func.Parameters[i];
+        WriteNvvmType(param.Type);
+        Write($" %{param.Name}");
+        if (i < func.Parameters.Length - 1)
+            Write(",");
+        else
+            Write(") {");
+        WriteLine();
+    }
+    WriteLine("entry:");
+
+    PushIndent();
+    Write("%call = call ");
+    WriteNvvmType(func.ReturnType);
+    Write(" @");
+    Write(func.Name);
+    Write("(");
+    for (int i = 0; i < func.Parameters.Length; i++)
+    {
+        var param = func.Parameters[i];
+        WriteNvvmType(param.Type);
+        Write($" %{param.Name}");
+        if (i < func.Parameters.Length - 1)
+            Write(",");
+        else
+            Write(")");
+    }
+    WriteLine();
+    Write("ret ");
+    WriteNvvmType(func.ReturnType);
+    WriteLine(" %call");
+    PopIndent();
+    WriteLine("}\";");
+    WriteLine();
+
+    PopIndent();
+}
+
+void WriteNvvmType(string type)
+{
+    if (type == "string")
+        Write("i8*");
+    else
+        Write(type);
+}
+
+#>

--- a/Src/ILGPU/Context.Builder.cs
+++ b/Src/ILGPU/Context.Builder.cs
@@ -19,6 +19,9 @@ using ILGPU.Runtime.Cuda;
 using ILGPU.Runtime.OpenCL;
 using System;
 using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
 
 namespace ILGPU
 {
@@ -276,6 +279,55 @@ namespace ILGPU
             }
 
             /// <summary>
+            /// Turns on LibDevice support.
+            /// Automatically detects the CUDA SDK location.
+            /// </summary>
+            /// <returns>The current builder instance.</returns>
+            public Builder LibDevice()
+            {
+                // Find the CUDA installation path.
+                var cudaEnvName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                    ? "CUDA_PATH"
+                    : "CUDA_HOME";
+                var cudaPath = Environment.GetEnvironmentVariable(cudaEnvName);
+                if (string.IsNullOrEmpty(cudaPath))
+                {
+                    throw new NotSupportedException(string.Format(
+                        RuntimeErrorMessages.NotSupportedLibDeviceEnvironmentVariable,
+                        cudaEnvName));
+                }
+                var nvvmRoot = Path.Combine(cudaPath, "nvvm");
+
+                // Find the NVVM DLL.
+                var nvvmBinName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                    ? "bin"
+                    : "lib64";
+                var nvvmBinDir = Path.Combine(nvvmRoot, nvvmBinName);
+                var nvvmSearchPattern =
+                    RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                    ? "nvvm*.dll"
+                    : "libnvvm*.so";
+                var nvvmFiles = Directory.EnumerateFiles(nvvmBinDir, nvvmSearchPattern);
+                LibNvvmPath = nvvmFiles.FirstOrDefault()
+                    ?? throw new NotSupportedException(string.Format(
+                        RuntimeErrorMessages.NotSupportedLibDeviceNotFoundNvvmDll,
+                        nvvmBinDir));
+
+                // Find the LibDevice Bitcode.
+                var libDeviceDir = Path.Combine(nvvmRoot, "libdevice");
+                var libDeviceFiles = Directory.EnumerateFiles(
+                    libDeviceDir,
+                    "libdevice.*.bc");
+                LibDevicePath = libDeviceFiles.FirstOrDefault()
+                    ?? throw new NotSupportedException(string.Format(
+                        RuntimeErrorMessages.NotSupportedLibDeviceNotFoundBitCode,
+                        libDeviceDir));
+
+                return this;
+            }
+
+            /// <summary>
+            /// Turns on LibDevice support.
             /// Explicitly specifies the LibDevice location.
             /// </summary>
             /// <param name="libNvvmPath">Path to LibNvvm DLL.</param>

--- a/Src/ILGPU/Context.Builder.cs
+++ b/Src/ILGPU/Context.Builder.cs
@@ -276,6 +276,19 @@ namespace ILGPU
             }
 
             /// <summary>
+            /// Explicitly specifies the LibDevice location.
+            /// </summary>
+            /// <param name="libNvvmPath">Path to LibNvvm DLL.</param>
+            /// <param name="libDevicePath">Path to LibDevice bitcode.</param>
+            /// <returns>The current builder instance.</returns>
+            public Builder LibDevice(string libNvvmPath, string libDevicePath)
+            {
+                LibNvvmPath = libNvvmPath;
+                LibDevicePath = libDevicePath;
+                return this;
+            }
+
+            /// <summary>
             /// Converts this builder instance into a context instance.
             /// </summary>
             /// <returns>The created context instance.</returns>

--- a/Src/ILGPU/ContextProperties.cs
+++ b/Src/ILGPU/ContextProperties.cs
@@ -400,6 +400,16 @@ namespace ILGPU
         /// <remarks>Disabled by default.</remarks>
         public bool EnableProfiling { get; protected set; }
 
+        /// <summary>
+        /// Returns the path to LibNVVM DLL.
+        /// </summary>
+        public string LibNvvmPath { get; protected set; }
+
+        /// <summary>
+        /// Returns the path to LibDevice bitcode.
+        /// </summary>
+        public string LibDevicePath { get; protected set; }
+
         #endregion
 
         #region Methods
@@ -455,6 +465,8 @@ namespace ILGPU
                 CachingMode = CachingMode,
                 PageLockingMode = PageLockingMode,
                 EnableProfiling = EnableProfiling,
+                LibNvvmPath = LibNvvmPath,
+                LibDevicePath = LibDevicePath,
             };
 
         #endregion

--- a/Src/ILGPU/ILGPU.csproj
+++ b/Src/ILGPU/ILGPU.csproj
@@ -154,6 +154,16 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Update="Backends\PTX\PTXLibDeviceMethods.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>PTXLibDeviceMethods.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Backends\PTX\PTXLibDeviceNvvm.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>PTXLibDeviceNvvm.tt</DependentUpon>
+    </Compile>
     <Compile Update="Memory.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
@@ -218,6 +228,11 @@
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
       <DependentUpon>CudaAsm.Generated.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Runtime\Cuda\LibDevice.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>LibDevice.tt</DependentUpon>
     </Compile>
     <Compile Update="Runtime\MemoryBuffers.cs">
       <DesignTime>True</DesignTime>
@@ -286,6 +301,14 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <None Update="Backends\PTX\PTXLibDeviceNvvm.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>PTXLibDeviceNvvm.cs</LastGenOutput>
+    </None>
+    <None Update="Backends\PTX\PTXLibDeviceMethods.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>PTXLibDeviceMethods.cs</LastGenOutput>
+    </None>
     <None Update="Runtime\ArrayViews.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>ArrayViews.cs</LastGenOutput>
@@ -341,6 +364,10 @@
     <None Update="Runtime\Cuda\CudaAsm.Generated.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>CudaAsm.Generated.cs</LastGenOutput>
+    </None>
+    <None Update="Runtime\Cuda\LibDevice.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>LibDevice.cs</LastGenOutput>
     </None>
     <None Update="Runtime\ExchangeBufferExtensions.tt">
       <Generator>TextTemplatingFileGenerator</Generator>

--- a/Src/ILGPU/Resources/RuntimeErrorMessages.Designer.cs
+++ b/Src/ILGPU/Resources/RuntimeErrorMessages.Designer.cs
@@ -304,6 +304,33 @@ namespace ILGPU.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Could not find environment variable &apos;{0}&apos;.
+        /// </summary>
+        internal static string NotSupportedLibDeviceEnvironmentVariable {
+            get {
+                return ResourceManager.GetString("NotSupportedLibDeviceEnvironmentVariable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not find LibDevice BitCode in &apos;{0}&apos;.
+        /// </summary>
+        internal static string NotSupportedLibDeviceNotFoundBitCode {
+            get {
+                return ResourceManager.GetString("NotSupportedLibDeviceNotFoundBitCode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not find NVVM DLL in &apos;{0}&apos;.
+        /// </summary>
+        internal static string NotSupportedLibDeviceNotFoundNvvmDll {
+            get {
+                return ResourceManager.GetString("NotSupportedLibDeviceNotFoundNvvmDll", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Type type &apos;{0}&apos; is not blittable.
         /// </summary>
         internal static string NotSupportedNonBlittableType {

--- a/Src/ILGPU/Resources/RuntimeErrorMessages.resx
+++ b/Src/ILGPU/Resources/RuntimeErrorMessages.resx
@@ -198,6 +198,15 @@
   <data name="NotSupportedKernelSpecialization" xml:space="preserve">
     <value>The given kernel specialization is not compatible with the current accelerator.</value>
   </data>
+  <data name="NotSupportedLibDeviceEnvironmentVariable" xml:space="preserve">
+    <value>Could not find environment variable '{0}'</value>
+  </data>
+  <data name="NotSupportedLibDeviceNotFoundBitCode" xml:space="preserve">
+    <value>Could not find LibDevice BitCode in '{0}'</value>
+  </data>
+  <data name="NotSupportedLibDeviceNotFoundNvvmDll" xml:space="preserve">
+    <value>Could not find NVVM DLL in '{0}'</value>
+  </data>
   <data name="NotSupportedNonBlittableType" xml:space="preserve">
     <value>Type type '{0}' is not blittable</value>
   </data>

--- a/Src/ILGPU/Runtime/Cuda/CudaAccelerator.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaAccelerator.cs
@@ -178,11 +178,18 @@ namespace ILGPU.Runtime.Cuda
             CudaException.ThrowIfFailed(
                 CurrentAPI.GetCacheConfig(out cacheConfiguration));
 
+            var nvvmAPI = !string.IsNullOrEmpty(context.Properties.LibNvvmPath)
+                ? NvvmAPI.Create(
+                    context.Properties.LibNvvmPath,
+                    context.Properties.LibDevicePath)
+                : default;
+
             Init(new PTXBackend(
                 Context,
                 Capabilities,
                 Architecture,
-                InstructionSet));
+                InstructionSet,
+                nvvmAPI));
         }
 
         #endregion

--- a/Src/ILGPU/Runtime/Cuda/LibDevice.tt
+++ b/Src/ILGPU/Runtime/Cuda/LibDevice.tt
@@ -1,0 +1,160 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                           Copyright (c) 2021 ILGPU Project
+//                                    www.ilgpu.net
+//
+// File: LibDevice.tt/LibDevice.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details.
+// ---------------------------------------------------------------------------------------
+
+<#@ template debug="false" hostspecific="true" language="C#" #>
+<#@ include file="../../Static/TextTransformHelpers.ttinclude" #>
+<#@ include file="../../Static/TypeInformation.ttinclude" #>
+<#@ include file="../../Static/CudaLibDevice.ttinclude" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ output extension=".cs" #>
+<#
+string rootPath = Host.ResolvePath(".");
+var functions = LibDeviceFunctions.Load(rootPath, "../../Static/CudaLibDevice.xml");
+#>
+using ILGPU.Backends.PTX;
+using System.Runtime.CompilerServices;
+
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+#pragma warning disable CS3001 // Argument type is not CLS-compliant
+#pragma warning disable CS3002 // Return type is not CLS-compliant
+#pragma warning disable IDE0018 // Inline variable declaration
+#pragma warning disable IDE1006 // Naming Styles
+
+namespace ILGPU.Runtime.Cuda
+{
+    /// <summary>
+    /// Provides bindings for Cuda LibDevice functions.
+    /// </summary>
+    /// <remarks>
+    /// Deals with thunking the Cuda LibDevice functions, because the compiled PTX uses
+    /// u32/u64 registers rather than f32/f64 registers.
+    /// </remarks>
+    public static class LibDevice
+    {
+<#
+    foreach (var func in functions) {
+        WriteLibDeviceFunction(func);
+    }
+
+#>
+    }
+}
+
+#pragma warning restore IDE1006 // Naming Styles
+#pragma warning restore IDE0018 // Inline variable declaration
+#pragma warning restore CS3002 // Return type is not CLS-compliant
+#pragma warning restore CS3001 // Argument type is not CLS-compliant
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
+
+<#+
+
+void WriteLibDeviceFunction(LibDeviceFunction func)
+{
+    PushIndent(2);
+    WriteLibDeviceInterop(func);
+    PopIndent();
+}
+
+void WriteLibDeviceInterop(LibDeviceFunction func)
+{
+    // Write function signature
+    WriteLine("[MethodImpl(MethodImplOptions.AggressiveInlining)]");
+    Write($"public static ");
+    Write(func.ReturnType);
+    Write(" ");
+    Write(func.DisplayName);
+    WriteLine("(");
+    PushIndent();
+    for (int i = 0; i < func.Parameters.Length; i++)
+    {
+        var param = func.Parameters[i];
+        Write(param.FlagsExpression);
+        Write(param.Type);
+        Write($" {param.Name}");
+        if (i < func.Parameters.Length - 1)
+            Write(",");
+        else
+            Write(")");
+        WriteLine();
+    }
+    PopIndent();
+
+    // Write function arguments
+    WriteLine("{");
+    PushIndent();
+    for (int i = 0; i < func.Parameters.Length; i++)
+    {
+        var param = func.Parameters[i];
+        if (string.IsNullOrEmpty(param.Flags))
+        {
+            if (param.Type == "float" || param.Type == "double")
+                WriteLine($"var arg{i} = Interop.FloatAsInt({param.Name});");
+            else
+                WriteLine($"var arg{i} = {param.Name};");
+        }
+        else
+        {
+            if (param.Type == "float")
+                WriteLine($"uint arg{i};");
+            else if (param.Type == "double")
+                WriteLine($"ulong arg{i};");
+            else
+                WriteLine($"{param.Type} arg{i};");
+        }
+    }
+
+    // Write function call
+    WriteLine();
+    if (func.ReturnType != "void")
+        Write("var result = ");
+    WriteLine($"PTXLibDeviceMethods.{func.Name}(");
+    PushIndent();
+    for (int i = 0; i < func.Parameters.Length; i++)
+    {
+        var param = func.Parameters[i];
+        Write($"{param.FlagsExpression}arg{i}");
+
+        if (i < func.Parameters.Length - 1)
+            Write(",");
+        else
+            Write(");");
+        WriteLine();
+    }
+    PopIndent();
+
+    // Write function return
+    WriteLine();
+    for (int i = 0; i < func.Parameters.Length; i++)
+    {
+        var param = func.Parameters[i];
+        if (!string.IsNullOrEmpty(param.Flags))
+        {
+            if (param.Type == "float" || param.Type == "double")
+                WriteLine($"{param.Name} = Interop.IntAsFloat(arg{i});");
+            else
+                WriteLine($"{param.Name} = arg{i};");
+        }
+    }
+
+    if (func.ReturnType == "float" || func.ReturnType == "double")
+        WriteLine("return Interop.IntAsFloat(result);");
+    else if (func.ReturnType != "void")
+        WriteLine("return result;");
+
+    PopIndent();
+    WriteLine("}");
+    WriteLine();
+}
+
+#>

--- a/Src/ILGPU/Runtime/Cuda/NvvmAPI.cs
+++ b/Src/ILGPU/Runtime/Cuda/NvvmAPI.cs
@@ -1,0 +1,452 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                           Copyright (c) 2021 ILGPU Project
+//                                    www.ilgpu.net
+//
+// File: NvvmAPI.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details.
+// ---------------------------------------------------------------------------------------
+
+using ILGPU.Util;
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+#if NET5_0_OR_GREATER
+using NativeLibrary = System.Runtime.InteropServices.NativeLibrary;
+#else
+using NativeLibrary = ILGPU.Util.NativeLibrary;
+#endif
+
+#pragma warning disable CA2216 // Disposable types should declare finalizer
+
+namespace ILGPU.Runtime.Cuda
+{
+    /// <summary>
+    /// Wrapper for the NVVM API.
+    /// </summary>
+    public sealed class NvvmAPI : DisposeBase
+    {
+        #region Delegates
+
+        [UnmanagedFunctionPointer(
+            CallingConvention.Winapi,
+            CharSet = CharSet.Ansi,
+            BestFitMapping = false,
+            ThrowOnUnmappableChar = true)]
+        delegate string NvvmGetErrorString(NvvmResult result);
+
+        delegate NvvmResult NvvmVersion(out int major, out int minor);
+
+        delegate NvvmResult NvvmIRVersion(
+            out int majorIR,
+            out int minorIR,
+            out int majorDbg,
+            out int minorDbg);
+
+        delegate NvvmResult NvvmCreateProgram(out IntPtr program);
+
+        delegate NvvmResult NvvmDestroyProgram(ref IntPtr program);
+
+        [UnmanagedFunctionPointer(
+            CallingConvention.Winapi,
+            CharSet = CharSet.Ansi,
+            BestFitMapping = false,
+            ThrowOnUnmappableChar = true)]
+        delegate NvvmResult NvvmAddModuleToProgram(
+            IntPtr program,
+            IntPtr buffer,
+            IntPtr size,
+            string name);
+
+        [UnmanagedFunctionPointer(
+            CallingConvention.Winapi,
+            CharSet = CharSet.Ansi,
+            BestFitMapping = false,
+            ThrowOnUnmappableChar = true)]
+        delegate NvvmResult NvvmLazyAddModuleToProgram(
+            IntPtr program,
+            IntPtr buffer,
+            IntPtr size,
+            string name);
+
+        delegate NvvmResult NvvmCompileProgram(
+            IntPtr program,
+            int numOptions,
+            IntPtr options);
+
+        delegate NvvmResult NvvmVerifyProgram(
+            IntPtr program,
+            int numOptions,
+            IntPtr options);
+
+        delegate NvvmResult NvvmGetCompiledResultSize(
+            IntPtr program,
+            out IntPtr bufferSize);
+        delegate NvvmResult NvvmGetCompiledResult(
+            IntPtr program,
+            IntPtr buffer);
+
+        delegate NvvmResult NvvmGetProgramLogSize(
+            IntPtr program,
+            out IntPtr bufferSize);
+        delegate NvvmResult NvvmGetProgramLog(
+            IntPtr program,
+            IntPtr buffer);
+
+        #endregion
+
+        #region Static
+
+        /// <summary>
+        /// Creates a new instance of the NVVM API for the specified path.
+        /// </summary>
+        /// <param name="libNvvmPath">Path to NVVM library.</param>
+        /// <returns>The NVVM API instance.</returns>
+        public static NvvmAPI Create(string libNvvmPath) =>
+            Create(libNvvmPath, string.Empty);
+
+        /// <summary>
+        /// Creates a new instance of the NVVM API for the specified path.
+        /// </summary>
+        /// <param name="libNvvmPath">Path to NVVM library.</param>
+        /// <param name="libDevicePath">Path to LibDevice bitcode.</param>
+        /// <returns>The NVVM API instance.</returns>
+        public static NvvmAPI Create(string libNvvmPath, string libDevicePath) =>
+            new NvvmAPI(libNvvmPath, libDevicePath);
+
+        #endregion
+
+        #region Instance
+
+        /// <summary>
+        /// The bytes of the loaded LibDevice bitcode.
+        /// </summary>
+        public ReadOnlySpan<byte> LibDeviceBytes => libDeviceBytes;
+
+        /// <summary>
+        /// The storage bytes of the loaded LibDevice bitcode. Exposed to the caller
+        /// via <see cref="LibDeviceBytes"/> so that the contents cannot be modified.
+        /// </summary>
+        private readonly byte[] libDeviceBytes;
+
+        /// <summary>
+        /// Handle to NVVM module.
+        /// </summary>
+        private IntPtr libNvvmModule;
+
+        private readonly NvvmGetErrorString nvvmGetErrorString;
+        private readonly NvvmVersion nvvmVersion;
+        private readonly NvvmIRVersion nvvmIRVersion;
+        private readonly NvvmCreateProgram nvvmCreateProgram;
+        private readonly NvvmDestroyProgram nvvmDestroyProgram;
+        private readonly NvvmAddModuleToProgram nvvmAddModuleToProgram;
+        private readonly NvvmLazyAddModuleToProgram nvvmLazyAddModuleToProgram;
+        private readonly NvvmCompileProgram nvvmCompileProgram;
+        private readonly NvvmVerifyProgram nvvmVerifyProgram;
+        private readonly NvvmGetCompiledResultSize nvvmGetCompiledResultSize;
+        private readonly NvvmGetCompiledResult nvvmGetCompiledResult;
+        private readonly NvvmGetProgramLogSize nvvmGetProgramLogSize;
+        private readonly NvvmGetProgramLog nvvmGetProgramLog;
+
+        private NvvmAPI(string libNvvmPath, string libDevicePath)
+        {
+            libNvvmModule = NativeLibrary.Load(libNvvmPath);
+            libDeviceBytes = !string.IsNullOrEmpty(libDevicePath)
+                ? File.ReadAllBytes(libDevicePath)
+                : Array.Empty<byte>();
+
+            nvvmGetErrorString =
+                Marshal.GetDelegateForFunctionPointer<NvvmGetErrorString>(
+                    NativeLibrary.GetExport(
+                        libNvvmModule,
+                        "nvvmGetErrorString"));
+            nvvmVersion =
+                Marshal.GetDelegateForFunctionPointer<NvvmVersion>(
+                    NativeLibrary.GetExport(
+                        libNvvmModule,
+                        "nvvmVersion"));
+            nvvmIRVersion =
+                Marshal.GetDelegateForFunctionPointer<NvvmIRVersion>(
+                    NativeLibrary.GetExport(
+                        libNvvmModule,
+                        "nvvmIRVersion"));
+            nvvmCreateProgram =
+                Marshal.GetDelegateForFunctionPointer<NvvmCreateProgram>(
+                    NativeLibrary.GetExport(
+                        libNvvmModule,
+                        "nvvmCreateProgram"));
+            nvvmDestroyProgram =
+                Marshal.GetDelegateForFunctionPointer<NvvmDestroyProgram>(
+                    NativeLibrary.GetExport(
+                        libNvvmModule,
+                        "nvvmDestroyProgram"));
+            nvvmAddModuleToProgram =
+                Marshal.GetDelegateForFunctionPointer<NvvmAddModuleToProgram>(
+                    NativeLibrary.GetExport(
+                        libNvvmModule,
+                        "nvvmAddModuleToProgram"));
+            nvvmLazyAddModuleToProgram =
+                Marshal.GetDelegateForFunctionPointer<NvvmLazyAddModuleToProgram>(
+                    NativeLibrary.GetExport(
+                        libNvvmModule,
+                        "nvvmLazyAddModuleToProgram"));
+            nvvmCompileProgram =
+                Marshal.GetDelegateForFunctionPointer<NvvmCompileProgram>(
+                    NativeLibrary.GetExport(
+                        libNvvmModule,
+                        "nvvmCompileProgram"));
+            nvvmVerifyProgram =
+                Marshal.GetDelegateForFunctionPointer<NvvmVerifyProgram>(
+                    NativeLibrary.GetExport(
+                        libNvvmModule,
+                        "nvvmVerifyProgram"));
+            nvvmGetCompiledResultSize =
+                Marshal.GetDelegateForFunctionPointer<NvvmGetCompiledResultSize>(
+                    NativeLibrary.GetExport(
+                        libNvvmModule,
+                        "nvvmGetCompiledResultSize"));
+            nvvmGetCompiledResult =
+                Marshal.GetDelegateForFunctionPointer<NvvmGetCompiledResult>(
+                    NativeLibrary.GetExport(
+                        libNvvmModule,
+                        "nvvmGetCompiledResult"));
+            nvvmGetProgramLogSize =
+                Marshal.GetDelegateForFunctionPointer<NvvmGetProgramLogSize>(
+                    NativeLibrary.GetExport(
+                        libNvvmModule,
+                        "nvvmGetProgramLogSize"));
+            nvvmGetProgramLog =
+                Marshal.GetDelegateForFunctionPointer<NvvmGetProgramLog>(
+                    NativeLibrary.GetExport(
+                        libNvvmModule,
+                        "nvvmGetProgramLog"));
+        }
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            if (libNvvmModule != IntPtr.Zero)
+            {
+                NativeLibrary.Free(libNvvmModule);
+                libNvvmModule = IntPtr.Zero;
+            }
+            base.Dispose(disposing);
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Gets the error string for the NVVM error code.
+        /// </summary>
+        /// <param name="result">The error code.</param>
+        /// <returns>The error string.</returns>
+        public string GetErrorString(NvvmResult result) =>
+            nvvmGetErrorString(result);
+
+        /// <summary>
+        /// Gets the NVVM version.
+        /// </summary>
+        /// <param name="major">Filled in with the major version.</param>
+        /// <param name="minor">Filled in with the minor version.</param>
+        /// <returns>The error code.</returns>
+        public NvvmResult GetVersion(out int major, out int minor) =>
+            nvvmVersion(out major, out minor);
+
+        /// <summary>
+        /// Gets the NVVM IR version.
+        /// </summary>
+        /// <param name="majorIR">Filled in with the major version</param>
+        /// <param name="minorIR">Filled in with the minor version.</param>
+        /// <param name="majorDbg">Filled in with the major version</param>
+        /// <param name="minorDbg">Filled in with the minor version.</param>
+        /// <returns>The error code.</returns>
+        public NvvmResult GetIRVersion(
+            out int majorIR,
+            out int minorIR,
+            out int majorDbg,
+            out int minorDbg) =>
+            nvvmIRVersion(out majorIR, out minorIR, out majorDbg, out minorDbg);
+
+        /// <summary>
+        /// Creates a new NVVM program.
+        /// </summary>
+        /// <param name="program">Filled in with the program handle.</param>
+        /// <returns>The error code.</returns>
+        public NvvmResult CreateProgram(out IntPtr program) =>
+            nvvmCreateProgram(out program);
+
+        /// <summary>
+        /// Destroys a previously created NVVM program.
+        /// </summary>
+        /// <param name="program">The program to destroy. Filled in with NULL.</param>
+        /// <returns>The error code.</returns>
+        public NvvmResult DestroyProgram(ref IntPtr program) =>
+            nvvmDestroyProgram(ref program);
+
+        /// <summary>
+        /// Add a module to the program.
+        /// </summary>
+        /// <param name="program">The program.</param>
+        /// <param name="buffer">The buffer pointer.</param>
+        /// <param name="size">The buffer size.</param>
+        /// <param name="name">The module name.</param>
+        /// <returns>The error code.</returns>
+        public NvvmResult AddModuleToProgram(
+            IntPtr program,
+            IntPtr buffer,
+            IntPtr size,
+            string name) =>
+            nvvmAddModuleToProgram(program, buffer, size, name);
+
+        /// <summary>
+        /// Add a lazy module to the program.
+        /// </summary>
+        /// <param name="program">The program.</param>
+        /// <param name="buffer">The buffer pointer.</param>
+        /// <param name="size">The buffer size.</param>
+        /// <param name="name">The module name.</param>
+        /// <returns>The error code.</returns>
+        public NvvmResult LazyAddModuleToProgram(
+            IntPtr program,
+            IntPtr buffer,
+            IntPtr size,
+            string name) =>
+            nvvmLazyAddModuleToProgram(program, buffer, size, name);
+
+        /// <summary>
+        /// Compiles the program.
+        /// </summary>
+        /// <param name="program">The program.</param>
+        /// <param name="numOptions">The number of options.</param>
+        /// <param name="options">The options.</param>
+        /// <returns>The error code.</returns>
+        public NvvmResult CompileProgram(
+            IntPtr program,
+            int numOptions,
+            IntPtr options) =>
+            nvvmCompileProgram(program, numOptions, options);
+
+        /// <summary>
+        /// Verifies the program.
+        /// </summary>
+        /// <param name="program">The program.</param>
+        /// <param name="numOptions">The number of options.</param>
+        /// <param name="options">The options.</param>
+        /// <returns>The error code.</returns>
+        public NvvmResult VerifyProgram(IntPtr program, int numOptions, IntPtr options) =>
+            nvvmVerifyProgram(program, numOptions, options);
+
+        /// <summary>
+        /// Gets the compiled PTX result.
+        /// </summary>
+        /// <param name="program">The program.</param>
+        /// <param name="result">Filled in with the PTX result.</param>
+        /// <returns>The error code.</returns>
+        public unsafe NvvmResult GetCompiledResult(IntPtr program, out string result)
+        {
+            var error = GetCompiledResultSize(program, out var bufferSize);
+            if (error == NvvmResult.NVVM_SUCCESS)
+            {
+                var buffer = new byte[bufferSize.ToInt64()];
+                fixed (byte* bufferPtr = buffer)
+                {
+                    error = GetCompiledResult(program, new IntPtr(bufferPtr));
+                    if (error == NvvmResult.NVVM_SUCCESS)
+                    {
+                        // Remove the trailing null terminator.
+                        result = Encoding.ASCII.GetString(buffer, 0, buffer.Length - 1);
+                    }
+                    else
+                    {
+                        result = default;
+                    }
+                }
+            }
+            else
+            {
+                result = default;
+            }
+
+            return error;
+        }
+
+        /// <summary>
+        /// Gets the size of the compiled PTX result.
+        /// </summary>
+        /// <param name="program">The program.</param>
+        /// <param name="bufferSize">Filled in with the buffer size.</param>
+        /// <returns>The error code.</returns>
+        public NvvmResult GetCompiledResultSize(IntPtr program, out IntPtr bufferSize) =>
+            nvvmGetCompiledResultSize(program, out bufferSize);
+
+        /// <summary>
+        /// Gets the compiled PTX result.
+        /// </summary>
+        /// <param name="program">The program.</param>
+        /// <param name="buffer">The buffer pointer.</param>
+        /// <returns>The error code.</returns>
+        public NvvmResult GetCompiledResult(IntPtr program, IntPtr buffer) =>
+            nvvmGetCompiledResult(program, buffer);
+
+        /// <summary>
+        /// Gets the program log.
+        /// </summary>
+        /// <param name="program">The program.</param>
+        /// <param name="result">Filled in with the program log.</param>
+        /// <returns>The error code.</returns>
+        public unsafe NvvmResult GetProgramLog(IntPtr program, out string result)
+        {
+            var error = GetProgramLogSize(program, out var bufferSize);
+            if (error == NvvmResult.NVVM_SUCCESS)
+            {
+                var buffer = new byte[bufferSize.ToInt64()];
+                fixed (byte* bufferPtr = buffer)
+                {
+                    error = GetProgramLog(program, new IntPtr(bufferPtr));
+                    if (error == NvvmResult.NVVM_SUCCESS)
+                    {
+                        // Remove the trailing null terminator.
+                        result = Encoding.ASCII.GetString(buffer, 0, buffer.Length - 1);
+                    }
+                    else
+                    {
+                        result = default;
+                    }
+                }
+            }
+            else
+            {
+                result = default;
+            }
+
+            return error;
+        }
+
+        /// <summary>
+        /// Gets the size of the program log.
+        /// </summary>
+        /// <param name="program">The program.</param>
+        /// <param name="bufferSize">Filled in with the buffer size.</param>
+        /// <returns>The error code.</returns>
+        public NvvmResult GetProgramLogSize(IntPtr program, out IntPtr bufferSize) =>
+            nvvmGetProgramLogSize(program, out bufferSize);
+
+        /// <summary>
+        /// Gets the program log.
+        /// </summary>
+        /// <param name="program">The program.</param>
+        /// <param name="buffer">The buffer pointer.</param>
+        /// <returns>The error code.</returns>
+        public NvvmResult GetProgramLog(IntPtr program, IntPtr buffer) =>
+            nvvmGetProgramLog(program, buffer);
+
+        #endregion
+    }
+}
+
+#pragma warning restore CA2216 // Disposable types should declare finalizer

--- a/Src/ILGPU/Runtime/Cuda/NvvmEnums.cs
+++ b/Src/ILGPU/Runtime/Cuda/NvvmEnums.cs
@@ -1,0 +1,31 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                           Copyright (c) 2021 ILGPU Project
+//                                    www.ilgpu.net
+//
+// File: NvvmEnums.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details.
+// ---------------------------------------------------------------------------------------
+
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+namespace ILGPU.Runtime.Cuda
+{
+    public enum NvvmResult
+    {
+        NVVM_SUCCESS = 0,
+        NVVM_ERROR_OUT_OF_MEMORY = 1,
+        NVVM_ERROR_PROGRAM_CREATION_FAILURE = 2,
+        NVVM_ERROR_IR_VERSION_MISMATCH = 3,
+        NVVM_ERROR_INVALID_INPUT = 4,
+        NVVM_ERROR_INVALID_PROGRAM = 5,
+        NVVM_ERROR_INVALID_IR = 6,
+        NVVM_ERROR_INVALID_OPTION = 7,
+        NVVM_ERROR_NO_MODULE_IN_PROGRAM = 8,
+        NVVM_ERROR_COMPILATION = 9
+    }
+}
+
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member

--- a/Src/ILGPU/Static/CudaLibDevice.ttinclude
+++ b/Src/ILGPU/Static/CudaLibDevice.ttinclude
@@ -1,0 +1,76 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                           Copyright (c) 2021 ILGPU Project
+//                                    www.ilgpu.net
+//
+// File: CudaLibDevice.ttinclude
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details.
+// ---------------------------------------------------------------------------------------
+
+<#@ assembly name="System.Core" #>
+<#@ assembly name="System.Xml" #>
+<#@ import namespace="Microsoft.VisualStudio.TextTemplating" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ import namespace="System.ComponentModel" #>
+<#@ import namespace="System.IO" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Runtime.InteropServices" #>
+<#@ import namespace="System.Xml.Serialization" #>
+<#+
+
+public static class LibDeviceConstants
+{
+    public const string Prefix = "__ilgpu";
+}
+
+[XmlRoot("LibDevice")]
+public class LibDeviceFunctions
+{
+    internal static LibDeviceFunction[] Load(string rootPath, string fileName) =>
+        XmlHelper.Load<LibDeviceFunctions>(rootPath, fileName).Functions;
+
+    [XmlElement("Function")]
+    public LibDeviceFunction[] Functions { get; set; }
+}
+
+[XmlRoot("Function")]
+public class LibDeviceFunction
+{
+    [XmlAttribute]
+    public string Name { get; set; }
+
+    [XmlAttribute]
+    public string DisplayName { get; set; }
+
+    [XmlAttribute]
+    public string ReturnType { get; set; }
+
+    [XmlElement("Parameter")]
+    public LibDeviceFunctionParameter[] Parameters { get; set; }
+}
+
+[XmlRoot("Parameter")]
+public class LibDeviceFunctionParameter
+{
+    [XmlAttribute]
+    public string Name { get; set; }
+
+    [XmlAttribute]
+    public string Type { get; set; }
+    
+    [XmlAttribute]
+    public string Flags { get; set; }
+
+    [XmlIgnore]
+    public string FlagsExpression =>
+        Flags switch
+        {
+            "Out" => "out ",
+            "Ref" => "ref ",
+            _ => string.Empty
+        };
+}
+
+#>

--- a/Src/ILGPU/Static/CudaLibDevice.xml
+++ b/Src/ILGPU/Static/CudaLibDevice.xml
@@ -1,0 +1,1715 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<LibDevice>
+    <Function Name="__nv_abs"
+              DisplayName="Abs"
+              ReturnType="int">
+        <Parameter Name="x" Type="int" />
+    </Function>
+    <Function Name="__nv_acos"
+              DisplayName="Acos"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_acosf"
+              DisplayName="Acos"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_acosh"
+              DisplayName="Acosh"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_acoshf"
+              DisplayName="Acosh"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_asin"
+              DisplayName="Asin"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_asinf"
+              DisplayName="Asin"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_asinh"
+              DisplayName="Asinh"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_asinhf"
+              DisplayName="Asinh"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_atan"
+              DisplayName="Atan"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_atan2"
+              DisplayName="Atan"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+        <Parameter Name="y" Type="double" />
+    </Function>
+    <Function Name="__nv_atan2f"
+              DisplayName="Atan"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="y" Type="float" />
+    </Function>
+    <Function Name="__nv_atanf"
+              DisplayName="Atan"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_atanh"
+              DisplayName="Atanh"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_atanhf"
+              DisplayName="Atanh"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_brev"
+              DisplayName="BitReverse"
+              ReturnType="int">
+        <Parameter Name="x" Type="int" />
+    </Function>
+    <Function Name="__nv_brevll"
+              DisplayName="BitReverse"
+              ReturnType="long">
+        <Parameter Name="x" Type="long" />
+    </Function>
+    <Function Name="__nv_byte_perm"
+              DisplayName="BytePerm"
+              ReturnType="int">
+        <Parameter Name="x" Type="int" />
+        <Parameter Name="y" Type="int" />
+        <Parameter Name="z" Type="int" />
+    </Function>
+    <Function Name="__nv_cbrt"
+              DisplayName="Cbrt"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_cbrtf"
+              DisplayName="Cbrt"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_ceil"
+              DisplayName="Ceil"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_ceilf"
+              DisplayName="Ceil"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_clz"
+              DisplayName="CountLeadingZero"
+              ReturnType="int">
+        <Parameter Name="x" Type="int" />
+    </Function>
+    <Function Name="__nv_clzll"
+              DisplayName="CountLeadingZero"
+              ReturnType="long">
+        <Parameter Name="x" Type="long" />
+    </Function>
+    <Function Name="__nv_copysign"
+              DisplayName="CopySign"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_copysignf"
+              DisplayName="CopySign"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_cos"
+              DisplayName="Cos"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_cosf"
+              DisplayName="Cos"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_cosh"
+              DisplayName="Cosh"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_coshf"
+              DisplayName="Cosh"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_cospi"
+              DisplayName="CosPi"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_cospif"
+              DisplayName="CosPi"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_dadd_rd"
+              DisplayName="AddRoundDown"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+        <Parameter Name="y" Type="double" />
+    </Function>
+    <Function Name="__nv_dadd_rn"
+              DisplayName="AddRoundEven"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+        <Parameter Name="y" Type="double" />
+    </Function>
+    <Function Name="__nv_dadd_ru"
+              DisplayName="AddRoundUp"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+        <Parameter Name="y" Type="double" />
+    </Function>
+    <Function Name="__nv_dadd_rz"
+              DisplayName="AddRoundZero"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+        <Parameter Name="y" Type="double" />
+    </Function>
+    <Function Name="__nv_ddiv_rd"
+              DisplayName="DivRoundDown"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+        <Parameter Name="y" Type="double" />
+    </Function>
+    <Function Name="__nv_ddiv_rn"
+              DisplayName="DivRoundEven"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+        <Parameter Name="y" Type="double" />
+    </Function>
+    <Function Name="__nv_ddiv_ru"
+              DisplayName="DivRoundUp"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+        <Parameter Name="y" Type="double" />
+    </Function>
+    <Function Name="__nv_ddiv_rz"
+              DisplayName="DivRoundZero"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+        <Parameter Name="y" Type="double" />
+    </Function>
+    <Function Name="__nv_dmul_rd"
+              DisplayName="MulRoundDown"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+        <Parameter Name="y" Type="double" />
+    </Function>
+    <Function Name="__nv_dmul_rn"
+              DisplayName="MulRoundEven"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+        <Parameter Name="y" Type="double" />
+    </Function>
+    <Function Name="__nv_dmul_ru"
+              DisplayName="MulRoundUp"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+        <Parameter Name="y" Type="double" />
+    </Function>
+    <Function Name="__nv_dmul_rz"
+              DisplayName="MulRoundZero"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+        <Parameter Name="y" Type="double" />
+    </Function>
+    <Function Name="__nv_double2float_rd"
+              DisplayName="DoubleToFloatRoundDown"
+              ReturnType="float">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_double2float_rn"
+              DisplayName="DoubleToFloatRoundEven"
+              ReturnType="float">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_double2float_ru"
+              DisplayName="DoubleToFloatRoundUp"
+              ReturnType="float">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_double2float_rz"
+              DisplayName="DoubleToFloatRoundZero"
+              ReturnType="float">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_double2hiint"
+              DisplayName="DoubleToHiInt"
+              ReturnType="int">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_double2int_rd"
+              DisplayName="DoubleToIntRoundDown"
+              ReturnType="int">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_double2int_rn"
+              DisplayName="DoubleToIntRoundEven"
+              ReturnType="int">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_double2int_ru"
+              DisplayName="DoubleToIntRoundUp"
+              ReturnType="int">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_double2int_rz"
+              DisplayName="DoubleToIntRoundZero"
+              ReturnType="int">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_double2ll_rd"
+              DisplayName="DoubleToLongRoundDown"
+              ReturnType="long">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_double2ll_rn"
+              DisplayName="DoubleToLongRoundEven"
+              ReturnType="long">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_double2ll_ru"
+              DisplayName="DoubleToLongRoundUp"
+              ReturnType="long">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_double2ll_rz"
+              DisplayName="DoubleToLongRoundZero"
+              ReturnType="long">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_double2loint"
+              DisplayName="DoubleToLoInt"
+              ReturnType="int">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_double2uint_rd"
+              DisplayName="DoubleToUIntRoundDown"
+              ReturnType="uint">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_double2uint_rn"
+              DisplayName="DoubleToUIntRoundEven"
+              ReturnType="uint">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_double2uint_ru"
+              DisplayName="DoubleToUIntRoundUp"
+              ReturnType="uint">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_double2uint_rz"
+              DisplayName="DoubleToUIntRoundZero"
+              ReturnType="uint">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_double2ull_rd"
+              DisplayName="DoubleToULongRoundDown"
+              ReturnType="ulong">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_double2ull_rn"
+              DisplayName="DoubleToULongRoundEven"
+              ReturnType="ulong">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_double2ull_ru"
+              DisplayName="DoubleToULongRoundUp"
+              ReturnType="ulong">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_double2ull_rz"
+              DisplayName="DoubleToULongRoundZero"
+              ReturnType="ulong">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_double_as_longlong"
+              DisplayName="DoubleAsLong"
+              ReturnType="long">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_drcp_rd"
+              DisplayName="RcpRoundDown"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_drcp_rn"
+              DisplayName="RcpRoundEven"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_drcp_ru"
+              DisplayName="RcpRoundUp"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_drcp_rz"
+              DisplayName="RcpRoundZero"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_dsqrt_rd"
+              DisplayName="SqrtRoundDown"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_dsqrt_rn"
+              DisplayName="SqrtRoundEven"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_dsqrt_ru"
+              DisplayName="SqrtRoundUp"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_dsqrt_rz"
+              DisplayName="SqrtRoundZero"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_erf"
+              DisplayName="Erf"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_erfc"
+              DisplayName="Erfc"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_erfcf"
+              DisplayName="Erfc"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_erfcinv"
+              DisplayName="ErfcInv"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_erfcinvf"
+              DisplayName="ErfcInv"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_erfcx"
+              DisplayName="Erfcx"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_erfcxf"
+              DisplayName="Erfcx"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_erff"
+              DisplayName="Erf"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_erfinv"
+              DisplayName="ErfInv"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_erfinvf"
+              DisplayName="ErfInv"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_exp"
+              DisplayName="Exp"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_exp10"
+              DisplayName="Exp10"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_exp10f"
+              DisplayName="Exp10"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_exp2"
+              DisplayName="Exp2"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_exp2f"
+              DisplayName="Exp2"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_expf"
+              DisplayName="Exp"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_expm1"
+              DisplayName="Expm1"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_expm1f"
+              DisplayName="Expm1"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_fabs"
+              DisplayName="Abs"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_fabsf"
+              DisplayName="Abs"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_fadd_rd"
+              DisplayName="AddRoundDown"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="y" Type="float" />
+    </Function>
+    <Function Name="__nv_fadd_rn"
+              DisplayName="AddRoundEven"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="y" Type="float" />
+    </Function>
+    <Function Name="__nv_fadd_ru"
+              DisplayName="AddRoundUp"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="y" Type="float" />
+    </Function>
+    <Function Name="__nv_fadd_rz"
+              DisplayName="AddRoundZero"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="y" Type="float" />
+    </Function>
+    <Function Name="__nv_fast_cosf"
+              DisplayName="FastCos"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_fast_exp10f"
+              DisplayName="FastExp10"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_fast_expf"
+              DisplayName="FastExp"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_fast_fdividef"
+              DisplayName="FastDivide"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="y" Type="float" />
+    </Function>
+    <Function Name="__nv_fast_log10f"
+              DisplayName="FastLog10"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_fast_log2f"
+              DisplayName="FastLog2"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_fast_logf"
+              DisplayName="FastLog"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_fast_powf"
+              DisplayName="FastPow"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="y" Type="float" />
+    </Function>
+    <Function Name="__nv_fast_sincosf"
+              DisplayName="FastSinCos"
+              ReturnType="void">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="sin" Type="float" Flags="Out" />
+        <Parameter Name="cos" Type="float" Flags="Out" />
+    </Function>
+    <Function Name="__nv_fast_sinf"
+              DisplayName="FastSin"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_fast_tanf"
+              DisplayName="FastTan"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_fdim"
+              DisplayName="Dim"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+        <Parameter Name="y" Type="double" />
+    </Function>
+    <Function Name="__nv_fdimf"
+              DisplayName="Dim"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="y" Type="float" />
+    </Function>
+    <Function Name="__nv_fdiv_rd"
+              DisplayName="DivRoundDown"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="y" Type="float" />
+    </Function>
+    <Function Name="__nv_fdiv_rn"
+              DisplayName="DivRoundEven"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="y" Type="float" />
+    </Function>
+    <Function Name="__nv_fdiv_ru"
+              DisplayName="DivRoundUp"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="y" Type="float" />
+    </Function>
+    <Function Name="__nv_fdiv_rz"
+              DisplayName="DivRoundZero"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="y" Type="float" />
+    </Function>
+    <Function Name="__nv_ffs"
+              DisplayName="FindFirstSignificant"
+              ReturnType="int">
+        <Parameter Name="x" Type="int" />
+    </Function>
+    <Function Name="__nv_ffsll"
+              DisplayName="FindFirstSignificant"
+              ReturnType="int">
+        <Parameter Name="x" Type="long" />
+    </Function>
+    <Function Name="__nv_finitef"
+              DisplayName="Finite"
+              ReturnType="int">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_float2half_rn"
+              DisplayName="FloatToHalfRoundEven"
+              ReturnType="Half">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_float2int_rd"
+              DisplayName="FloatToIntRoundDown"
+              ReturnType="int">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_float2int_rn"
+              DisplayName="FloatToIntRoundEven"
+              ReturnType="int">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_float2int_ru"
+              DisplayName="FloatToIntRoundUp"
+              ReturnType="int">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_float2int_rz"
+              DisplayName="FloatToIntRoundZero"
+              ReturnType="int">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_float2ll_rd"
+              DisplayName="FloatToLongRoundDown"
+              ReturnType="long">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_float2ll_rn"
+              DisplayName="FloatToLongRoundEven"
+              ReturnType="long">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_float2ll_ru"
+              DisplayName="FloatToLongRoundUp"
+              ReturnType="long">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_float2ll_rz"
+              DisplayName="FloatToLongRoundZero"
+              ReturnType="long">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_float2uint_rd"
+              DisplayName="FloatToUIntRoundDown"
+              ReturnType="uint">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_float2uint_rn"
+              DisplayName="FloatToUIntRoundEven"
+              ReturnType="uint">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_float2uint_ru"
+              DisplayName="FloatToUIntRoundUp"
+              ReturnType="uint">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_float2uint_rz"
+              DisplayName="FloatToUIntRoundZero"
+              ReturnType="uint">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_float2ull_rd"
+              DisplayName="FloatToULongRoundDown"
+              ReturnType="ulong">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_float2ull_rn"
+              DisplayName="FloatToULongRoundEven"
+              ReturnType="ulong">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_float2ull_ru"
+              DisplayName="FloatToULongRoundUp"
+              ReturnType="ulong">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_float2ull_rz"
+              DisplayName="FloatToULongRoundZero"
+              ReturnType="ulong">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_float_as_int"
+              DisplayName="FloatAsInt"
+              ReturnType="int">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_floor"
+              DisplayName="Floor"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_floorf"
+              DisplayName="Floor"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_fma"
+              DisplayName="FusedMultiplyAdd"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+        <Parameter Name="y" Type="double" />
+        <Parameter Name="z" Type="double" />
+    </Function>
+    <Function Name="__nv_fma_rd"
+              DisplayName="FusedMultiplyAddRoundDown"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+        <Parameter Name="y" Type="double" />
+        <Parameter Name="z" Type="double" />
+    </Function>
+    <Function Name="__nv_fma_rn"
+              DisplayName="FusedMultiplyAddRoundEven"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+        <Parameter Name="y" Type="double" />
+        <Parameter Name="z" Type="double" />
+    </Function>
+    <Function Name="__nv_fma_ru"
+              DisplayName="FusedMultiplyAddRoundUp"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+        <Parameter Name="y" Type="double" />
+        <Parameter Name="z" Type="double" />
+    </Function>
+    <Function Name="__nv_fma_rz"
+              DisplayName="FusedMultiplyAddRoundZero"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+        <Parameter Name="y" Type="double" />
+        <Parameter Name="z" Type="double" />
+    </Function>
+    <Function Name="__nv_fmaf"
+              DisplayName="FusedMultiplyAdd"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="y" Type="float" />
+        <Parameter Name="z" Type="float" />
+    </Function>
+    <Function Name="__nv_fmaf_rd"
+              DisplayName="FusedMultiplyAddRoundDown"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="y" Type="float" />
+        <Parameter Name="z" Type="float" />
+    </Function>
+    <Function Name="__nv_fmaf_rn"
+              DisplayName="FusedMultiplyAddRoundEven"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="y" Type="float" />
+        <Parameter Name="z" Type="float" />
+    </Function>
+    <Function Name="__nv_fmaf_ru"
+              DisplayName="FusedMultiplyAddRoundUp"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="y" Type="float" />
+        <Parameter Name="z" Type="float" />
+    </Function>
+    <Function Name="__nv_fmaf_rz"
+              DisplayName="FusedMultiplyAddRoundZero"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="y" Type="float" />
+        <Parameter Name="z" Type="float" />
+    </Function>
+    <Function Name="__nv_fmax"
+              DisplayName="Max"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+        <Parameter Name="y" Type="double" />
+    </Function>
+    <Function Name="__nv_fmaxf"
+              DisplayName="Max"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="y" Type="float" />
+    </Function>
+    <Function Name="__nv_fmin"
+              DisplayName="Min"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+        <Parameter Name="y" Type="double" />
+    </Function>
+    <Function Name="__nv_fminf"
+              DisplayName="Min"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="y" Type="float" />
+    </Function>
+    <Function Name="__nv_fmod"
+              DisplayName="Fmod"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+        <Parameter Name="y" Type="double" />
+    </Function>
+    <Function Name="__nv_fmodf"
+              DisplayName="Fmod"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="y" Type="float" />
+    </Function>
+    <Function Name="__nv_fmul_rd"
+              DisplayName="MulRoundDown"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="y" Type="float" />
+    </Function>
+    <Function Name="__nv_fmul_rn"
+              DisplayName="MulRoundEven"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="y" Type="float" />
+    </Function>
+    <Function Name="__nv_fmul_ru"
+              DisplayName="MulRoundUp"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="y" Type="float" />
+    </Function>
+    <Function Name="__nv_fmul_rz"
+              DisplayName="MulRoundZero"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="y" Type="float" />
+    </Function>
+    <Function Name="__nv_frcp_rd"
+              DisplayName="RcpRoundDown"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_frcp_rn"
+              DisplayName="RcpRoundEven"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_frcp_ru"
+              DisplayName="RcpRoundUp"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_frcp_rz"
+              DisplayName="RcpRoundZero"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_frexp"
+              DisplayName="Rexp"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+        <Parameter Name="y" Type="int" Flags="Out" />
+    </Function>
+    <Function Name="__nv_frexpf"
+              DisplayName="Rexp"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="y" Type="int" Flags="Out" />
+    </Function>
+    <Function Name="__nv_frsqrt_rn"
+              DisplayName="RsqrtRoundEven"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_fsqrt_rd"
+              DisplayName="SqrtRoundDown"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_fsqrt_rb"
+              DisplayName="SqrtRoundEven"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_fsqrt_ru"
+              DisplayName="SqrtRoundUp"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_fsqrt_rz"
+              DisplayName="SqrtRoundZero"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_fsub_rd"
+              DisplayName="SubRoundDown"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="y" Type="float" />
+    </Function>
+    <Function Name="__nv_fsub_rn"
+              DisplayName="SubRoundEven"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="y" Type="float" />
+    </Function>
+    <Function Name="__nv_fsub_ru"
+              DisplayName="SubRoundUp"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="y" Type="float" />
+    </Function>
+    <Function Name="__nv_fsub_rz"
+              DisplayName="SubRoundZero"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="y" Type="float" />
+    </Function>
+    <Function Name="__nv_hadd"
+              DisplayName="Hadd"
+              ReturnType="int">
+        <Parameter Name="x" Type="int" />
+        <Parameter Name="y" Type="int" />
+    </Function>
+    <Function Name="__nv_half2float"
+              DisplayName="HalfToFloat"
+              ReturnType="float">
+        <Parameter Name="x" Type="Half" />
+    </Function>
+    <Function Name="__nv_hiloint2double"
+              DisplayName="HiLoIntToDouble"
+              ReturnType="double">
+        <Parameter Name="x" Type="int" />
+        <Parameter Name="y" Type="int" />
+    </Function>
+    <Function Name="__nv_hypot"
+              DisplayName="Hypot"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+        <Parameter Name="y" Type="double" />
+    </Function>
+    <Function Name="__nv_hypotf"
+              DisplayName="Hypot"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="y" Type="float" />
+    </Function>
+    <Function Name="__nv_ilogb"
+              DisplayName="ILogB"
+              ReturnType="int">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_ilogbf"
+              DisplayName="ILogB"
+              ReturnType="int">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_int2double_rn"
+              DisplayName="IntToDoubleRoundEven"
+              ReturnType="double">
+        <Parameter Name="x" Type="int" />
+    </Function>
+    <Function Name="__nv_int2float_rd"
+              DisplayName="IntToFloatRoundDown"
+              ReturnType="float">
+        <Parameter Name="x" Type="int" />
+    </Function>
+    <Function Name="__nv_int2float_rn"
+              DisplayName="IntToFloatRoundEven"
+              ReturnType="float">
+        <Parameter Name="x" Type="int" />
+    </Function>
+    <Function Name="__nv_int2float_ru"
+              DisplayName="IntToFloatRoundUp"
+              ReturnType="float">
+        <Parameter Name="x" Type="int" />
+    </Function>
+    <Function Name="__nv_int2float_rz"
+              DisplayName="IntToFloatRoundZero"
+              ReturnType="float">
+        <Parameter Name="x" Type="int" />
+    </Function>
+    <Function Name="__nv_int_as_float"
+              DisplayName="IntAsFloat"
+              ReturnType="float">
+        <Parameter Name="x" Type="int" />
+    </Function>
+    <Function Name="__nv_isfinited"
+              DisplayName="IsFinite"
+              ReturnType="int">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_isinfd"
+              DisplayName="IsInfinity"
+              ReturnType="int">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_isinff"
+              DisplayName="IsInfinity"
+              ReturnType="int">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_isnand"
+              DisplayName="IsNaN"
+              ReturnType="int">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_isnanf"
+              DisplayName="IsNaN"
+              ReturnType="int">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_j0"
+              DisplayName="J0"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_j0f"
+              DisplayName="J0"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_j1"
+              DisplayName="J1"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_j1f"
+              DisplayName="J1"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_jn"
+              DisplayName="JN"
+              ReturnType="double">
+        <Parameter Name="x" Type="int" />
+        <Parameter Name="y" Type="double" />
+    </Function>
+    <Function Name="__nv_jnf"
+              DisplayName="JN"
+              ReturnType="float">
+        <Parameter Name="x" Type="int" />
+        <Parameter Name="y" Type="float" />
+    </Function>
+    <Function Name="__nv_ldexp"
+              DisplayName="Exp"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+        <Parameter Name="y" Type="int" />
+    </Function>
+    <Function Name="__nv_ldexpf"
+              DisplayName="Exp"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="y" Type="int" />
+    </Function>
+    <Function Name="__nv_lgamma"
+              DisplayName="Gamma"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_lgammaf"
+              DisplayName="Gamma"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_ll2double_rd"
+              DisplayName="LongToDoubleRoundDown"
+              ReturnType="double">
+        <Parameter Name="x" Type="long" />
+    </Function>
+    <Function Name="__nv_ll2double_rn"
+              DisplayName="LongToDoubleRoundEven"
+              ReturnType="double">
+        <Parameter Name="x" Type="long" />
+    </Function>
+    <Function Name="__nv_ll2double_ru"
+              DisplayName="LongToDoubleRoundUp"
+              ReturnType="double">
+        <Parameter Name="x" Type="long" />
+    </Function>
+    <Function Name="__nv_ll2double_rz"
+              DisplayName="LongToDoubleRoundZero"
+              ReturnType="double">
+        <Parameter Name="x" Type="long" />
+    </Function>
+    <Function Name="__nv_ll2float_rd"
+              DisplayName="LongToFloatRoundDown"
+              ReturnType="float">
+        <Parameter Name="x" Type="long" />
+    </Function>
+    <Function Name="__nv_ll2float_rn"
+              DisplayName="LongToFloatRoundEven"
+              ReturnType="float">
+        <Parameter Name="x" Type="long" />
+    </Function>
+    <Function Name="__nv_ll2float_ru"
+              DisplayName="LongToFloatRoundUp"
+              ReturnType="float">
+        <Parameter Name="x" Type="long" />
+    </Function>
+    <Function Name="__nv_ll2float_rz"
+              DisplayName="LongToFloatRoundZero"
+              ReturnType="float">
+        <Parameter Name="x" Type="long" />
+    </Function>
+    <Function Name="__nv_llabs"
+              DisplayName="Abs"
+              ReturnType="long">
+        <Parameter Name="x" Type="long" />
+    </Function>
+    <Function Name="__nv_llmax"
+              DisplayName="Max"
+              ReturnType="long">
+        <Parameter Name="x" Type="long" />
+        <Parameter Name="y" Type="long" />
+    </Function>
+    <Function Name="__nv_llmin"
+              DisplayName="Min"
+              ReturnType="long">
+        <Parameter Name="x" Type="long" />
+        <Parameter Name="y" Type="long" />
+    </Function>
+    <Function Name="__nv_llrint"
+              DisplayName="LRint"
+              ReturnType="long">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_llrintf"
+              DisplayName="LRint"
+              ReturnType="long">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_llround"
+              DisplayName="LRound"
+              ReturnType="long">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_llroundf"
+              DisplayName="LRound"
+              ReturnType="long">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_log"
+              DisplayName="Log"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_log10"
+              DisplayName="Log10"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_log10f"
+              DisplayName="Log10"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_log1p"
+              DisplayName="Log1P"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_log1pf"
+              DisplayName="Log1P"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_log2"
+              DisplayName="Log2"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_log2f"
+              DisplayName="Log2"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_logb"
+              DisplayName="LogB"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_logbf"
+              DisplayName="LogB"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_logf"
+              DisplayName="Log"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_longlong_as_double"
+              DisplayName="LongAsDouble"
+              ReturnType="double">
+        <Parameter Name="x" Type="long" />
+    </Function>
+    <Function Name="__nv_max"
+              DisplayName="Max"
+              ReturnType="int">
+        <Parameter Name="x" Type="int" />
+        <Parameter Name="y" Type="int" />
+    </Function>
+    <Function Name="__nv_min"
+              DisplayName="Min"
+              ReturnType="int">
+        <Parameter Name="x" Type="int" />
+        <Parameter Name="y" Type="int" />
+    </Function>
+    <Function Name="__nv_modf"
+              DisplayName="Modf"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+        <Parameter Name="y" Type="double" />
+    </Function>
+    <Function Name="__nv_modff"
+              DisplayName="Modf"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="y" Type="float" />
+    </Function>
+    <Function Name="__nv_mul24"
+              DisplayName="Mul24"
+              ReturnType="int">
+        <Parameter Name="x" Type="int" />
+        <Parameter Name="y" Type="int" />
+    </Function>
+    <Function Name="__nv_mul64hi"
+              DisplayName="Mul64Hi"
+              ReturnType="long">
+        <Parameter Name="x" Type="long" />
+        <Parameter Name="y" Type="long" />
+    </Function>
+    <Function Name="__nv_mulhi"
+              DisplayName="MulHi"
+              ReturnType="int">
+        <Parameter Name="x" Type="int" />
+        <Parameter Name="y" Type="int" />
+    </Function>
+    <Function Name="__nv_nan"
+              DisplayName="NaN"
+              ReturnType="double">
+        <Parameter Name="tagp" Type="string" />
+    </Function>
+    <Function Name="__nv_nanf"
+              DisplayName="NaNF"
+              ReturnType="float">
+        <Parameter Name="tagp" Type="string" />
+    </Function>
+    <Function Name="__nv_nearbyint"
+              DisplayName="NearbyInt"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_nearbyintf"
+              DisplayName="NearbyInt"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_nextafter"
+              DisplayName="NextAfter"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_nextafterf"
+              DisplayName="NextAfter"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_normcdf"
+              DisplayName="Normcdf"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_normcdff"
+              DisplayName="Normcdf"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_normcdfinv"
+              DisplayName="NormcdfInv"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_normcdfinvf"
+              DisplayName="NormcdfInv"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_popc"
+              DisplayName="PopCount"
+              ReturnType="int">
+        <Parameter Name="x" Type="int" />
+    </Function>
+    <Function Name="__nv_popcll"
+              DisplayName="PopCount"
+              ReturnType="int">
+        <Parameter Name="x" Type="long" />
+    </Function>
+    <Function Name="__nv_pow"
+              DisplayName="Pow"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+        <Parameter Name="y" Type="double" />
+    </Function>
+    <Function Name="__nv_powf"
+              DisplayName="Pow"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="y" Type="float" />
+    </Function>
+    <Function Name="__nv_powi"
+              DisplayName="Pow"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+        <Parameter Name="y" Type="int" />
+    </Function>
+    <Function Name="__nv_powif"
+              DisplayName="Pow"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="y" Type="int" />
+    </Function>
+    <Function Name="__nv_rcbrt"
+              DisplayName="Rcbrt"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_rcbrtf"
+              DisplayName="Rcbrt"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_remainder"
+              DisplayName="Remainder"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+        <Parameter Name="y" Type="double" />
+    </Function>
+    <Function Name="__nv_remainderf"
+              DisplayName="Remainder"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="y" Type="float" />
+    </Function>
+    <Function Name="__nv_remquo"
+              DisplayName="RemQuo"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+        <Parameter Name="y" Type="double" />
+        <Parameter Name="quo" Type="int" Flags="Out" />
+    </Function>
+    <Function Name="__nv_remquof"
+              DisplayName="RemQuo"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="y" Type="float" />
+        <Parameter Name="quo" Type="int" Flags="Out" />
+    </Function>
+    <Function Name="__nv_rhadd"
+              DisplayName="Rhadd"
+              ReturnType="int">
+        <Parameter Name="x" Type="int" />
+        <Parameter Name="y" Type="int" />
+    </Function>
+    <Function Name="__nv_rint"
+              DisplayName="Rint"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_rintf"
+              DisplayName="Rint"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_round"
+              DisplayName="Round"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_roundf"
+              DisplayName="Round"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_rsqrt"
+              DisplayName="Rsqrt"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_rsqrtf"
+              DisplayName="Rsqrt"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_sad"
+              DisplayName="Sad"
+              ReturnType="int">
+        <Parameter Name="x" Type="int" />
+        <Parameter Name="y" Type="int" />
+        <Parameter Name="z" Type="int" />
+    </Function>
+    <Function Name="__nv_saturatef"
+              DisplayName="Saturate"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_scalbn"
+              DisplayName="Scalbn"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+        <Parameter Name="y" Type="int" />
+    </Function>
+    <Function Name="__nv_scalbnf"
+              DisplayName="Scalbn"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="y" Type="int" />
+    </Function>
+    <Function Name="__nv_signbitd"
+              DisplayName="SignBit"
+              ReturnType="int">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_signbitf"
+              DisplayName="SignBit"
+              ReturnType="int">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_sin"
+              DisplayName="Sin"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_sincos"
+              DisplayName="SinCos"
+              ReturnType="void">
+        <Parameter Name="x" Type="double" />
+        <Parameter Name="sin" Type="double" Flags="Out" />
+        <Parameter Name="cos" Type="double" Flags="Out" />
+    </Function>
+    <Function Name="__nv_sincosf"
+              DisplayName="SinCos"
+              ReturnType="void">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="sin" Type="float" Flags="Out" />
+        <Parameter Name="cos" Type="float" Flags="Out" />
+    </Function>
+    <Function Name="__nv_sincospi"
+              DisplayName="SinCosPi"
+              ReturnType="void">
+        <Parameter Name="x" Type="double" />
+        <Parameter Name="sin" Type="double" Flags="Out" />
+        <Parameter Name="cos" Type="double" Flags="Out" />
+    </Function>
+    <Function Name="__nv_sincospif"
+              DisplayName="SinCosPi"
+              ReturnType="void">
+        <Parameter Name="x" Type="float" />
+        <Parameter Name="sin" Type="float" Flags="Out" />
+        <Parameter Name="cos" Type="float" Flags="Out" />
+    </Function>
+    <Function Name="__nv_sinf"
+              DisplayName="Sin"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_sinh"
+              DisplayName="Sinh"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_sinhf"
+              DisplayName="Sinh"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_sinpi"
+              DisplayName="SinPi"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_sinpif"
+              DisplayName="SinPi"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_sqrt"
+              DisplayName="Sqrt"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_sqrtf"
+              DisplayName="Sqrt"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_tan"
+              DisplayName="Tan"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_tanf"
+              DisplayName="Tan"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_tanh"
+              DisplayName="Tanh"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_tanhf"
+              DisplayName="Tanh"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_tgamma"
+              DisplayName="Tgamma"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_tgammaf"
+              DisplayName="Tgamma"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_trunc"
+              DisplayName="Trunc"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_truncf"
+              DisplayName="Trunc"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_uhadd"
+              DisplayName="Uhadd"
+              ReturnType="int">
+        <Parameter Name="x" Type="int" />
+        <Parameter Name="y" Type="int" />
+    </Function>
+    <Function Name="__nv_uint2double_rn"
+              DisplayName="UIntToDoubleRoundEven"
+              ReturnType="double">
+        <Parameter Name="x" Type="int" />
+    </Function>
+    <Function Name="__nv_uint2float_rd"
+              DisplayName="UIntToFloatRoundDown"
+              ReturnType="float">
+        <Parameter Name="x" Type="int" />
+    </Function>
+    <Function Name="__nv_uint2float_rn"
+              DisplayName="UIntToFloatRoundEven"
+              ReturnType="float">
+        <Parameter Name="x" Type="int" />
+    </Function>
+    <Function Name="__nv_uint2float_ru"
+              DisplayName="UIntToFloatRoundUp"
+              ReturnType="float">
+        <Parameter Name="x" Type="int" />
+    </Function>
+    <Function Name="__nv_uint2float_rz"
+              DisplayName="UIntToFloatRoundZero"
+              ReturnType="float">
+        <Parameter Name="x" Type="int" />
+    </Function>
+    <Function Name="__nv_ull2double_rd"
+              DisplayName="ULongToDoubleRoundDown"
+              ReturnType="double">
+        <Parameter Name="x" Type="ulong" />
+    </Function>
+    <Function Name="__nv_ull2double_rn"
+              DisplayName="LongToDoubleRoundEven"
+              ReturnType="double">
+        <Parameter Name="x" Type="ulong" />
+    </Function>
+    <Function Name="__nv_ull2double_ru"
+              DisplayName="ULongToDoubleRoundUp"
+              ReturnType="double">
+        <Parameter Name="x" Type="ulong" />
+    </Function>
+    <Function Name="__nv_ull2double_rz"
+              DisplayName="ULongToDoubleRoundZero"
+              ReturnType="double">
+        <Parameter Name="x" Type="ulong" />
+    </Function>
+    <Function Name="__nv_ull2float_rd"
+              DisplayName="ULongToFloatRoundDown"
+              ReturnType="float">
+        <Parameter Name="x" Type="ulong" />
+    </Function>
+    <Function Name="__nv_ull2float_rn"
+              DisplayName="ULongToFloatRoundEven"
+              ReturnType="float">
+        <Parameter Name="x" Type="ulong" />
+    </Function>
+    <Function Name="__nv_ull2float_ru"
+              DisplayName="ULongToFloatRoundUp"
+              ReturnType="float">
+        <Parameter Name="x" Type="ulong" />
+    </Function>
+    <Function Name="__nv_ull2float_rz"
+              DisplayName="ULongToFloatRoundZero"
+              ReturnType="float">
+        <Parameter Name="x" Type="ulong" />
+    </Function>
+    <Function Name="__nv_ullmax"
+              DisplayName="Max"
+              ReturnType="ulong">
+        <Parameter Name="x" Type="ulong" />
+        <Parameter Name="y" Type="ulong" />
+    </Function>
+    <Function Name="__nv_ullmin"
+              DisplayName="Min"
+              ReturnType="ulong">
+        <Parameter Name="x" Type="ulong" />
+        <Parameter Name="y" Type="ulong" />
+    </Function>
+    <Function Name="__nv_umax"
+              DisplayName="Max"
+              ReturnType="uint">
+        <Parameter Name="x" Type="uint" />
+        <Parameter Name="y" Type="uint" />
+    </Function>
+    <Function Name="__nv_umin"
+              DisplayName="Min"
+              ReturnType="uint">
+        <Parameter Name="x" Type="uint" />
+        <Parameter Name="y" Type="uint" />
+    </Function>
+    <Function Name="__nv_umul24"
+              DisplayName="Mul24"
+              ReturnType="uint">
+        <Parameter Name="x" Type="uint" />
+        <Parameter Name="y" Type="uint" />
+    </Function>
+    <Function Name="__nv_umul64hi"
+              DisplayName="Mul64Hi"
+              ReturnType="ulong">
+        <Parameter Name="x" Type="ulong" />
+        <Parameter Name="y" Type="ulong" />
+    </Function>
+    <Function Name="__nv_umulhi"
+              DisplayName="MulHi"
+              ReturnType="uint">
+        <Parameter Name="x" Type="uint" />
+        <Parameter Name="y" Type="uint" />
+    </Function>
+    <Function Name="__nv_urhadd"
+              DisplayName="Rhadd"
+              ReturnType="uint">
+        <Parameter Name="x" Type="uint" />
+        <Parameter Name="y" Type="uint" />
+    </Function>
+    <Function Name="__nv_usad"
+              DisplayName="Sad"
+              ReturnType="uint">
+        <Parameter Name="x" Type="uint" />
+        <Parameter Name="y" Type="uint" />
+        <Parameter Name="z" Type="uint" />
+    </Function>
+    <Function Name="__nv_y0"
+              DisplayName="Y0"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_y0f"
+              DisplayName="Y0"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_y1"
+              DisplayName="Y1"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_y1f"
+              DisplayName="Y1"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+    <Function Name="__nv_yn"
+              DisplayName="YN"
+              ReturnType="double">
+        <Parameter Name="x" Type="double" />
+    </Function>
+    <Function Name="__nv_ynf"
+              DisplayName="YN"
+              ReturnType="float">
+        <Parameter Name="x" Type="float" />
+    </Function>
+</LibDevice>

--- a/Src/ILGPU/Static/TextTransformHelpers.ttinclude
+++ b/Src/ILGPU/Static/TextTransformHelpers.ttinclude
@@ -1,0 +1,33 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                           Copyright (c) 2021 ILGPU Project
+//                                    www.ilgpu.net
+//
+// File: TextTransformHelpers.ttinclude
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details.
+// ---------------------------------------------------------------------------------------
+
+<#+
+
+/// <summary>
+/// Writes a blank line.
+/// The T4 implementation does not provide this overload.
+/// </summary>
+public void WriteLine() =>
+    WriteLine("");
+
+/// <summary>
+/// Pushes a single 4 space indent.
+/// </summary>
+public void PushIndent() =>
+    PushIndent(1);
+
+/// <summary>
+/// Pushes a single indent as multiple of 4 spaces.
+/// </summary>
+public void PushIndent(int width) =>
+    PushIndent(new string(Enumerable.Repeat(' ', width * 4).ToArray()));
+
+#>

--- a/Src/ILGPU/Util/NativeLibrary.cs
+++ b/Src/ILGPU/Util/NativeLibrary.cs
@@ -1,0 +1,120 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                           Copyright (c) 2021 ILGPU Project
+//                                    www.ilgpu.net
+//
+// File: NativeLibrary.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details.
+// ---------------------------------------------------------------------------------------
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace ILGPU.Util
+{
+    /// <summary>
+    /// Provides cross-platform functions for loading a DLL and extracting function
+    /// pointers.
+    ///
+    /// System.Runtime.InteropServices.NativeLibrary is not available for
+    /// NETFRAMEWORK or NETSTANDARD.
+    /// </summary>
+#if NET5_0_OR_GREATER
+    static class NativeLibrary
+    {
+        public static IntPtr Load(string path) =>
+            System.Runtime.InteropServices.NativeLibrary.Load(path);
+
+        public static void Free(IntPtr handle) =>
+            System.Runtime.InteropServices.NativeLibrary.Free(handle);
+
+        public static IntPtr GetExport(IntPtr handle, string name) =>
+            System.Runtime.InteropServices.NativeLibrary.GetExport(handle, name);
+    }
+#else
+    static class NativeLibrary
+    {
+        public static IntPtr Load(string path)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                return NativeLibrary_Windows.LoadLibrary(path);
+            else
+                return NativeLibrary_Unix.dlopen(path, NativeLibrary_Unix.RTLD_NOW);
+        }
+
+        public static void Free(IntPtr handle)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                NativeLibrary_Windows.FreeLibrary(handle);
+            else
+                _ = NativeLibrary_Unix.dlclose(handle);
+        }
+
+        public static IntPtr GetExport(IntPtr handle, string name)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                return NativeLibrary_Windows.GetProcAddress(handle, name);
+            else
+                return NativeLibrary_Unix.dlsym(handle, name);
+        }
+    }
+
+    static class NativeLibrary_Windows
+    {
+        private const string LibName = "kernel32.dll";
+
+        [DllImport(
+            LibName,
+            CharSet = CharSet.Ansi,
+            BestFitMapping = false,
+            ThrowOnUnmappableChar = true,
+            SetLastError = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
+        public static extern IntPtr LoadLibrary(string dllToLoad);
+
+        [DllImport(
+            LibName,
+            CharSet = CharSet.Ansi,
+            BestFitMapping = false,
+            ThrowOnUnmappableChar = true,
+            SetLastError = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
+        public static extern IntPtr GetProcAddress(
+            IntPtr hModule,
+            string procedureName);
+
+        [DllImport(LibName, SetLastError = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
+        public static extern bool FreeLibrary(IntPtr hModule);
+    }
+
+    static class NativeLibrary_Unix
+    {
+        private const string LibName = "libdl";
+
+        public const int RTLD_NOW = 0x002;
+
+        [DllImport(
+            LibName,
+            CharSet = CharSet.Ansi,
+            BestFitMapping = false,
+            ThrowOnUnmappableChar = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
+        public static extern IntPtr dlopen(string dllToLoad, int flags);
+
+        [DllImport(
+            LibName,
+            CharSet = CharSet.Ansi,
+            BestFitMapping = false,
+            ThrowOnUnmappableChar = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
+        public static extern IntPtr dlsym(IntPtr hModule, string procedureName);
+
+        [DllImport(LibName)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
+        public static extern int dlclose(IntPtr hModule);
+    }
+#endif
+}


### PR DESCRIPTION
Fixes #407.

Adds a new `LibDevice` class that exposes all the [Cuda LibDevice functions](https://docs.nvidia.com/cuda/libdevice-users-guide/index.html).

To initialize LibDevice, we need to call `LibDevice()` or `LibDevice(string, string)` in the Context Builder.
e.g. `using var context = Context.Create(builder => builder.Cuda().LibDevice());`

We require the path to the Cuda NVVM DLL (e.g. `C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.4\nvvm\bin\nvvm64_40_0.dll`) and the path to the LibDevice BitCode (e.g. `C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.4\nvvm\libdevice\libdevice.10.bc`). There is also an auto-detection mechanism that will try to guess the correct paths.

The LibDevice BitCode is loaded into an NVVM module, and a custom NVVM function is added that calls the desired LibDevice function. We then compile the NVVM module into PTX and extract the generate PTX.

If two LibDevice functions are called, we will add both function class to the same NVVM module, and compile them together. This is because there could be shared functions or variables. e.g. Sin and Cos both use the same helper function. If generated separately, we would get naming conflicts if we just appended the PTX of both modules.

There is also an issue with the generated PTX code, where the Float32 or Float64 are actually using Int32 or Int64 registers. Therefore, we need to add wrapper methods (`PTXLibDeviceMethods`) that deals with this transition.

NOTE: The custom NVVM module uses the textual representation. This has been deprecated by Nvidia, so in future, we may need to replace this with the binary representation.