### PR TITLE
Added support for adjusting copyright headers on JS files.

### DIFF
--- a/Tools/CopyrightUpdateTool/Parsers/SourceCodeCopyrightParser.cs
+++ b/Tools/CopyrightUpdateTool/Parsers/SourceCodeCopyrightParser.cs
@@ -35,7 +35,7 @@ namespace CopyrightUpdateTool.Parsers
         private readonly ImmutableHashSet<string> SupportedExtensions =
             ImmutableHashSet.CreateRange(
                 StringComparer.OrdinalIgnoreCase,
-                new[] { ".cs", ".fs", ".tt", ".ttinclude", ".ps1" });
+                new[] { ".cs", ".fs", ".tt", ".ttinclude", ".ps1", ".js" });
 
         /// <summary>
         /// The delimeter used for padding the line.


### PR DESCRIPTION
Needed to handle the recently added `Samples\BlazorSampleApp\wwwroot\Scripts\BasicCanvas.js`.