### PR TITLE
Disabled AssemblyBuilder reloading in TestContext.

### DIFF
--- a/Src/ILGPU.Tests/Generic/TestContext.cs
+++ b/Src/ILGPU.Tests/Generic/TestContext.cs
@@ -67,7 +67,7 @@ namespace ILGPU.Tests
         public void ClearCaches()
         {
             Accelerator.ClearCache(ClearCacheMode.Everything);
-            Context.ClearCache(ClearCacheMode.Everything);
+            Context.ClearCache(ClearCacheMode.Default);
         }
 
         /// <summary>

--- a/Src/ILGPU/RuntimeSystem.cs
+++ b/Src/ILGPU/RuntimeSystem.cs
@@ -650,8 +650,15 @@ namespace ILGPU
         /// <summary>
         /// Clears all internal caches.
         /// </summary>
-        /// <param name="mode">Not used.</param>
-        public void ClearCache(ClearCacheMode mode) => ReloadAssemblyBuilder();
+        /// <param name="mode">
+        /// Passing <see cref="ClearCacheMode.Everything"/>, causes a reload of the
+        /// CLR assembly builder, which is used internally.
+        /// </param>
+        public void ClearCache(ClearCacheMode mode)
+        {
+            if (mode == ClearCacheMode.Everything)
+                ReloadAssemblyBuilder();
+        }
 
         #endregion
 


### PR DESCRIPTION
This PR disables reloading of `AssemblyBuilder` instances after test runs. This avoids certain `OutOfMemoryt` problems that can occur if we create too many runtime assemblies (> 32K) during test execution.