### PR TITLE
Fixed issue with the same phi value being reused in a loop.

### DIFF
--- a/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.cs
@@ -539,11 +539,18 @@ namespace ILGPU.Backends.OpenCL
                         // Check for an intermediate phi value
                         if (bindings.IsIntermediate(phiValue))
                         {
-                            var intermediateVariable = AllocateType(phiValue.Type);
-                            intermediatePhiVariables.Add(phiValue, intermediateVariable);
+                            if (!intermediatePhiVariables.TryGetValue(
+                                phiValue,
+                                out var intermediateVariable))
+                            {
+                                intermediateVariable = AllocateType(phiValue.Type);
+                                intermediatePhiVariables.Add(
+                                    phiValue,
+                                    intermediateVariable);
 
-                            // Move this phi value into a temporary variable for reuse
-                            Declare(intermediateVariable);
+                                // Move this phi value into a temporary variable for reuse
+                                Declare(intermediateVariable);
+                            }
                             Move(intermediateVariable, phiTargetVariable);
                         }
 


### PR DESCRIPTION
I member of the community reported an issue when upgrading from ILGPU v0.9.1 to v1.0.

It appears to only be affecting OpenCL.
```
System.ArgumentException: An item with the same key has already been added.
   at System.ThrowHelper.ThrowArgumentException(ExceptionResource resource)
   at System.Collections.Generic.Dictionary`2.Insert(TKey key, TValue value, Boolean add)
   at ILGPU.Backends.OpenCL.CLCodeGenerator.GenerateCodeInternal() in /_/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.cs:line 546
   at ILGPU.Backends.OpenCL.CLKernelFunctionGenerator.GenerateCode() in /_/Src/ILGPU/Backends/OpenCL/CLKernelFunctionGenerator.cs:line 326
   at ILGPU.Backends.CodeGeneratorBackend`4.<>c__DisplayClass1_0.<Compile>b__0(Int32 i) in /_/Src/ILGPU/Backends/CodeGeneratorBackend.cs:line 104
   at System.Threading.Tasks.Parallel.<>c__DisplayClass17_0`1.<ForWorker>b__1()
```

Minimal example code to reproduce:
```CSharp
using ILGPU;
using ILGPU.Runtime;
using ILGPU.Runtime.OpenCL;

namespace ConsoleApp1
{
    public class Program
    {
        public static void Main()
        {
            using var context = Context.Create(b => b.OpenCL());
            var device = context.Devices.First();
            using var accelerator = device.CreateAccelerator(context);

            var kernel = accelerator.LoadAutoGroupedStreamKernel<
                Index1D,
                ArrayView<float>,
                ArrayView<ulong>
                >(KernelMethod);
        }

        public static void KernelMethod(
            Index1D index,
            ArrayView<float> input,
            ArrayView<ulong> output
        )
        {
            ulong shifter = 0x1;
            ulong result = 0;

            var loop = 2;

            while (true)
            {
                loop--;
                if (loop == 0)
                {
                    break;
                }

                if (0.0f < input[0])
                {
                    shifter <<= 1;
                    continue;
                }

                if (1.0f < input[0])
                {
                    shifter <<= 1;
                    continue;
                }

                result ^= shifter;
            }

            output[index] = result;
        }
    }
}
```