### PR TITLE
Fixed inheritance to avoid removal of IOValue instances.

### DIFF
--- a/Src/ILGPU/IR/Values/IOValues.cs
+++ b/Src/ILGPU/IR/Values/IOValues.cs
@@ -28,7 +28,7 @@ namespace ILGPU.IR.Values
     /// <summary>
     /// Represents an abstract Input/Output (IO) value with side effects.
     /// </summary>
-    public abstract class IOValue : ControlFlowValue
+    public abstract class IOValue : MemoryValue
     {
         #region Instance
 


### PR DESCRIPTION
This PR fixes #744 by changing the inherited base class of `IOValue` classes.