### PR TITLE
Updated copyright year in GitHub workflow scripts.

### DIFF
--- a/.github/workflows/Scripts/UpdateSampleReferences.ps1
+++ b/.github/workflows/Scripts/UpdateSampleReferences.ps1
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------------------------
 ##                                        ILGPU
-##                           Copyright (c) 2021 ILGPU Project
+##                        Copyright (c) 2021-2022 ILGPU Project
 ##                                    www.ilgpu.net
 ##
 ## File: UpdateSampleReferences.ps1


### PR DESCRIPTION
Looks like the scheduled copyright year cannot update the GitHub workflow scripts:
https://github.com/m4rs-mt/ILGPU/actions/runs/2080341469
