### PR TITLE
[CI] Disable parallelization when running clean tests to avoid OutOfMemory issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,10 +140,11 @@ jobs:
         id: env
         shell: bash
         run: |
-          echo "::set-output name=json::{}"
+          jsonValue="{}"
           if [[ ${{ github.event_name == 'schedule' || (github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))) }} ]]; then
-            echo "::set-output name=json::{\"ILGPU_CLEAN_TESTS\":\"true\", \"ILGPU_TEST_PARALLELIZATION_LEVEL\":\"1\"}"
+            jsonValue="{\"ILGPU_CLEAN_TESTS\":\"true\", \"ILGPU_TEST_PARALLELIZATION_LEVEL\":\"1\"}"
           fi
+          echo "::set-output name=json::$jsonValue"
 
       - name: Build and test
         run: dotnet test --configuration=Release --framework=${{ matrix.framework }} -p:TreatWarningsAsErrors=true --logger GitHubActions Src/${{ matrix.library }}.Tests.${{ steps.test-flavor.outputs.flavor }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,10 +133,18 @@ jobs:
         shell: bash
         run: echo ::set-output name=flavor::$([[ "${{ matrix.os }}" == "cuda" ]] && echo "Cuda" || echo "CPU")
 
+      - name: Set environment variables
+        id: env
+        shell: bash
+        run: |
+          echo "::set-output name=json::{\"ILGPU_CLEAN_TESTS\":\"false\", \"ILGPU_TEST_PARALLELIZATION_LEVEL\":\"1\"}"
+          if [[ ${{ github.event_name == 'schedule' || (github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))) }} ]]; then
+            echo "::set-output name=json::{\"ILGPU_CLEAN_TESTS\":\"true\", \"ILGPU_TEST_PARALLELIZATION_LEVEL\":\"4\"}"
+          fi
+
       - name: Build and test
         run: dotnet test --configuration=Release --framework=${{ matrix.framework }} -p:TreatWarningsAsErrors=true --logger GitHubActions Src/${{ matrix.library }}.Tests.${{ steps.test-flavor.outputs.flavor }}
-        env:
-          ILGPU_CLEAN_TESTS: ${{ github.event_name == 'schedule' || (github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))) }}
+        env: ${{ fromJson(steps.env.outputs.json) }}
 
   # Ensure that ILGPU libraries are built using the same version tag.
   check-version:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,13 +133,16 @@ jobs:
         shell: bash
         run: echo ::set-output name=flavor::$([[ "${{ matrix.os }}" == "cuda" ]] && echo "Cuda" || echo "CPU")
 
+      # Clean tests (kernel caching disabled) use more CPU and memory, so we only run them for
+      # scheduled runs, pushes to master, and pushes to tags.
+      # Parallelization also needs to be disabled to avoid Out of Memory errors.
       - name: Set environment variables
         id: env
         shell: bash
         run: |
-          echo "::set-output name=json::{\"ILGPU_CLEAN_TESTS\":\"false\", \"ILGPU_TEST_PARALLELIZATION_LEVEL\":\"1\"}"
+          echo "::set-output name=json::{}"
           if [[ ${{ github.event_name == 'schedule' || (github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))) }} ]]; then
-            echo "::set-output name=json::{\"ILGPU_CLEAN_TESTS\":\"true\", \"ILGPU_TEST_PARALLELIZATION_LEVEL\":\"4\"}"
+            echo "::set-output name=json::{\"ILGPU_CLEAN_TESTS\":\"true\", \"ILGPU_TEST_PARALLELIZATION_LEVEL\":\"1\"}"
           fi
 
       - name: Build and test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
         run: |
           jsonValue="{}"
           if [[ ${{ github.event_name == 'schedule' || (github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))) }} ]]; then
-            jsonValue="{\"ILGPU_CLEAN_TESTS\":\"true\", \"ILGPU_TEST_PARALLELIZATION_LEVEL\":\"1\"}"
+            jsonValue="{\"ILGPU_CLEAN_TESTS\":\"true\"}"
           fi
           echo "::set-output name=json::$jsonValue"
 


### PR DESCRIPTION
Build test job should have default environment variables for master/tags and schedule events, otherwise use `ILGPU_CLEAN_TESTS=false` and `ILGPU_TEST_PARALLELIZATION_LEVEL=4` to debug and test parallelization.

Example:
 [here ](https://github.com/ljubon/ILGPU/runs/4831531492?check_suite_focus=true#step:7:3)is when the condition is `true` (p.s I've changed just `if condition` to match my branch name) and [here ](https://github.com/ljubon/ILGPU/runs/4831531659?check_suite_focus=true#step:8:7)confirmation that jobs `Build and test` afterward used configured values.
