### PR TITLE
Enable dynamic self-hosted CUDA runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
             )
           ) && os+=("macos-latest")
 
-          [ "${{ steps.is-fork.outputs.fork }}" == "false" ] && os+=("cuda")
+          [ "${{ steps.is-fork.outputs.fork }}" == "false" ] && os+=("cuda-${{ github.run_id }}-${{ github.run_attempt }}")
 
           echo "::set-output name=os::$(jq -cn '$ARGS.positional' --args ${os[@]})"
     outputs:
@@ -136,7 +136,7 @@ jobs:
       - name: Set test flavor
         id: test-flavor
         shell: bash
-        run: echo ::set-output name=flavor::$([[ "${{ matrix.os }}" == "cuda" ]] && echo "Cuda" || echo "CPU")
+        run: echo ::set-output name=flavor::$([[ "${{ matrix.os }}" == cuda-* ]] && echo "Cuda" || echo "CPU")
 
       - name: Build and test
         run: dotnet test --configuration=Release --framework=${{ matrix.framework }} -p:TreatWarningsAsErrors=true --logger GitHubActions Src/${{ matrix.library }}.Tests.${{ steps.test-flavor.outputs.flavor }}

--- a/.github/workflows/runners.yaml
+++ b/.github/workflows/runners.yaml
@@ -1,0 +1,97 @@
+name: Runners Deployment
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: 
+      - completed
+      - requested
+
+jobs:
+  check-skipped:
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.repository.fork }}
+    outputs:
+      skipped: ${{ steps.check-skipped.outputs.skipped }}
+    steps:
+      - name: Check whether the workflow is skipped
+        id: check-skipped
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          url="/repos/${{ github.event.repository.owner.login }}/${{ github.event.repository.name }}/actions/runs/${{ github.event.workflow_run.id }}/attempts/${{ github.event.workflow_run.run_attempt }}"
+          skipped="false"
+          for i in $(seq 10); do
+            conclusion=$(gh api $url | jq -r .conclusion)
+            if [ "$conclusion" == "skipped" ]; then
+              skipped="true"
+              break
+            fi
+            sleep 1
+          done
+          echo ::set-output name=skipped::$skipped
+
+  manage-runners:
+    runs-on: ubuntu-latest
+    environment: cuda-test-infra
+    needs: check-skipped
+    if: ${{ needs.check-skipped.outputs.skipped == 'false' }}
+    steps:
+      - name: Checkout main repo for config
+        if: github.event.action == 'requested'
+        uses: actions/checkout@v3
+        with:
+          path: ilgpu
+
+      - name: Checkout Pulumi Ephemeral Github Runner project
+        uses: actions/checkout@v3
+        with:
+          repository: m4rs-mt/ILGPU-github-runner-gcp
+          ref: main
+          path: pulumi
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '14'
+
+      - name: Setup modules
+        env:
+          PULUMI_SKIP_UPDATE_CHECK: "true"
+        working-directory: pulumi
+        run: npm ci
+
+      - name: Create/destroy runners
+        env:
+          APP_ID: ${{ secrets.APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+          GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
+          GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
+          GOOGLE_REGION: ${{ secrets.GOOGLE_REGION }}
+          GOOGLE_ZONE: ${{ secrets.GOOGLE_ZONE }}
+          PULUMI_BACKEND_URL: ${{ secrets.PULUMI_BACKEND_URL }}
+          PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
+          PULUMI_SKIP_CONFIRMATIONS: "true"
+          PULUMI_SKIP_UPDATE_CHECK: "true"
+          PULUMI_STACK_NAME: ilgpu-ghrunner-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}
+          LABEL: cuda-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}
+          OWNER: ${{ github.event.repository.owner.login }}
+          REPO: ${{ github.event.repository.name }}
+        working-directory: pulumi
+        run: |
+          case ${{ github.event.action }} in
+            'requested')
+              cp ../ilgpu/.github/workflows/runners/config.yaml Pulumi.$PULUMI_STACK_NAME.yaml
+              pulumi stack init $PULUMI_STACK_NAME
+              pulumi config set labels $LABEL
+              pulumi config set owner $OWNER
+              pulumi config set repo $REPO
+              pulumi update --diff
+              ;;
+            'completed')
+              pulumi stack select $PULUMI_STACK_NAME
+              pulumi destroy
+              pulumi stack rm
+              npm run cleanup-runners $OWNER $REPO $LABEL
+              ;;
+          esac

--- a/.github/workflows/runners/config.yaml
+++ b/.github/workflows/runners/config.yaml
@@ -1,0 +1,6 @@
+config:
+  ephemeral-github-runner-gcp:bootDiskSizeInGB: "100"
+  ephemeral-github-runner-gcp:bootDiskType: pd-balanced
+  ephemeral-github-runner-gcp:machineImage: ubuntu-2004-focal-v20220308-ghr22881-nv47010301
+  ephemeral-github-runner-gcp:machineType: a2-highgpu-1g
+  ephemeral-github-runner-gcp:runnersCount: "6"


### PR DESCRIPTION
This PR is based on and supersedes #751 by @pavlovic-ivan.

All the secrets have already been setup offline with @m4rs-mt.

The key differences are:
* labels are created and assigned _per workflow run attempt_
* the repo used to create/destroy GCP instances is under @m4rs-mt's control
* some secrets have been renamed
* a GitHub App owned and setup by @m4rs-mt is used instead of a PAT (this app has `admin:write` access to `m4rs-mt/ILGPU` and nothing else)
* service account email has been removed
* skipped workflows should not create/destroy runners
* npm modules are installed according to `package-lock.json` (through `npm ci`)
* machine image has been updated to the current latest versions of Ubuntu, GitHub Actions Runner, and NVIDIA drivers v470 (see https://github.com/pavlovic-ivan/ephemeral-github-runner-image-gcp/pull/7 for details)
* offline runners are cleaned up after the GCP instances are destroyed (as a fallback)

More information about the changes can be found in https://github.com/pavlovic-ivan/ephemeral-github-runner-gcp/pull/1.

This PR won't be able to run any CUDA tests, as it depends on itself being merged. Once merged, all the CUDA tests will run on the new GCP infrastructure. In case of problem, rolling back this change would make the CI use the current infrastructure again.