### PR TITLE
Fixed regression when extracting CI pipeline scripts.

### DIFF
--- a/.github/workflows/Scripts/UpdateSampleReferences.ps1
+++ b/.github/workflows/Scripts/UpdateSampleReferences.ps1
@@ -14,7 +14,7 @@ Param (
     [Parameter(Mandatory=$True, HelpMessage="The ILGPU package version")]
     [string]$version,
 
-    [Parameter(Mandatory=$True, HelpMessage="The ILGPU package suffix")]
+    [Parameter(HelpMessage="The ILGPU package suffix")]
     [string]$suffix
 )
 


### PR DESCRIPTION
In #719, we extracted several steps from the CI pipeline into separate scripts. This introduced a new bug when updating the sample references for pre-release packages. In Powershell, the mandatory string prevents the empty string, but this is what we use to indicate an official release package.