### PR TITLE
Fixed CodePlacement and invalid removal of DebugAssert values

### DIFF
--- a/Src/ILGPU/IR/Transformations/Optimizer.cs
+++ b/Src/ILGPU/IR/Transformations/Optimizer.cs
@@ -197,9 +197,9 @@ namespace ILGPU.IR.Transformations
                 // Add additional code placement optimizations to reduce register
                 // pressure and improve performance
                 builder.Add(new DeadCodeElimination());
+                builder.Add(new LoopInvariantCodeMotion());
                 builder.Add(new CodePlacement<TPlacementStrategy>(
                     CodePlacementMode.Aggressive));
-                builder.Add(new LoopInvariantCodeMotion());
             }
         }
 

--- a/Src/ILGPU/IR/Values/Debug.cs
+++ b/Src/ILGPU/IR/Values/Debug.cs
@@ -18,7 +18,7 @@ namespace ILGPU.IR.Values
     /// Represents a debug assert operation.
     /// </summary>
     [ValueKind(ValueKind.DebugAssert)]
-    public sealed class DebugAssertOperation : ControlFlowValue
+    public sealed class DebugAssertOperation : MemoryValue
     {
         #region Instance
 


### PR DESCRIPTION
This PR fixes a regression in `v1.1.0-beta1` affecting `DebugAssert` values and addresses a conceptual program in the `O2` pipeline. Recent changes cause debug assertions to be removed although they have been explicitly enabled (#704). Moreover, there are many cases in which the current `CodePlacement` phase emits code that actually consumes more registers than before. A detailed analysis revealed that this is caused by a suboptimal ordering of the `LICM` and `CodePlacement` phases. This PR addresses this issue by reordering these two phases in the `O2` pipeline.