### PR TITLE
Add support for Arm and Arm64 architectures

### DIFF
--- a/Src/ILGPU.Tests/.test.tt
+++ b/Src/ILGPU.Tests/.test.tt
@@ -1,14 +1,11 @@
 ﻿<#@ template debug="false" hostspecific="false" language="C#" #>
 <#@ assembly name="System.Core" #>
 <#@ output extension=".runsettings" #>
+<#@ import namespace="System.Runtime.InteropServices" #>
 <?xml version="1.0" encoding="utf-8"?>
 <RunSettings>
   <RunConfiguration>
     <!-- Run on native platform architecture. -->
-<# if (Environment.Is64BitOperatingSystem) { #>
-    <TargetPlatform>x64</TargetPlatform>
-<# } else { #>
-    <TargetPlatform>x86</TargetPlatform>
-<# } #>
+    <TargetPlatform><#= RuntimeInformation.ProcessArchitecture #></TargetPlatform>
   </RunConfiguration>
 </RunSettings>

--- a/Src/ILGPU/Backends/Backend.cs
+++ b/Src/ILGPU/Backends/Backend.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2017-2021 ILGPU Project
+//                        Copyright (c) 2017-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Backend.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace ILGPU.Backends
 {
@@ -41,6 +42,35 @@ namespace ILGPU.Backends
         /// The X64 target platform.
         /// </summary>
         X64,
+
+        /// <summary>
+        /// The Arm target platform.
+        /// </summary>
+        Arm,
+
+        /// <summary>
+        /// The Arm64 target platform.
+        /// </summary>
+        Arm64,
+    }
+
+    /// <summary>
+    /// Extension methods for TargetPlatform related objects.
+    /// </summary>
+    public static class TargetPlatformExtensions
+    {
+        /// <summary>
+        /// Returns true if the current runtime platform is 64-bit.
+        /// </summary>
+        public static bool Is64Bit(this TargetPlatform targetPlatform) =>
+                targetPlatform switch
+                {
+                    TargetPlatform.X86 => false,
+                    TargetPlatform.X64 => true,
+                    TargetPlatform.Arm => false,
+                    TargetPlatform.Arm64 => true,
+                    _ => throw new NotSupportedException(),
+                };
     }
 
     /// <summary>
@@ -375,13 +405,27 @@ namespace ILGPU.Backends
         /// Returns the current execution platform.
         /// </summary>
         public static TargetPlatform RuntimePlatform =>
-            IntPtr.Size == 8 ? TargetPlatform.X64 : TargetPlatform.X86;
+            RuntimeInformation.ProcessArchitecture switch
+            {
+                Architecture.X86 => TargetPlatform.X86,
+                Architecture.X64 => TargetPlatform.X64,
+                Architecture.Arm => TargetPlatform.Arm,
+                Architecture.Arm64 => TargetPlatform.Arm64,
+                _ => throw new NotSupportedException(),
+            };
 
         /// <summary>
         /// Returns the native OS platform.
         /// </summary>
         public static TargetPlatform OSPlatform =>
-            Environment.Is64BitOperatingSystem ? TargetPlatform.X64 : TargetPlatform.X86;
+            RuntimeInformation.OSArchitecture switch
+            {
+                Architecture.X86 => TargetPlatform.X86,
+                Architecture.X64 => TargetPlatform.X64,
+                Architecture.Arm => TargetPlatform.Arm,
+                Architecture.Arm64 => TargetPlatform.Arm64,
+                _ => throw new NotSupportedException(),
+            };
 
         /// <summary>
         /// Returns true if the current runtime platform is equal to the OS platform.

--- a/Src/ILGPU/Frontend/CodeGenerator/Objects.cs
+++ b/Src/ILGPU/Frontend/CodeGenerator/Objects.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2018-2021 ILGPU Project
+//                        Copyright (c) 2018-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Objects.cs
@@ -148,12 +148,7 @@ namespace ILGPU.Frontend
             }
             else
             {
-                var pointerSize = TypeContext.TargetPlatform switch
-                {
-                    TargetPlatform.X86 => 4,
-                    TargetPlatform.X64 => 8,
-                    _ => throw new NotImplementedException()
-                };
+                var pointerSize = TypeContext.TargetPlatform.Is64Bit() ? 8 : 4;
                 Load(pointerSize);
             }
         }

--- a/Src/ILGPU/IR/Types/PointerTypes.cs
+++ b/Src/ILGPU/IR/Types/PointerTypes.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2018-2021 ILGPU Project
+//                        Copyright (c) 2018-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: PointerTypes.cs
@@ -165,15 +165,15 @@ namespace ILGPU.IR.Types
             MemoryAddressSpace addressSpace)
             : base(typeContext, elementType, addressSpace)
         {
-            if (typeContext.TargetPlatform == TargetPlatform.X86)
-            {
-                Size = Alignment = 4;
-                BasicValueType = BasicValueType.Int32;
-            }
-            else
+            if (typeContext.TargetPlatform.Is64Bit())
             {
                 Size = Alignment = 8;
                 BasicValueType = BasicValueType.Int64;
+            }
+            else
+            {
+                Size = Alignment = 4;
+                BasicValueType = BasicValueType.Int32;
             }
             AddFlags(TypeFlags.PointerDependent);
         }

--- a/Src/ILGPU/Resources/RuntimeErrorMessages.Designer.cs
+++ b/Src/ILGPU/Resources/RuntimeErrorMessages.Designer.cs
@@ -99,9 +99,9 @@ namespace ILGPU.Resources {
         /// <summary>
         ///   Looks up a localized string similar to Cuda accelerator requires 64-bit application ({0} not supported). Ensure Prefer32Bit is set to &apos;false&apos;..
         /// </summary>
-        internal static string CudaPlatformX64 {
+        internal static string CudaPlatform64 {
             get {
-                return ResourceManager.GetString("CudaPlatformX64", resourceCulture);
+                return ResourceManager.GetString("CudaPlatform64", resourceCulture);
             }
         }
         

--- a/Src/ILGPU/Resources/RuntimeErrorMessages.resx
+++ b/Src/ILGPU/Resources/RuntimeErrorMessages.resx
@@ -129,7 +129,7 @@
   <data name="CudaNotSupported" xml:space="preserve">
     <value>Cuda is not supported on this platform</value>
   </data>
-  <data name="CudaPlatformX64" xml:space="preserve">
+  <data name="CudaPlatform64" xml:space="preserve">
     <value>Cuda accelerator requires 64-bit application ({0} not supported). Ensure Prefer32Bit is set to 'false'.</value>
   </data>
   <data name="InvalidCodeGenerationOperation0" xml:space="preserve">

--- a/Src/ILGPU/Runtime/Cuda/CudaContextExtensions.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaContextExtensions.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: CudaContextExtensions.cs
@@ -47,10 +47,10 @@ namespace ILGPU.Runtime.Cuda
             this Context.Builder builder,
             Predicate<CudaDevice> predicate)
         {
-            if (Backend.RuntimePlatform != TargetPlatform.X64)
+            if (!Backend.RuntimePlatform.Is64Bit())
             {
                 throw new NotSupportedException(string.Format(
-                    RuntimeErrorMessages.CudaPlatformX64,
+                    RuntimeErrorMessages.CudaPlatform64,
                     Backend.RuntimePlatform));
             }
 


### PR DESCRIPTION
This PR adds basic support for running ILGPU on Arm and Arm64 architectures.
It address partially #769, allowing the CPU backend to be used for testing/debugging kernels.
It also adds support for using CUDA on Arm and Arm64 (e.g. NVIDIA's [Grace](https://www.nvidia.com/en-gb/data-center/grace-cpu/)).