### PR TITLE
Fixed issues with LibDevice integration.

### DIFF
--- a/Src/ILGPU/Backends/PTX/PTXLibDeviceMethods.tt
+++ b/Src/ILGPU/Backends/PTX/PTXLibDeviceMethods.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: PTXLibDeviceMethods.tt/PTXLibDeviceMethods.cs
@@ -112,7 +112,8 @@ void WriteLibDeviceFunction(LibDeviceFunction func)
 
 void WriteBinaryType(string type)
 {
-    if (type == "float")
+    // Map .NET types to the .NET type used by PTX to represent the register.
+    if (type == "Half" || type == "float")
         Write("uint");
     else if (type == "double")
         Write("ulong");

--- a/Src/ILGPU/Backends/PTX/PTXLibDeviceNvvm.tt
+++ b/Src/ILGPU/Backends/PTX/PTXLibDeviceNvvm.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: PTXLibDeviceNvvm.tt/PTXLibDeviceNvvm.cs
@@ -161,8 +161,13 @@ void WriteLibDeviceFunctionNvvm(LibDeviceFunction func)
 
 void WriteNvvmType(string type)
 {
+    // Map .NET types to the equivalent NNVM types.
     if (type == "string")
         Write("i8*");
+    else if (type == "int" || type == "uint")
+        Write("i32");
+    else if (type == "long" || type == "ulong")
+        Write("i64");
     else
         Write(type);
 }

--- a/Src/ILGPU/Backends/PTX/PTXLibDeviceNvvm.tt
+++ b/Src/ILGPU/Backends/PTX/PTXLibDeviceNvvm.tt
@@ -164,6 +164,8 @@ void WriteNvvmType(string type)
     // Map .NET types to the equivalent NNVM types.
     if (type == "string")
         Write("i8*");
+    else if (type == "Half")
+        Write("i16");
     else if (type == "int" || type == "uint")
         Write("i32");
     else if (type == "long" || type == "ulong")

--- a/Src/ILGPU/Runtime/Cuda/LibDevice.tt
+++ b/Src/ILGPU/Runtime/Cuda/LibDevice.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: LibDevice.tt/LibDevice.cs
@@ -37,8 +37,10 @@ namespace ILGPU.Runtime.Cuda
     /// Provides bindings for Cuda LibDevice functions.
     /// </summary>
     /// <remarks>
-    /// Deals with thunking the Cuda LibDevice functions, because the compiled PTX uses
-    /// u32/u64 registers rather than f32/f64 registers.
+    /// Deals with thunking the Cuda LibDevice functions, because the compiled PTX uses:
+    /// - b32 registers rather than f16 registers (Half type).
+    /// - b32 registers rather than f32 registers (float type).
+    /// - b64 registers rather than f64 registers (double type).
     /// </remarks>
     public static class LibDevice
     {
@@ -98,14 +100,16 @@ void WriteLibDeviceInterop(LibDeviceFunction func)
         var param = func.Parameters[i];
         if (string.IsNullOrEmpty(param.Flags))
         {
-            if (param.Type == "float" || param.Type == "double")
+            if (param.Type == "Half")
+                WriteLine($"var arg{i} = (uint){param.Name};");
+            else if (param.Type == "float" || param.Type == "double")
                 WriteLine($"var arg{i} = Interop.FloatAsInt({param.Name});");
             else
                 WriteLine($"var arg{i} = {param.Name};");
         }
         else
         {
-            if (param.Type == "float")
+            if (param.Type == "Half" || param.Type == "float")
                 WriteLine($"uint arg{i};");
             else if (param.Type == "double")
                 WriteLine($"ulong arg{i};");
@@ -140,14 +144,18 @@ void WriteLibDeviceInterop(LibDeviceFunction func)
         var param = func.Parameters[i];
         if (!string.IsNullOrEmpty(param.Flags))
         {
-            if (param.Type == "float" || param.Type == "double")
+            if (param.Type == "Half")
+                WriteLine($"{param.Name} = (Half)arg{i};");
+            else if (param.Type == "float" || param.Type == "double")
                 WriteLine($"{param.Name} = Interop.IntAsFloat(arg{i});");
             else
                 WriteLine($"{param.Name} = arg{i};");
         }
     }
 
-    if (func.ReturnType == "float" || func.ReturnType == "double")
+    if (func.ReturnType == "Half")
+        WriteLine("return (Half)result;");
+    else if (func.ReturnType == "float" || func.ReturnType == "double")
         WriteLine("return Interop.IntAsFloat(result);");
     else if (func.ReturnType != "void")
         WriteLine("return result;");


### PR DESCRIPTION
Fixes #781.

The issue with JN is that we are generating the wrong NVVM/LLVM code, used for extracting the PTX. It does not support the .NET type names of `int`, `long`, `uint` and `ulong`. Instead, we use the types `i32` and `i64`.

Upon further testing, also discovered an issue with `Half` type. The generated PTX uses the `b32` register, and the NVVM code uses the `i16` type.

@m4rs-mt I have based this commit on the ILGPU v1.1.0 tag, in case we wanted to do create an ILGPU v1.1.1 patch release.