### PR TITLE
Enhanced Loop Unrolling

### DIFF
--- a/Src/ILGPU/IR/Transformations/Optimizer.cs
+++ b/Src/ILGPU/IR/Transformations/Optimizer.cs
@@ -196,8 +196,8 @@ namespace ILGPU.IR.Transformations
             {
                 // Add additional code placement optimizations to reduce register
                 // pressure and improve performance
+                builder.AddLoopOptimizations();
                 builder.Add(new DeadCodeElimination());
-                builder.Add(new LoopInvariantCodeMotion());
                 builder.Add(new CodePlacement<TPlacementStrategy>(
                     CodePlacementMode.Aggressive));
             }

--- a/Src/ILGPU/Util/Utilities.cs
+++ b/Src/ILGPU/Util/Utilities.cs
@@ -26,12 +26,8 @@ namespace ILGPU.Util
         /// <typeparam name="T">The type of the values.</typeparam>
         /// <param name="first">The first value to swap with the second one.</param>
         /// <param name="second">The second value to swap with the first one.</param>
-        public static void Swap<T>(ref T first, ref T second)
-        {
-            T temp = first;
-            first = second;
-            second = temp;
-        }
+        public static void Swap<T>(ref T first, ref T second) =>
+            (first, second) = (second, first);
 
         /// <summary>
         /// Swaps the given values if swap is true.


### PR DESCRIPTION
This PR enhances the internal `Loop Unrolling` pass to be compatible with additional loops (involving `mul`, `shr`, `div` and `shl` operations). This allows ILGPU to unroll common `Warp.Reduce` patterns, which in turn reduces register consumption and improves runtime performance.