### PR TITLE
Added automatic folding of Convert values into LEA values.

### DIFF
--- a/Src/ILGPU/IR/Construction/Memory.cs
+++ b/Src/ILGPU/IR/Construction/Memory.cs
@@ -208,6 +208,14 @@ namespace ILGPU.IR.Construction
             var addressSpaceType = source.Type as AddressSpaceType;
             location.AssertNotNull(addressSpaceType);
 
+            // Fold nested conversion operations that do not change the semantics
+            if (elementIndex is ConvertValue convertValue &&
+                convertValue.Value.BasicValueType == BasicValueType.Int32 &&
+                convertValue.BasicValueType == BasicValueType.Int64)
+            {
+                elementIndex = convertValue.Value;
+            }
+
             // Fold primitive pointer arithmetic that does not change anything
             return source.Type is PointerType && elementIndex.IsPrimitive(0)
                 ? (ValueReference)source


### PR DESCRIPTION
This PR adds a special IR-value folding pattern to combine specific `ConvertValue` operations with `LoadElementAddress` values. First, this reduces the number of PTX instructions issued. Secondly (and more importantly 💡), it avoids the generation of "uncommon" PTX instruction sequences that ultimately lead to suboptimal `SASS` code (which, for example, requires more registers than actually needed).