### PR TITLE
Added support for net6.0.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,10 +82,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup the latest .NET 5 SDK
+      - name: Setup the latest .NET 6 SDK
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 6.0.x
 
       - name: Build
         run: dotnet build --configuration=Release -p:TreatWarningsAsErrors=true ${{ matrix.path }}
@@ -97,7 +97,7 @@ jobs:
       matrix:
         os: ${{ fromJson(needs.setup-os-matrix.outputs.os) }}
         library: [ILGPU, ILGPU.Algorithms]
-        framework: [netcoreapp3.1, net5.0]
+        framework: [netcoreapp3.1, net5.0, net6.0]
         include:
           - os: windows-latest
             library: ILGPU
@@ -111,7 +111,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Setup the latest .NET 6 SDK
+        if: matrix.framework == 'net6.0'
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.x
+
       - name: Setup the latest .NET 5 SDK
+        if: matrix.framework == 'net5.0'
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 5.0.x
@@ -179,10 +186,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup the latest .NET 5 SDK
+      - name: Setup the latest .NET 6 SDK
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 6.0.x
 
       - name: Create NuGet packages
         run: |
@@ -213,10 +220,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup the latest .NET 5 SDK
+      - name: Setup the latest .NET 6 SDK
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 6.0.x
 
       # Change the ILGPU project references to NuGet package references
       - name: Update sample references

--- a/Samples/Directory.Build.props
+++ b/Samples/Directory.Build.props
@@ -3,5 +3,9 @@
     <LibrarySamplesTargetFrameworks>net471;netcoreapp3.1;net5.0</LibrarySamplesTargetFrameworks>
     <LibrarySamplesTargetFrameworksWindows>net471;netcoreapp3.1;net5.0-windows</LibrarySamplesTargetFrameworksWindows>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(MSBuildVersion)' &gt;= '17.0'">
+    <LibrarySamplesTargetFrameworks>$(LibrarySamplesTargetFrameworks);net6.0</LibrarySamplesTargetFrameworks>
+    <LibrarySamplesTargetFrameworksWindows>$(LibrarySamplesTargetFrameworksWindows);net6.0-windows</LibrarySamplesTargetFrameworksWindows>
+  </PropertyGroup>
 
 </Project>

--- a/Src/Directory.Build.props
+++ b/Src/Directory.Build.props
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <LibraryTargetFrameworks>net471;netstandard2.1;net5.0</LibraryTargetFrameworks>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(MSBuildVersion)' &gt;= '17.0'">
+    <LibraryTargetFrameworks>$(LibraryTargetFrameworks);net6.0</LibraryTargetFrameworks>
+  </PropertyGroup>
 
   <PropertyGroup>
     <LibraryVersionPrefix>1.1.0-beta1</LibraryVersionPrefix>
@@ -14,7 +17,11 @@
   <PropertyGroup>
     <LibraryUnitTestTargetFrameworks>net5.0</LibraryUnitTestTargetFrameworks>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(MSBuildVersion)' &gt;= '17.0'">
+    <LibraryUnitTestTargetFrameworks>net6.0</LibraryUnitTestTargetFrameworks>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <LibraryUnitTestTargetFrameworks Condition="'$(MSBuildVersion)' &gt;= '17.0'">$(LibraryUnitTestTargetFrameworks);net5.0</LibraryUnitTestTargetFrameworks>
     <LibraryUnitTestTargetFrameworks>$(LibraryUnitTestTargetFrameworks);netcoreapp3.1</LibraryUnitTestTargetFrameworks>
     <LibraryUnitTestTargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(LibraryUnitTestTargetFrameworks);net471</LibraryUnitTestTargetFrameworks>
   </PropertyGroup>

--- a/Src/ILGPU/Util/NativeLibrary.cs
+++ b/Src/ILGPU/Util/NativeLibrary.cs
@@ -12,6 +12,8 @@
 using System;
 using System.Runtime.InteropServices;
 
+#pragma warning disable CA2101 // Specify marshaling for P/Invoke string arguments
+
 namespace ILGPU.Util
 {
     /// <summary>
@@ -118,3 +120,5 @@ namespace ILGPU.Util
     }
 #endif
 }
+
+#pragma warning restore CA2101 // Specify marshaling for P/Invoke string arguments

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
   "sdk": {
-    "version": "5.0.x"
+    "version": "6.0.x"
   }
 }


### PR DESCRIPTION
Depends on https://github.com/m4rs-mt/ILGPU/pull/718.

Conditionally adds .NET 6.0 support if the MSBuild version is v17 or later. This is because VS2019 (MSBuild v16) does not support .NET 6.0, and fails to compile if it sees the `net6.0` target framework.

Also updates the CI pipeline to use the .NET 6 SDK.