### PR TITLE
Uniform branches for NVIDIA GPUs

### DIFF
--- a/Src/ILGPU/Backends/PTX/PTXBackend.cs
+++ b/Src/ILGPU/Backends/PTX/PTXBackend.cs
@@ -216,19 +216,29 @@ namespace ILGPU.Backends.PTX
 
             GenerateLibDeviceCode(backendContext, builder);
 
+            // Check whether we are running in the O1 or O2 pipeline
+            bool o1Enabled = Context.Properties.OptimizationLevel >= OptimizationLevel.O1;
+            bool o2Enabled = Context.Properties.OptimizationLevel > OptimizationLevel.O1;
+
             // Creates pointer alignment information in the context of O1 or higher
-            var alignments = Context.Properties.OptimizationLevel >= OptimizationLevel.O1
+            var alignments = o1Enabled
                 ? PointerAlignments.Apply(
                     backendContext.KernelMethod,
                     DefaultGlobalMemoryAlignment)
                 : PointerAlignments.AlignmentInfo.Empty;
+
+            // Create detailed uniform information in O2 builds
+            var uniforms = o2Enabled
+                ? Uniforms.Apply(backendContext.KernelMethod)
+                : Uniforms.Info.Empty;
 
             data = new PTXCodeGenerator.GeneratorArgs(
                 this,
                 entryPoint,
                 Context.Properties,
                 debugInfoGenerator,
-                alignments);
+                alignments,
+                uniforms);
 
             return builder;
         }

--- a/Src/ILGPU/Backends/PTX/PTXCodeGenerator.Values.cs
+++ b/Src/ILGPU/Backends/PTX/PTXCodeGenerator.Values.cs
@@ -49,19 +49,26 @@ namespace ILGPU.Backends.PTX
 
             // Reserve a sufficient amount of memory
             var returnType = target.ReturnType;
+            string callCommand = Uniforms.IsUniform(methodCall)
+                ? PTXInstructions.UniformMethodCall
+                : PTXInstructions.MethodCall;
             if (!returnType.IsVoidType)
             {
                 Builder.Append('\t');
                 AppendParamDeclaration(Builder, returnType, ReturnValueName);
                 Builder.AppendLine(";");
-                Builder.Append("\tcall ");
+                Builder.Append('\t');
+                Builder.Append(callCommand);
+                Builder.Append(' ');
                 Builder.Append('(');
                 Builder.Append(ReturnValueName);
                 Builder.Append("), ");
             }
             else
             {
-                Builder.Append("\tcall ");
+                Builder.Append('\t');
+                Builder.Append(callCommand);
+                Builder.Append(' ');
             }
             Builder.Append(GetMethodName(target));
             Builder.AppendLine(", (");

--- a/Src/ILGPU/Backends/PTX/PTXCodeGenerator.cs
+++ b/Src/ILGPU/Backends/PTX/PTXCodeGenerator.cs
@@ -78,13 +78,15 @@ namespace ILGPU.Backends.PTX
                 EntryPoint entryPoint,
                 ContextProperties contextProperties,
                 PTXDebugInfoGenerator debugInfoGenerator,
-                PointerAlignments.AlignmentInfo pointerAlignments)
+                PointerAlignments.AlignmentInfo pointerAlignments,
+                Uniforms.Info uniforms)
             {
                 Backend = backend;
                 EntryPoint = entryPoint;
                 Properties = contextProperties;
                 DebugInfoGenerator = debugInfoGenerator;
                 PointerAlignments = pointerAlignments;
+                Uniforms = uniforms;
             }
 
             /// <summary>
@@ -111,6 +113,12 @@ namespace ILGPU.Backends.PTX
             /// Returns detailed information about all pointer alignments.
             /// </summary>
             public PointerAlignments.AlignmentInfo PointerAlignments { get; }
+
+            /// <summary>
+            /// Returns detailed information about uniform values, terminators in
+            /// particular.
+            /// </summary>
+            public Uniforms.Info Uniforms { get; }
         }
 
         /// <summary>
@@ -335,6 +343,7 @@ namespace ILGPU.Backends.PTX
             DebugInfoGenerator = args.DebugInfoGenerator.BeginScope();
             ImplementationProvider = Backend.IntrinsicProvider;
             Allocas = allocas;
+            Uniforms = args.Uniforms;
 
             Architecture = args.Backend.Architecture;
             FastMath = args.Properties.MathMode >= MathMode.Fast;
@@ -407,6 +416,11 @@ namespace ILGPU.Backends.PTX
         /// Returns detailed information about all pointer alignments.
         /// </summary>
         public PointerAlignments.AlignmentInfo PointerAlignments { get; }
+
+        /// <summary>
+        /// Returns information about whether a branch is a uniform control-flow branch.
+        /// </summary>
+        public Uniforms.Info Uniforms { get; }
 
         /// <summary>
         /// Returns all blocks in an appropriate schedule.

--- a/Src/ILGPU/Backends/PTX/PTXInstructions.Data.cs
+++ b/Src/ILGPU/Backends/PTX/PTXInstructions.Data.cs
@@ -25,6 +25,11 @@ namespace ILGPU.Backends.PTX
         public const string ReturnOperation = "ret";
 
         /// <summary>
+        /// A uniform return operation.
+        /// </summary>
+        public const string UniformReturnOperation = "ret.uni";
+
+        /// <summary>
         /// A general move operation.
         /// </summary>
         public const string MoveOperation = "mov";
@@ -38,11 +43,6 @@ namespace ILGPU.Backends.PTX
         /// A general load operation that loads parameter values.
         /// </summary>
         public const string LoadParamOperation = "ld.param";
-
-        /// <summary>
-        /// A general load operation that loads local values.
-        /// </summary>
-        public const string LoadLocalOperation = "ld.local";
 
         /// <summary>
         /// A general store operation.
@@ -60,9 +60,19 @@ namespace ILGPU.Backends.PTX
         public const string BranchOperation = "bra";
 
         /// <summary>
+        /// A uniform branch operation.
+        /// </summary>
+        public const string UniformBranchOperation = "bra.uni";
+
+        /// <summary>
         /// An indexed branch operation.
         /// </summary>
         public const string BranchIndexOperation = "brx.idx";
+
+        /// <summary>
+        /// A unified indexed branch operation.
+        /// </summary>
+        public const string UniformBranchIndexOperation = "brx.idx.uni";
 
         /// <summary>
         /// An indexed branch range comparison.
@@ -78,6 +88,16 @@ namespace ILGPU.Backends.PTX
         /// An index FMA operation.
         /// </summary>
         public const string IndexFMAOperationLo = "mad.lo.s32";
+
+        /// <summary>
+        /// A uniform method call.
+        /// </summary>
+        public const string UniformMethodCall = "call.uni";
+
+        /// <summary>
+        /// A method call.
+        /// </summary>
+        public const string MethodCall = "call.uni";
 
         /// <summary>
         /// An atomic CAS operation.
@@ -377,7 +397,7 @@ namespace ILGPU.Backends.PTX
             new Dictionary<(UnaryArithmeticKind, ArithmeticBasicValueType), string>()
             {
                 // Basic arithmetic
-                
+
                 { (UnaryArithmeticKind.Neg, ArithmeticBasicValueType.Int8), "neg.s16" },
                 { (UnaryArithmeticKind.Neg, ArithmeticBasicValueType.Int16), "neg.s16" },
                 { (UnaryArithmeticKind.Neg, ArithmeticBasicValueType.Int32), "neg.s32" },
@@ -473,7 +493,7 @@ namespace ILGPU.Backends.PTX
             new Dictionary<(BinaryArithmeticKind, ArithmeticBasicValueType), string>()
             {
                 // Basic arithmetic
-                
+
                 { (BinaryArithmeticKind.Add, ArithmeticBasicValueType.Int8), "add.s16" },
                 { (BinaryArithmeticKind.Add, ArithmeticBasicValueType.Int16), "add.s16" },
                 { (BinaryArithmeticKind.Add, ArithmeticBasicValueType.Int32), "add.s32" },
@@ -616,7 +636,7 @@ namespace ILGPU.Backends.PTX
             new Dictionary<(BinaryArithmeticKind, ArithmeticBasicValueType), string>()
             {
                 // Basic arithmetic
-                
+
                 { (BinaryArithmeticKind.Add, ArithmeticBasicValueType.Float16), "add.ftz.f16" },
                 { (BinaryArithmeticKind.Add, ArithmeticBasicValueType.Float32), "add.ftz.f32" },
 

--- a/Src/ILGPU/CompatibilitySuppressions.xml
+++ b/Src/ILGPU/CompatibilitySuppressions.xml
@@ -56,4 +56,32 @@
     <Right>lib/netstandard2.1/ILGPU.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:ILGPU.Backends.PTX.PTXInstructions.LoadLocalOperation</Target>
+    <Left>lib/net471/ILGPU.dll</Left>
+    <Right>lib/net471/ILGPU.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:ILGPU.Backends.PTX.PTXInstructions.LoadLocalOperation</Target>
+    <Left>lib/net5.0/ILGPU.dll</Left>
+    <Right>lib/net5.0/ILGPU.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:ILGPU.Backends.PTX.PTXInstructions.LoadLocalOperation</Target>
+    <Left>lib/netstandard2.1/ILGPU.dll</Left>
+    <Right>lib/netstandard2.1/ILGPU.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:ILGPU.Backends.PTX.PTXInstructions.LoadLocalOperation</Target>
+    <Left>lib/net6.0/ILGPU.dll</Left>
+    <Right>lib/net6.0/ILGPU.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
 </Suppressions>

--- a/Src/ILGPU/IR/Analyses/FixPointAnalysis.cs
+++ b/Src/ILGPU/IR/Analyses/FixPointAnalysis.cs
@@ -445,12 +445,9 @@ namespace ILGPU.IR.Analyses
                     if (!valueMapping.ContainsKey(value))
                         valueMapping[value] = CreateData(value);
                 }
-                // Register return terminators
-                if (block.Terminator is ReturnTerminator terminator &&
-                    !valueMapping.ContainsKey(terminator))
-                {
-                    valueMapping[terminator] = CreateData(terminator);
-                }
+                // Register terminators
+                if (!valueMapping.ContainsKey(block.Terminator))
+                    valueMapping[block.Terminator] = CreateData(block.Terminator);
             }
 
             // Create the analysis context and perform the analysis
@@ -468,8 +465,8 @@ namespace ILGPU.IR.Analyses
                 foreach (Value value in block)
                     changed |= Update(value, context);
                 // Check for a return terminator
-                if (block.Terminator is ReturnTerminator terminator)
-                    Update(terminator, context);
+                if (block.Terminator != null)
+                    changed |= Update(block.Terminator, context);
                 if (!changed)
                     return;
 

--- a/Src/ILGPU/IR/Analyses/Uniforms.cs
+++ b/Src/ILGPU/IR/Analyses/Uniforms.cs
@@ -1,0 +1,292 @@
+using ILGPU.IR.Analyses.ControlFlowDirection;
+using ILGPU.IR.Types;
+using ILGPU.IR.Values;
+using System;
+
+namespace ILGPU.IR.Analyses
+{
+    /// <summary>
+    /// An analysis to determine whether values and terminators can be considered uniform.
+    /// </summary>
+    public class Uniforms : GlobalFixPointAnalysis<Uniforms.ValueInfo, Forwards>
+    {
+        #region Nested Types
+
+        /// <summary>
+        /// The state of a value.
+        /// </summary>
+        public enum UniformKind
+        {
+            /// <summary>
+            /// No or insufficient information is available for the value attached.
+            /// </summary>
+            Unknown = 0,
+
+            /// <summary>
+            /// The associated value can be considered uniform.
+            /// </summary>
+            Uniform = 1,
+
+            /// <summary>
+            /// The associated value has to be considered divergent.
+            /// </summary>
+            Divergent = 2,
+        }
+
+        /// <summary>
+        /// Information carried per value.
+        /// </summary>
+        public readonly struct ValueInfo : IEquatable<ValueInfo>
+        {
+            #region Instance
+
+            /// <summary>
+            /// Constructs a new value information instance.
+            /// </summary>
+            /// <param name="kind">The associated value kind.</param>
+            public ValueInfo(UniformKind kind)
+            {
+                Kind = kind;
+            }
+
+            #endregion
+
+            #region Properties
+
+            /// <summary>
+            /// Returns the current kind of the current uniform information instance.
+            /// </summary>
+            public UniformKind Kind { get; }
+
+            #endregion
+
+            #region IEquatable
+
+            /// <inheritdoc cref="IEquatable{T}.Equals(T)"/>>
+            public bool Equals(ValueInfo other) =>
+                Kind == other.Kind;
+
+            #endregion
+
+            #region Object
+
+            /// <summary>
+            /// Returns true if the given object is equal to the current instance.
+            /// </summary>
+            /// <param name="obj">The other object.</param>
+            /// <returns>
+            /// True, if the given object is equal to the current instance.
+            /// </returns>
+            public override bool Equals(object obj) =>
+                obj is ValueInfo other && Equals(other);
+
+            /// <summary>
+            /// Returns the hash code of this instance.
+            /// </summary>
+            /// <returns>The hash code of this instance.</returns>
+            public override int GetHashCode() => (int)Kind;
+
+            /// <summary>
+            /// Returns the string representation of this instance.
+            /// </summary>
+            /// <returns>The string representation of this instance.</returns>
+            public override string ToString() => Kind.ToString();
+
+            #endregion
+
+            #region Operators
+
+            /// <summary>
+            /// Converts a value of type <see cref="UniformKind"/> into a
+            /// <see cref="ValueInfo"/> instance.
+            /// </summary>
+            /// <param name="kind">The kind to convert to.</param>
+            /// <returns>The created value information instance.</returns>
+            public static implicit operator ValueInfo(UniformKind kind) =>
+                new ValueInfo(kind);
+
+            /// <summary>
+            /// Returns true if the first and second information instances are the same.
+            /// </summary>
+            /// <param name="first">The first instance.</param>
+            /// <param name="second">The second instance.</param>
+            /// <returns>True, if the first and second instances are the same.</returns>
+            public static bool operator ==(ValueInfo first, ValueInfo second) =>
+                first.Equals(second);
+
+            /// <summary>
+            /// Returns true if the first and second information instances are not the
+            /// same.
+            /// </summary>
+            /// <param name="first">The first instance.</param>
+            /// <param name="second">The second instance.</param>
+            /// <returns>
+            /// True, if the first and second instances are not the same.
+            /// </returns>
+            public static bool operator !=(ValueInfo first, ValueInfo second) =>
+                !first.Equals(second);
+
+            #endregion
+        }
+
+        /// <summary>
+        /// Stores information of a uniform analysis run.
+        /// </summary>
+        public readonly struct Info
+        {
+            #region Static
+
+            /// <summary>
+            /// Empty allocation information.
+            /// </summary>
+            public static readonly Info Empty =
+                new Info(GlobalAnalysisValueResult<ValueInfo>.Empty);
+
+            #endregion
+
+            #region Instance
+
+            /// <summary>
+            /// Constructs a new alignment analysis.
+            /// </summary>
+            internal Info(GlobalAnalysisValueResult<ValueInfo> analysisResult)
+            {
+                AnalysisResult = analysisResult;
+            }
+
+            #endregion
+
+            #region Properties
+
+            /// <summary>
+            /// Stores a method value-alignment mapping.
+            /// </summary>
+            public GlobalAnalysisValueResult<ValueInfo> AnalysisResult { get; }
+
+            /// <summary>
+            /// Returns pointer alignment information for the given value.
+            /// </summary>
+            /// <param name="value">The value to get alignment information for.</param>
+            /// <returns>Pointer alignment in bytes (can be 1 byte).</returns>
+            public UniformKind this[Value value] =>
+                AnalysisResult.TryGetData(value, out var data)
+                    ? data.Data.Kind
+                    : UniformKind.Unknown;
+
+            #endregion
+
+            #region Methods
+
+            /// <summary>
+            /// Returns true if the given value can be considered to be uniformly
+            /// distributed across all threads in the current group. However, it
+            /// pessimistically assumes that <see cref="UniformKind.Unknown"/> refers
+            /// to a divergent value.
+            /// </summary>
+            /// <param name="value">The value to test.</param>
+            /// <returns>True, if the given value can be considered uniform.</returns>
+            public bool IsUniform(Value value) => this[value] == UniformKind.Uniform;
+
+            #endregion
+        }
+
+        #endregion
+
+        #region Static
+
+        /// <summary>
+        /// Creates a new uniforms analysis.
+        /// </summary>
+        public static Uniforms Create(Method entryPoint) => new Uniforms();
+
+        /// <summary>
+        /// Applies a new alignment analysis to the given root method.
+        /// </summary>
+        /// <param name="entryPoint">The root (entry) method.</param>
+        public static Info Apply(Method entryPoint)
+        {
+            var analysis = Create(entryPoint);
+            var result = analysis.AnalyzeGlobalMethod(entryPoint, UniformKind.Uniform);
+            return new Info(result);
+        }
+
+        #endregion
+
+        #region Instance
+
+        /// <summary>
+        /// Constructs a new analysis implementation.
+        /// </summary>
+        protected Uniforms()
+            : base(defaultValue: UniformKind.Unknown)
+        { }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Returns initial and unconstrained information about whether the given value
+        /// can be considered uniform.
+        /// </summary>
+        /// <param name="node">The IR node.</param>
+        /// <returns>The uniform state of the given node.</returns>
+        private static ValueInfo IsUniformByDefinition(Value node) =>
+            node switch
+            {
+                // Thread-dependent values are divergent by definition
+                LaneIdxValue _ => UniformKind.Divergent,
+                GroupIndexValue _ => UniformKind.Divergent,
+                // (Device-wide) constants are uniform by definition
+                GridIndexValue _ => UniformKind.Uniform,
+                ConstantNode _ => UniformKind.Uniform,
+                UndefinedValue _ => UniformKind.Uniform,
+                // Method calls can be considered uniform since each thread will perform
+                // the same call (since we do not support virtual and jump-table based
+                // calls at the moment)
+                MethodCall _ => UniformKind.Uniform,
+                // Unconditional branches can be considered uniform
+                UnconditionalBranch _ => UniformKind.Uniform,
+                // Conditional branches are considered to be unknown
+                ConditionalBranch _ => UniformKind.Unknown,
+                // All return terminators must be assumed to be divergent
+                ReturnTerminator _ => UniformKind.Divergent,
+                // All remaining values have an unknown state
+                _ => UniformKind.Unknown
+            };
+
+        /// <summary>
+        /// Creates initial analysis data using <see cref="IsUniformByDefinition"/>.
+        /// </summary>
+        protected override AnalysisValue<ValueInfo> CreateData(Value node) =>
+            CreateValue(IsUniformByDefinition(node), node.Type);
+
+        /// <summary>
+        /// Returns the maximum of the first and the second kind.
+        /// </summary>
+        protected override ValueInfo Merge(ValueInfo first, ValueInfo second) =>
+            (UniformKind)Math.Max((int)first.Kind, (int)second.Kind);
+
+        /// <summary>
+        /// Returns no type-based information.
+        /// </summary>
+        protected override AnalysisValue<ValueInfo>? TryProvide(TypeNode typeNode) =>
+            null;
+
+        /// <summary>
+        /// Merges information about terminators.
+        /// </summary>
+        protected override AnalysisValue<ValueInfo>? TryMerge<TContext>(
+            Value value,
+            TContext context) =>
+            value switch
+            {
+                // Conditional branches depend on their condition value
+                ConditionalBranch condBranch => context[condBranch.Condition],
+                // Use the default merge logic for all remaining values
+                _ => null
+            };
+
+        #endregion
+    }
+}


### PR DESCRIPTION
This PR adds a performance-oriented optimization to differentiate between *uniform* and *divergent* branches. Uniform branches are jumps that will be taken by all *active* lanes in a warp in all cases. This PR adds this new performance-driven pass to the O2 pipeline and is designed to reduce register consumption and improve control-flow performance of kernels for NVIDIA GPUs.