### PR TITLE
Fix CodeQL failure on windows-latest

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,7 +23,9 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: windows-latest
+    # CodeQL does not yet support Windows Server 2022
+    # see https://github.com/github/codeql-action/issues/850
+    runs-on: windows-2019
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
CodeQL does not yet support Windows Server 2022 (see https://github.com/github/codeql-action/issues/850). This PR switches our CodeQL CI workflow to explicitly use `windows-2019` instead of `windows-latest`, which GitHub started to move to `windows-2022`.