### PR TITLE
Fixed CodeQL scanning 'Error' alerts.

### DIFF
--- a/Samples/AlgorithmsRadixSort/Program.cs
+++ b/Samples/AlgorithmsRadixSort/Program.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                    ILGPU Samples
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Program.cs
@@ -56,7 +56,7 @@ namespace AlgorithmsRadixSort
                 Console.WriteLine($"Performing operations on {accelerator}");
 
                 // Allocate the source buffer that will be sorted later on.
-                var sourceBuffer = accelerator.Allocate1D<int>(32);
+                using var sourceBuffer = accelerator.Allocate1D<int>(32);
                 accelerator.Sequence(
                     accelerator.DefaultStream,
                     sourceBuffer.View,
@@ -111,8 +111,6 @@ namespace AlgorithmsRadixSort
                     for (int i = 0, e = data.Length; i < e; ++i)
                         Console.WriteLine($"Data[{i}] = {data[i]}");
                 }
-
-                sourceBuffer.Dispose();
             }
         }
     }

--- a/Samples/AlgorithmsScan/Program.cs
+++ b/Samples/AlgorithmsScan/Program.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                    ILGPU Samples
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Program.cs
@@ -29,7 +29,7 @@ namespace AlgorithmsScan
                 using var accelerator = device.CreateAccelerator(context);
                 Console.WriteLine($"Performing operations on {accelerator}");
 
-                var sourceBuffer = accelerator.Allocate1D<int>(32);
+                using var sourceBuffer = accelerator.Allocate1D<int>(32);
                 accelerator.Initialize(accelerator.DefaultStream, sourceBuffer.View, 2);
 
                 // The parallel scan implementation needs temporary storage.
@@ -126,8 +126,6 @@ namespace AlgorithmsScan
                     for (int i = 0, e = data.Length; i < e; ++i)
                         Console.WriteLine($"Data[{i}] = {data[i]}");
                 }
-
-                sourceBuffer.Dispose();
             }
         }
     }

--- a/Samples/AlgorithmsTransform/Program.cs
+++ b/Samples/AlgorithmsTransform/Program.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                    ILGPU Samples
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Program.cs
@@ -61,7 +61,7 @@ namespace AlgorithmsTransform
                 using var accelerator = device.CreateAccelerator(context);
                 Console.WriteLine($"Performing operations on {accelerator}");
 
-                var sourceBuffer = accelerator.Allocate1D<int>(64);
+                using var sourceBuffer = accelerator.Allocate1D<int>(64);
                 accelerator.Initialize(accelerator.DefaultStream, sourceBuffer.View, 2);
 
                 using (var targetBuffer = accelerator.Allocate1D<CustomStruct>(64))
@@ -104,8 +104,6 @@ namespace AlgorithmsTransform
                     for (int i = 0, e = data.Length; i < e; ++i)
                         Console.WriteLine($"Data[{i}] = {data[i]}");
                 }
-
-                sourceBuffer.Dispose();
             }
         }
     }

--- a/Samples/BlazorSampleApp/ILGPUWebHost/ComputeHost.cs
+++ b/Samples/BlazorSampleApp/ILGPUWebHost/ComputeHost.cs
@@ -97,19 +97,11 @@ namespace BlazorSampleApp.ILGPUWebHost
                     
                     if (types.Exists(x => x == device.AcceleratorType))
                     {
-
-                        var accelerator = device.CreateAccelerator(_context);
-
-                        if (accelerator.MemorySize >= minimumMemory && accelerator.NumMultiprocessors >= multiProcessors)
+                        if (device.MemorySize > minimumMemory && device.NumMultiprocessors >= multiProcessors)
                         {
-
-                            result = true;
-
+                            var accelerator = device.CreateAccelerator(_context);
                             _accelerators.Add(accelerator);
-                        }
-                        else
-                        {
-                            accelerator.Dispose();
+                            result = true;
                         }
                     }
                 }

--- a/Samples/BlazorSampleApp/MandelbrotExplorer/MandelbrotBasic.cs
+++ b/Samples/BlazorSampleApp/MandelbrotExplorer/MandelbrotBasic.cs
@@ -128,9 +128,9 @@ namespace BlazorSampleApp.MandelbrotExplorer
         {
             _computing = true;
             int num_values = buffer.Length;
-            var dev_out = _accelerator.Allocate1D<int>(num_values);
-            var displayParams = _accelerator.Allocate1D<int>(dispayPort);
-            var viewAreaParams = _accelerator.Allocate1D<float>(viewArea);
+            using var dev_out = _accelerator.Allocate1D<int>(num_values);
+            using var displayParams = _accelerator.Allocate1D<int>(dispayPort);
+            using var viewAreaParams = _accelerator.Allocate1D<float>(viewArea);
 
 
             if (!_disposing)
@@ -142,14 +142,10 @@ namespace BlazorSampleApp.MandelbrotExplorer
             // Reads data from the GPU buffer into a new CPU array.
             // Implicitly calls accelerator.DefaultStream.Synchronize() to ensure
             // the kernel computation is complete.
-
-            displayParams.Dispose();
-            viewAreaParams.Dispose();
             if (!_disposing)
             {
                 dev_out.CopyToCPU(buffer);
             }
-            dev_out.Dispose();
             _computing = false;
 
             return;

--- a/Samples/SimpleMath/Program.cs
+++ b/Samples/SimpleMath/Program.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                    ILGPU Samples
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Program.cs
@@ -63,9 +63,9 @@ namespace SimpleMath
                 var kernel = accelerator.LoadAutoGroupedStreamKernel<
                     Index1D, ArrayView<float>, ArrayView<double>, ArrayView<double>>(MathKernel);
 
-                var buffer = accelerator.Allocate1D<float>(128);
-                var buffer2 = accelerator.Allocate1D<double>(128);
-                var buffer3 = accelerator.Allocate1D<double>(128);
+                using var buffer = accelerator.Allocate1D<float>(128);
+                using var buffer2 = accelerator.Allocate1D<double>(128);
+                using var buffer3 = accelerator.Allocate1D<double>(128);
 
                 // Launch buffer.Length many threads
                 kernel((int)buffer.Length, buffer.View, buffer2.View, buffer3.View);
@@ -78,10 +78,6 @@ namespace SimpleMath
                 var data3 = buffer3.GetAsArray1D();
                 for (int i = 0, e = data.Length; i < e; ++i)
                     Console.WriteLine($"Math results: {data[i]} (float) {data2[i]} (double [GPUMath]) {data3[i]} (double [.Net Math])");
-
-                buffer.Dispose();
-                buffer2.Dispose();
-                buffer3.Dispose();
             }
         }
     }

--- a/Src/ILGPU.Algorithms/HistogramExtensions.cs
+++ b/Src/ILGPU.Algorithms/HistogramExtensions.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                   ILGPU Algorithms
-//                        Copyright (c) 2020-2021 ILGPU Project
+//                        Copyright (c) 2020-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: HistogramExtensions.cs
@@ -337,7 +337,6 @@ namespace ILGPU.Algorithms
                 var (gridDim, groupDim) = accelerator.ComputeGridStrideLoopExtent(
                        numElements,
                        out int numIterationsPerGroup);
-                int numVirtualGroups = gridDim * numIterationsPerGroup;
                 int lengthInformation =
                     XMath.DivRoundUp(numElements, groupDim) * groupDim;
 
@@ -412,7 +411,6 @@ namespace ILGPU.Algorithms
                 var (gridDim, groupDim) = accelerator.ComputeGridStrideLoopExtent(
                        numElements,
                        out int numIterationsPerGroup);
-                int numVirtualGroups = gridDim * numIterationsPerGroup;
                 int lengthInformation =
                     XMath.DivRoundUp(numElements, groupDim) * groupDim;
 

--- a/Src/ILGPU.Algorithms/RadixSortExtensions.cs
+++ b/Src/ILGPU.Algorithms/RadixSortExtensions.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                   ILGPU Algorithms
-//                        Copyright (c) 2019-2021 ILGPU Project
+//                        Copyright (c) 2019-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: RadixSortExtensions.cs
@@ -683,7 +683,8 @@ namespace ILGPU.Algorithms
                     for (int j = 0; j < specialization.UnrollFactor; ++j)
                     {
                         ref var newOffset = ref scanMemory[Group.IdxX + groupSize * j];
-                        newOffset += Utilities.Select(inRange & j == bits, 1, 0);
+                        newOffset += Utilities.Select(
+                            Bitwise.And(inRange, j == bits), 1, 0);
                         counter[j * numGroups + gridIdx] = newOffset;
                     }
                 }
@@ -691,7 +692,8 @@ namespace ILGPU.Algorithms
 
                 var gridSize = gridIdx * Group.DimX;
                 Index1D pos = gridSize + scanMemory[Group.IdxX + groupSize * bits] -
-                    Utilities.Select(inRange & Group.IdxX == Group.DimX - 1, 1, 0);
+                    Utilities.Select(
+                        Bitwise.And(inRange, Group.IdxX == Group.DimX - 1), 1, 0);
                 for (int j = 1; j <= bits; ++j)
                 {
                     pos += scanMemory[groupSize * j - 1] +

--- a/Src/ILGPU.Algorithms/ScanExtensions.cs
+++ b/Src/ILGPU.Algorithms/ScanExtensions.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                   ILGPU Algorithms
-//                        Copyright (c) 2019-2021 ILGPU Project
+//                        Copyright (c) 2019-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: ScanExtensions.cs
@@ -664,7 +664,6 @@ namespace ILGPU.Algorithms
 
             long numIntTElementsLong = ComputeNumIntElementsForSinglePassScan<T>();
             IndexTypeExtensions.AssertIntIndexRange(numIntTElementsLong);
-            int numIntTElements = (int)numIntTElementsLong;
 
             return (stream, input, output, temp) =>
             {

--- a/Src/ILGPU.Tests/Arrays.cs
+++ b/Src/ILGPU.Tests/Arrays.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Arrays.cs
@@ -10,6 +10,7 @@
 // ---------------------------------------------------------------------------------------
 
 using ILGPU.Runtime;
+using ILGPU.Util;
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
@@ -891,7 +892,7 @@ namespace ILGPU.Tests
         {
             int[] values = new[] { 0, 1 };
 
-            if (index == values[1] & constant == values[0])
+            if (Bitwise.And(index == values[1], constant == values[0]))
                 buffer[index] = 42;
             else
                 buffer[index] = 24;

--- a/Src/ILGPU.Tests/MemoryBufferOperations.tt
+++ b/Src/ILGPU.Tests/MemoryBufferOperations.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: MemoryBufferOperations.tt/MemoryBufferOperations.cs
@@ -14,6 +14,7 @@
 <#@ assembly name="System.Core" #>
 <#@ import namespace="System.IO" #>
 using ILGPU.Runtime;
+using ILGPU.Util;
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
@@ -112,7 +113,7 @@ namespace ILGPU.Tests
             ArrayView1D<T, Stride1D.Dense> output)
             where T : unmanaged
         {
-            if (index < input.Length & index < output.Length)
+            if (Bitwise.And(index < input.Length, index < output.Length))
                 output[index] = input[index];
         }
 

--- a/Src/ILGPU.Tests/UnaryFloatOperations.cs
+++ b/Src/ILGPU.Tests/UnaryFloatOperations.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: UnaryFloatOperations.cs
@@ -10,6 +10,9 @@
 // ---------------------------------------------------------------------------------------
 
 using ILGPU.Runtime;
+#if NETFRAMEWORK
+using ILGPU.Util;
+#endif
 using Xunit;
 using Xunit.Abstractions;
 
@@ -76,7 +79,10 @@ namespace ILGPU.Tests
             float value)
         {
 #if NETFRAMEWORK
-            data[index + 0] = (!float.IsNaN(value) & !float.IsInfinity(value)) ? 1 : 0;
+            data[index + 0] =
+                Bitwise.And(!float.IsNaN(value), !float.IsInfinity(value))
+                ? 1
+                : 0;
 #else
             data[index + 0] = float.IsFinite(value) ? 1 : 0;
 #endif
@@ -121,7 +127,10 @@ namespace ILGPU.Tests
             double value)
         {
 #if NETFRAMEWORK
-            data[index + 0] = (!double.IsNaN(value) & !double.IsInfinity(value)) ? 1 : 0;
+            data[index + 0] =
+                Bitwise.And(!double.IsNaN(value), !double.IsInfinity(value))
+                ? 1
+                : 0;
 #else
             data[index + 0] = double.IsFinite(value) ? 1 : 0;
 #endif

--- a/Src/ILGPU/Backends/IL/ILBackend.cs
+++ b/Src/ILGPU/Backends/IL/ILBackend.cs
@@ -153,7 +153,7 @@ namespace ILGPU.Backends.IL
                 out ImmutableArray<FieldInfo> taskArgumentMapping);
 
             MethodInfo kernelMethod;
-            using (var scopedLock = RuntimeSystem.DefineRuntimeMethod(
+            using (RuntimeSystem.DefineRuntimeMethod(
                 typeof(void),
                 CPUAcceleratorTask.ExecuteParameterTypes,
                 out var methodEmitter))

--- a/Src/ILGPU/Backends/OpenCL/CLKernelFunctionGenerator.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLKernelFunctionGenerator.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2019-2021 ILGPU Project
+//                        Copyright (c) 2019-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: CLKernelFunctionGenerator.cs
@@ -465,7 +465,7 @@ namespace ILGPU.Backends.OpenCL
             Builder.Append(tempCondition.ToString());
             Builder.AppendLine(")");
             PushIndent();
-            using (var statement = BeginStatement(CLInstructions.ReturnStatement)) { }
+            using (BeginStatement(CLInstructions.ReturnStatement)) { }
             PopIndent();
         }
 

--- a/Src/ILGPU/Backends/PTX/PTXBackend.cs
+++ b/Src/ILGPU/Backends/PTX/PTXBackend.cs
@@ -307,14 +307,17 @@ namespace ILGPU.Backends.PTX
             try
             {
                 // Add custom NVVM module.
-                var nvvmModuleBytes = Encoding.ASCII.GetBytes(nvvmModule);
-                fixed (byte* nvvmPtr = nvvmModuleBytes)
+                if (result == NvvmResult.NVVM_SUCCESS)
                 {
-                    result = NvvmAPI.AddModuleToProgram(
-                        program,
-                        new IntPtr(nvvmPtr),
-                        new IntPtr(nvvmModuleBytes.Length),
-                        null);
+                    var nvvmModuleBytes = Encoding.ASCII.GetBytes(nvvmModule);
+                    fixed (byte* nvvmPtr = nvvmModuleBytes)
+                    {
+                        result = NvvmAPI.AddModuleToProgram(
+                            program,
+                            new IntPtr(nvvmPtr),
+                            new IntPtr(nvvmModuleBytes.Length),
+                            null);
+                    }
                 }
 
                 // Add the LibDevice bit code.
@@ -355,12 +358,15 @@ namespace ILGPU.Backends.PTX
                 if (result == NvvmResult.NVVM_SUCCESS)
                 {
                     result = NvvmAPI.GetCompiledResult(program, out var compiledPTX);
-                    var compiledString =
-                        compiledPTX
-                        .Replace(".version", "//.version")
-                        .Replace(".target", "//.target")
-                        .Replace(".address_size", "//.address_size");
-                    builder.Append(compiledString);
+                    if (result == NvvmResult.NVVM_SUCCESS)
+                    {
+                        var compiledString =
+                            compiledPTX
+                            .Replace(".version", "//.version")
+                            .Replace(".target", "//.target")
+                            .Replace(".address_size", "//.address_size");
+                        builder.Append(compiledString);
+                    }
                 }
             }
             finally

--- a/Src/ILGPU/Backends/RegisterAllocator.cs
+++ b/Src/ILGPU/Backends/RegisterAllocator.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2018-2021 ILGPU Project
+//                        Copyright (c) 2018-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: RegisterAllocator.cs
@@ -132,12 +132,12 @@ namespace ILGPU.Backends
             /// <summary>
             /// Returns true if this register is a primitive register.
             /// </summary>
-            public bool IsPrimitive => this is PrimitiveRegister;
+            public virtual bool IsPrimitive => false;
 
             /// <summary>
             /// Returns true if this register is a compound register.
             /// </summary>
-            public bool IsCompound => this is CompoundRegister;
+            public virtual bool IsCompound => false;
 
             /// <summary>
             /// Returns the input error messages for assertion purposes.
@@ -160,6 +160,9 @@ namespace ILGPU.Backends
             {
                 Kind = description.Kind;
             }
+
+            /// <inheritdoc/>
+            public override bool IsPrimitive => true;
 
             /// <summary>
             /// Returns the actual register kind.
@@ -256,6 +259,9 @@ namespace ILGPU.Backends
             #endregion
 
             #region Properties
+
+            /// <inheritdoc/>
+            public override bool IsCompound => true;
 
             /// <summary>
             /// Returns the underlying type.

--- a/Src/ILGPU/Frontend/CodeGenerator/CodeGenerator.cs
+++ b/Src/ILGPU/Frontend/CodeGenerator/CodeGenerator.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2018-2021 ILGPU Project
+//                        Copyright (c) 2018-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: CodeGenerator.cs
@@ -417,7 +417,7 @@ namespace ILGPU.Frontend
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void VerifyStaticFieldLoad(FieldInfo field)
         {
-            Debug.Assert(field != null || !field.IsStatic, "Invalid field");
+            Debug.Assert(field != null && field.IsStatic, "Invalid field");
 
             bool isInitOnly = (field.Attributes & FieldAttributes.InitOnly) !=
                 FieldAttributes.InitOnly;
@@ -437,7 +437,7 @@ namespace ILGPU.Frontend
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void VerifyStaticFieldStore(FieldInfo field)
         {
-            Debug.Assert(field != null || !field.IsStatic, "Invalid field");
+            Debug.Assert(field != null && field.IsStatic, "Invalid field");
 
             if (Context.Properties.StaticFieldMode
                 < StaticFieldMode.IgnoreStaticFieldStores)

--- a/Src/ILGPU/Frontend/Intrinsic/RemappedIntrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/RemappedIntrinsics.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2018-2021 ILGPU Project
+//                        Copyright (c) 2018-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: RemappedIntrinsics.cs
@@ -47,8 +47,6 @@ namespace ILGPU.Frontend.Intrinsic
 
         static RemappedIntrinsics()
         {
-            var remappedType = typeof(RemappedIntrinsics);
-
             AddRemapping(
                 typeof(float),
                 CPUMathType,

--- a/Src/ILGPU/Frontend/Intrinsic/ViewIntrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/ViewIntrinsics.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2018-2021 ILGPU Project
+//                        Copyright (c) 2018-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: ViewIntrinsics.cs
@@ -93,7 +93,7 @@ namespace ILGPU.Frontend.Intrinsic
                     location,
                     instanceValue,
                     context[paramOffset++],
-                    context[paramOffset++]),
+                    context[paramOffset]),
                 ViewIntrinsicKind.GetSubViewImplicitLength =>
                     builder.CreateSubViewValue(
                         location,
@@ -108,7 +108,7 @@ namespace ILGPU.Frontend.Intrinsic
                     GetViewElementAddress(
                         ref context,
                         instanceValue,
-                        context[paramOffset++]),
+                        context[paramOffset]),
                 ViewIntrinsicKind.CastView => builder.CreateViewCast(
                     location,
                     instanceValue,
@@ -133,18 +133,18 @@ namespace ILGPU.Frontend.Intrinsic
                         instanceValue,
                         builder.CreateGetField(
                             location,
-                            context[paramOffset++],
+                            context[paramOffset],
                             new FieldAccess(0))),
                 ViewIntrinsicKind.AlignTo =>
                     builder.CreateAlignTo(
                         location,
                         instanceValue,
-                        context[paramOffset++]),
+                        context[paramOffset]),
                 ViewIntrinsicKind.AsAligned =>
                     builder.CreateAsAligned(
                         location,
                         instanceValue,
-                        context[paramOffset++]),
+                        context[paramOffset]),
                 _ => throw context.Location.GetNotSupportedException(
                     ErrorMessages.NotSupportedViewIntrinsic,
                     attribute.IntrinsicKind.ToString()),

--- a/Src/ILGPU/Half.cs
+++ b/Src/ILGPU/Half.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2020-2021 ILGPU Project
+//                        Copyright (c) 2020-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Half.cs
@@ -11,6 +11,7 @@
 
 using ILGPU.Frontend.Intrinsic;
 using ILGPU.IR.Values;
+using ILGPU.Util;
 using System;
 #if !DEBUG
 using System.Diagnostics;
@@ -396,7 +397,8 @@ namespace ILGPU
         /// <param name="half">The half value.</param>
         /// <returns>True, if the given half value represents a finite number.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsFinite(Half half) => !IsNaN(half) & !IsInfinity(half);
+        public static bool IsFinite(Half half) =>
+            Bitwise.And(!IsNaN(half), !IsInfinity(half));
 
         /// <summary>
         /// Implements a FP16 addition using FP32.

--- a/Src/ILGPU/IIndex.cs
+++ b/Src/ILGPU/IIndex.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2017-2021 ILGPU Project
+//                        Copyright (c) 2017-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: IIndex.cs
@@ -9,6 +9,7 @@
 // Source License. See LICENSE.txt for details.
 // ---------------------------------------------------------------------------------------
 
+using ILGPU.Util;
 using System;
 using System.Diagnostics;
 using System.Reflection;
@@ -110,7 +111,7 @@ namespace ILGPU
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void AssertIntIndex(long index) =>
             Trace.Assert(
-                index >= int.MinValue & index <= int.MaxValue,
+                Bitwise.And(index >= int.MinValue, index <= int.MaxValue),
                 "32-bit index expected");
 
         /// <summary>
@@ -120,7 +121,7 @@ namespace ILGPU
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void AssertIntIndexRange(long range) =>
             Trace.Assert(
-                range >= int.MinValue & range <= int.MaxValue,
+                Bitwise.And(range >= int.MinValue, range <= int.MaxValue),
                 "32-bit index out of range");
 
         /// <summary>

--- a/Src/ILGPU/IR/Analyses/Movement.cs
+++ b/Src/ILGPU/IR/Analyses/Movement.cs
@@ -290,7 +290,7 @@ namespace ILGPU.IR.Analyses
             // semantics by violating the order of load/store operations
             int increment = startIndex > valueIndex ? -1 : 1;
             for (int i = startIndex + increment;
-                lower && i > valueIndex || i < valueIndex;
+                i > valueIndex || i < valueIndex;
                 i += increment)
             {
                 if (!CanSkip(memoryValue, values[i]))

--- a/Src/ILGPU/IR/BasicBlock.cs
+++ b/Src/ILGPU/IR/BasicBlock.cs
@@ -312,6 +312,9 @@ namespace ILGPU.IR
 
         #region Properties
 
+        /// <inheritdoc/>
+        public override bool IsBasicBlock => true;
+
         /// <summary>
         /// Returns the parent IR method.
         /// </summary>

--- a/Src/ILGPU/IR/Construction/ArithmeticOperations.tt
+++ b/Src/ILGPU/IR/Construction/ArithmeticOperations.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2016-2021 ILGPU Project
+//                        Copyright (c) 2016-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: ArithmeticOperations.tt/ArithmeticOperations.cs
@@ -140,8 +140,18 @@ namespace ILGPU.IR.Construction
 <#          foreach (var rewriter in op.Rewriters) { #>
 <#              if (rewriter.Mode == MathOpRewriterMode.CombineOperation) { #>
                     {
-                        if (value is <#= rewriter.Type #> nested &&
-                            <#= rewriter.MakeSourceExpr("value", "nested") #>)
+                        if (value is <#= rewriter.Type #> nested
+                            <#
+                                var sourceExpr =
+                                    rewriter.MakeSourceExpr("value", "nested");
+                                if (!sourceExpr.Equals(
+                                    "true",
+                                    StringComparison.OrdinalIgnoreCase))
+                                {
+                                    Write(" && ");
+                                    Write(sourceExpr);
+                                }
+                            #>)
                         {
                             return <#= rewriter.MakeTargetExpr("value", "nested") #>;
                         }

--- a/Src/ILGPU/IR/Method.cs
+++ b/Src/ILGPU/IR/Method.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2018-2021 ILGPU Project
+//                        Copyright (c) 2018-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Method.cs
@@ -416,6 +416,9 @@ namespace ILGPU.IR
         #endregion
 
         #region Properties
+
+        /// <inheritdoc/>
+        public override bool IsMethod => true;
 
         /// <summary>
         /// Returns the associated IR context reference.

--- a/Src/ILGPU/IR/Transformations/IfConversion.cs
+++ b/Src/ILGPU/IR/Transformations/IfConversion.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2019-2021 ILGPU Project
+//                        Copyright (c) 2019-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: IfConversion.cs
@@ -1319,7 +1319,7 @@ namespace ILGPU.IR.Transformations
             /// Returns true if the given block should be maintained.
             /// </summary>
             private readonly bool IsBlockToKeep(BasicBlock block) =>
-                block == EntryBlock | CaseBlocks.Contains(block);
+                Bitwise.Or(block == EntryBlock, CaseBlocks.Contains(block));
 
             /// <summary>
             /// Returns true if the given block is an exit block.

--- a/Src/ILGPU/IR/Transformations/IntrinsicSpecializer.cs
+++ b/Src/ILGPU/IR/Transformations/IntrinsicSpecializer.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2018-2021 ILGPU Project
+//                        Copyright (c) 2018-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: IntrinsicSpecializer.cs
@@ -108,8 +108,6 @@ namespace ILGPU.IR.Transformations
             // Analyze intrinsic nodes
             foreach (Value value in blocks.Values)
             {
-                var blockBuilder = builder[value.BasicBlock];
-
                 // Check intrinsic implementations
                 if (provider.TryGetImplementation(value, out var implementation))
                 {

--- a/Src/ILGPU/IR/Types/ArrayType.cs
+++ b/Src/ILGPU/IR/Types/ArrayType.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2019-2021 ILGPU Project
+//                        Copyright (c) 2019-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: ArrayType.cs
@@ -43,6 +43,9 @@ namespace ILGPU.IR.Types
         #endregion
 
         #region Properties
+
+        /// <inheritdoc/>
+        public override bool IsArrayType => true;
 
         /// <summary>
         /// Returns the underlying element type.

--- a/Src/ILGPU/IR/Types/IRTypeContext.cs
+++ b/Src/ILGPU/IR/Types/IRTypeContext.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2018-2021 ILGPU Project
+//                        Copyright (c) 2018-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: IRTypeContext.cs
@@ -52,8 +52,9 @@ namespace ILGPU.IR.Types
         /// True if the given value type is a compatible view index type.
         /// </returns>
         internal static bool IsViewIndexType(BasicValueType basicValueType) =>
-            basicValueType == BasicValueType.Int32 |
-            basicValueType == BasicValueType.Int64;
+            Bitwise.Or(
+                basicValueType == BasicValueType.Int32,
+                basicValueType == BasicValueType.Int64);
 
         #endregion
 

--- a/Src/ILGPU/IR/Types/ObjectType.cs
+++ b/Src/ILGPU/IR/Types/ObjectType.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2019-2021 ILGPU Project
+//                        Copyright (c) 2019-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: ObjectType.cs
@@ -25,6 +25,13 @@ namespace ILGPU.IR.Types
         protected ObjectType(IRTypeContext typeContext)
             : base(typeContext)
         { }
+
+        #endregion
+
+        #region Properties
+
+        /// <inheritdoc/>
+        public override bool IsObjectType => true;
 
         #endregion
     }

--- a/Src/ILGPU/IR/Types/PaddingType.cs
+++ b/Src/ILGPU/IR/Types/PaddingType.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2020-2021 ILGPU Project
+//                        Copyright (c) 2020-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: PaddingType.cs
@@ -37,6 +37,9 @@ namespace ILGPU.IR.Types
         #endregion
 
         #region Properties
+
+        /// <inheritdoc/>
+        public override bool IsPaddingType => true;
 
         /// <summary>
         /// Returns the associated basic value type.

--- a/Src/ILGPU/IR/Types/PointerTypes.cs
+++ b/Src/ILGPU/IR/Types/PointerTypes.cs
@@ -182,6 +182,9 @@ namespace ILGPU.IR.Types
 
         #region Properties
 
+        /// <inheritdoc/>
+        public override bool IsPointerType => true;
+
         /// <summary>
         /// Returns the associated basic value type.
         /// </summary>
@@ -237,6 +240,13 @@ namespace ILGPU.IR.Types
             Size = Alignment = 4;
             AddFlags(TypeFlags.ViewDependent);
         }
+
+        #endregion
+
+        #region Properties
+
+        /// <inheritdoc/>
+        public override bool IsViewType => true;
 
         #endregion
 

--- a/Src/ILGPU/IR/Types/PrimitiveTypes.cs
+++ b/Src/ILGPU/IR/Types/PrimitiveTypes.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2018-2021 ILGPU Project
+//                        Copyright (c) 2018-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: PrimitiveTypes.cs
@@ -84,6 +84,9 @@ namespace ILGPU.IR.Types
 
         #region Properties
 
+        /// <inheritdoc/>
+        public override bool IsPrimitiveType => true;
+
         /// <summary>
         /// Returns the associated basic value type.
         /// </summary>
@@ -151,6 +154,13 @@ namespace ILGPU.IR.Types
         internal StringType(IRTypeContext typeContext)
             : base(typeContext)
         { }
+
+        #endregion
+
+        #region Properties
+
+        /// <inheritdoc/>
+        public override bool IsStringType => true;
 
         #endregion
 

--- a/Src/ILGPU/IR/Types/StructureType.cs
+++ b/Src/ILGPU/IR/Types/StructureType.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2018-2021 ILGPU Project
+//                        Copyright (c) 2018-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: StructureType.cs
@@ -731,6 +731,12 @@ namespace ILGPU.IR.Types
         #endregion
 
         #region Properties
+
+        /// <inheritdoc/>
+        public override bool IsStructureType => true;
+
+        /// <inheritdoc/>
+        public override bool IsRootType => NumFields < 1;
 
         /// <summary>
         /// Returns the high-level fields stored in this structure type.

--- a/Src/ILGPU/IR/Types/TypeNode.cs
+++ b/Src/ILGPU/IR/Types/TypeNode.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2018-2021 ILGPU Project
+//                        Copyright (c) 2018-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: TypeNode.cs
@@ -143,60 +143,58 @@ namespace ILGPU.IR.Types
         /// <summary>
         /// Returns true if the current type is a <see cref="VoidType"/>.
         /// </summary>
-        public bool IsVoidType => this is VoidType;
+        public virtual bool IsVoidType => false;
 
         /// <summary>
         /// Returns true if the current type is a <see cref="StringType"/>.
         /// </summary>
-        public bool IsStringType => this is StringType;
+        public virtual bool IsStringType => false;
 
         /// <summary>
         /// Returns true if the current type is a <see cref="PrimitiveType"/>.
         /// </summary>
-        public bool IsPrimitiveType => this is PrimitiveType;
+        public virtual bool IsPrimitiveType => false;
 
         /// <summary>
-        /// Returns true if the current type is a <see cref="PointerType"/>
+        /// Returns true if the current type is a <see cref="AddressSpaceType"/>
         /// or a <see cref="ViewType"/>.
         /// </summary>
-        public bool IsViewOrPointerType => this is AddressSpaceType;
+        public bool IsViewOrPointerType => IsViewType || IsPointerType;
 
         /// <summary>
         /// Returns true if the current type is a <see cref="PointerType"/>.
         /// </summary>
-        public bool IsPointerType => this is PointerType;
+        public virtual bool IsPointerType => false;
 
         /// <summary>
         /// Returns true if the current type is a <see cref="ViewType"/>.
         /// </summary>
-        public bool IsViewType => this is ViewType;
+        public virtual bool IsViewType => false;
 
         /// <summary>
         /// Returns true if the current type is a <see cref="ArrayType"/>.
         /// </summary>
-        public bool IsArrayType => this is ArrayType;
+        public virtual bool IsArrayType => false;
 
         /// <summary>
         /// Returns true if the current type is an <see cref="ObjectType"/>.
         /// </summary>
-        public bool IsObjectType => this is ObjectType;
+        public virtual bool IsObjectType => false;
 
         /// <summary>
         /// Returns true if the current type is a <see cref="StructureType"/>.
         /// </summary>
-        public bool IsStructureType => this is StructureType;
+        public virtual bool IsStructureType => false;
 
         /// <summary>
         /// Returns true if the current type is a <see cref="PaddingType"/>.
         /// </summary>
-        public bool IsPaddingType => this is PaddingType;
+        public virtual bool IsPaddingType => false;
 
         /// <summary>
         /// Returns true if this type is a root object type.
         /// </summary>
-        public bool IsRootType =>
-            this is StructureType structureType &&
-            structureType.NumFields < 1;
+        public virtual bool IsRootType => false;
 
         /// <summary>
         /// Returns the basic value type.

--- a/Src/ILGPU/IR/Types/VoidType.cs
+++ b/Src/ILGPU/IR/Types/VoidType.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2018-2021 ILGPU Project
+//                        Copyright (c) 2018-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: VoidType.cs
@@ -27,6 +27,13 @@ namespace ILGPU.IR.Types
         internal VoidType(IRTypeContext typeContext)
             : base(typeContext)
         { }
+
+        #endregion
+
+        #region Properties
+
+        /// <inheritdoc/>
+        public override bool IsVoidType => true;
 
         #endregion
 

--- a/Src/ILGPU/IR/Values/Value.cs
+++ b/Src/ILGPU/IR/Values/Value.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2018-2021 ILGPU Project
+//                        Copyright (c) 2018-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Value.cs
@@ -769,12 +769,12 @@ namespace ILGPU.IR
         /// <summary>
         /// Returns true if this parent container is a block.
         /// </summary>
-        public bool IsBasicBlock => this is BasicBlock;
+        public virtual bool IsBasicBlock => false;
 
         /// <summary>
         /// Returns true if this container is method.
         /// </summary>
-        public bool IsMethod => this is Method;
+        public virtual bool IsMethod => false;
 
         #endregion
     }

--- a/Src/ILGPU/IndexTypes.tt
+++ b/Src/ILGPU/IndexTypes.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2016-2021 ILGPU Project
+//                        Copyright (c) 2016-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: IndexTypes.tt/IndexTypes.cs
@@ -17,6 +17,7 @@
 <#@ import namespace="System.Collections.Generic" #>
 <#@ output extension=".cs" #>
 
+using ILGPU.Util;
 using System;
 using System.Diagnostics;
 using System.Reflection;
@@ -152,7 +153,11 @@ namespace ILGPU
         /// Returns true if this is the first index.
         /// </summary>
         public readonly bool IsFirst =>
-            <#= def.Expression(" & ", dim => $"{dim} == 0") #>;
+<# if (dimension == 1) { #>
+            <#= def.Expression(", ", dim => $"{dim} == 0") #>;
+<# } else { #>
+            Bitwise.And(<#= def.Expression(", ", dim => $"{dim} == 0") #>);
+<# } #>
 
         /// <summary>
         /// Returns the size represented by this index.
@@ -228,7 +233,19 @@ namespace ILGPU
         /// <param name="dimension">The dimension bounds.</param>
         /// <returns>True if the current index is inside the given bounds.</returns>
         public readonly bool InBounds(<#= name #> dimension) =>
-            <#= def.Expression(" & ", p => $"{p} >= 0 & {p} < dimension.{p}") #>;
+<# if (dimension == 1) { #>
+            <#=
+                def.Expression(
+                    ", ",
+                    p => $"Bitwise.And({p} >= 0, {p} < dimension.{p})")
+            #>;
+<# } else { #>
+            Bitwise.And(<#=
+                def.Expression(
+                    ", ",
+                    p => $"Bitwise.And({p} >= 0, {p} < dimension.{p})")
+                #>);
+<# } #>
 
         /// <summary>
         /// Returns true if the current index is greater than or equal to 0 and
@@ -237,7 +254,19 @@ namespace ILGPU
         /// <param name="dimension">The dimension bounds.</param>
         /// <returns>True if the current index is inside the given bounds.</returns>
         public readonly bool InBoundsInclusive(<#= name #> dimension) =>
-            <#= def.Expression(" & ", p => $"{p} >= 0 & {p} <= dimension.{p}") #>;
+<# if (dimension == 1) { #>
+            <#=
+                def.Expression(
+                    ", ",
+                    p => $"Bitwise.And({p} >= 0, {p} <= dimension.{p})")
+            #>;
+<# } else { #>
+            Bitwise.And(<#=
+                def.Expression(
+                    ", ",
+                    p => $"Bitwise.And({p} >= 0, {p} <= dimension.{p})")
+            #>);
+<# } #>
 
         /// <summary>
         /// Computes this + right-hand side.
@@ -442,7 +471,11 @@ namespace ILGPU
         /// <param name="second">The second index.</param>
         /// <returns>True, if the first and second index are the same.</returns>
         public static bool operator ==(<#= name #> first, <#= name #> second) =>
-            <#= def.Expression(" & ", p => $"first.{p} == second.{p}") #>;
+<# if (dimension == 1) { #>
+            <#= def.Expression(", ", p => $"first.{p} == second.{p}") #>;
+<# } else { #>
+            Bitwise.And(<#= def.Expression(", ", p => $"first.{p} == second.{p}") #>);
+<# } #>
 
         /// <summary>
         /// Returns true if the first and second index are not the same.
@@ -451,7 +484,11 @@ namespace ILGPU
         /// <param name="second">The second index.</param>
         /// <returns>True, if the first and second index are not the same.</returns>
         public static bool operator !=(<#= name #> first, <#= name #> second) =>
-            <#= def.Expression(" | ", p => $"first.{p} != second.{p}") #>;
+<# if (dimension == 1) { #>
+            <#= def.Expression(", ", p => $"first.{p} == second.{p}") #>;
+<# } else { #>
+            Bitwise.Or(<#= def.Expression(", ", p => $"first.{p} != second.{p}") #>);
+<# } #>
 
         #endregion
     }

--- a/Src/ILGPU/KernelConfig.cs
+++ b/Src/ILGPU/KernelConfig.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2020-2021 ILGPU Project
+//                        Copyright (c) 2020-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: KernelConfig.cs
@@ -11,6 +11,7 @@
 
 using ILGPU.Backends.EntryPoints;
 using ILGPU.Resources;
+using ILGPU.Util;
 using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -194,8 +195,8 @@ namespace ILGPU
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get =>
-                GridDim.X > 0 & GridDim.Y > 0 & GridDim.Z > 0 &&
-                GroupDim.X > 0 & GroupDim.Y > 0 & GroupDim.Z > 0;
+                Bitwise.And(GridDim.X > 0, GridDim.Y > 0, GridDim.Z > 0) &&
+                Bitwise.And(GroupDim.X > 0, GroupDim.Y > 0, GroupDim.Z > 0);
         }
 
         /// <summary>
@@ -408,7 +409,8 @@ namespace ILGPU
         /// <summary>
         /// Returns true if this configuration uses dynamic shared memory.
         /// </summary>
-        public bool UsesDynamicSharedMemory => NumElements > 0 & ElementSize > 0;
+        public bool UsesDynamicSharedMemory =>
+            Bitwise.And(NumElements > 0, ElementSize > 0);
 
         #endregion
     }
@@ -548,8 +550,8 @@ namespace ILGPU
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get =>
-                GridDim.X > 0 & GridDim.Y > 0 & GridDim.Z > 0 &&
-                GroupDim.X > 0 & GroupDim.Y > 0 & GroupDim.Z > 0;
+                Bitwise.And(GridDim.X > 0, GridDim.Y > 0, GridDim.Z > 0) &&
+                Bitwise.And(GroupDim.X > 0, GroupDim.Y > 0, GroupDim.Z > 0);
         }
 
         #endregion

--- a/Src/ILGPU/Memory.tt
+++ b/Src/ILGPU/Memory.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2016-2021 ILGPU Project
+//                        Copyright (c) 2016-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Memory.tt/Memory.cs
@@ -24,6 +24,7 @@ var classes = new (string, string)[]
 };
 #>
 using ILGPU.Runtime;
+using ILGPU.Util;
 using System.Diagnostics;
 
 namespace ILGPU
@@ -65,10 +66,14 @@ namespace ILGPU
             where TStride : struct, IStride<#= dimension #>D
         {
             Trace.Assert(
-                <#= string.Join(
-                    " & ",
+<# if (dimension == 1) { #>
+                <#= $"extent.{IndexDimensions[0].PropertyName} >= 0" #>,
+<# } else { #>
+                Bitwise.And(<#= string.Join(
+                    ", ",
                     Enumerable.Range(0, dimension).
-                    Select(t => $"extent.{IndexDimensions[t].PropertyName} >= 0")) #>,
+                    Select(t => $"extent.{IndexDimensions[t].PropertyName} >= 0")) #>),
+<# } #>
                 "Extent out of bounds");
 
             var baseView = Allocate<T>((int)stride.ComputeBufferLength(extent));

--- a/Src/ILGPU/Runtime/Accelerator.cs
+++ b/Src/ILGPU/Runtime/Accelerator.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2016-2021 ILGPU Project
+//                        Copyright (c) 2016-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Accelerator.cs
@@ -389,7 +389,7 @@ namespace ILGPU.Runtime
                 kernel,
                 groupSize,
                 dynamicSharedMemorySizeInBytes);
-            return (maxActiveGroups * groupSize) / (float)MaxNumThreadsPerGroup;
+            return (float)(maxActiveGroups * groupSize) / MaxNumThreadsPerGroup;
         }
 
         /// <summary>

--- a/Src/ILGPU/Runtime/ArrayViewExtensions.cs
+++ b/Src/ILGPU/Runtime/ArrayViewExtensions.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: ArrayViewExtensions.cs
@@ -229,7 +229,7 @@ namespace ILGPU.Runtime
         /// <returns>True, this view has a least one valid data element.</returns>
         public static bool HasData<TView>(this TView view)
             where TView : IArrayView =>
-            view.IsValid & view.Length > 0;
+            Bitwise.And(view.IsValid, view.Length > 0);
 
         /// <summary>
         /// Returns the associated accelerator of the current view.

--- a/Src/ILGPU/Runtime/ArrayViewExtensions.cs
+++ b/Src/ILGPU/Runtime/ArrayViewExtensions.cs
@@ -872,7 +872,6 @@ namespace ILGPU.Runtime
 
                 // Reorder the input elements and store them in the result buffer
                 var extent = (Index1D)view.Extent;
-                var stride = view.Stride;
                 for (int x = 0; x < extent.X; ++x)
                 {
                     int targetElementIndex = view.Stride.ComputeElementIndex(x);
@@ -937,7 +936,6 @@ namespace ILGPU.Runtime
 
                 // Reorder the input elements and store them in the result buffer
                 var extent = (Index2D)view.Extent;
-                var stride = view.Stride;
                 for (int x = 0; x < extent.X; ++x)
                 {
                     for (int y = 0; y < extent.Y; ++y)
@@ -1012,7 +1010,6 @@ namespace ILGPU.Runtime
 
                 // Reorder the input elements and store them in the result buffer
                 var extent = (Index3D)view.Extent;
-                var stride = view.Stride;
                 for (int x = 0; x < extent.X; ++x)
                 {
                     for (int y = 0; y < extent.Y; ++y)

--- a/Src/ILGPU/Runtime/ArrayViews.tt
+++ b/Src/ILGPU/Runtime/ArrayViews.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2016-2021 ILGPU Project
+//                        Copyright (c) 2016-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: ArrayViews.tt/ArrayViews.cs
@@ -18,6 +18,7 @@
 <#@ output extension=".cs" #>
 <# var alignmentValues = new int[] { 16, 32, 64, 128, 256, 512 }; #>
 
+using ILGPU.Util;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -298,9 +299,11 @@ namespace ILGPU.Runtime
 <#          var iName = IndexDimensions[i].PropertyName; #>
 <#          var thisExtent = $"({baseType})Extent.{iName}"; #>
             Trace.Assert(
-                index.<#= iName #> >= 0 &
-                (index.<#= iName #> + extent.<#= iName #> <= <#= thisExtent #>
-                 | (index.<#= iName #> == 0 & extent.<#= iName #> == 0)),
+                Bitwise.And(
+                    index.<#= iName #> >= 0,
+                    Bitwise.Or(
+                        index.<#= iName #> + extent.<#= iName #> <= <#= thisExtent #>,
+                        Bitwise.And(index.<#= iName #> == 0, extent.<#= iName #> == 0))),
                 "Index/Extent <#= iName #> out of bounds");
 <#      } #>
             <#= baseType #> offset = ComputeLinearIndex(index);

--- a/Src/ILGPU/Runtime/OpenCL/CLMemoryBuffer.cs
+++ b/Src/ILGPU/Runtime/OpenCL/CLMemoryBuffer.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2019-2021 ILGPU Project
+//                        Copyright (c) 2019-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: CLMemoryBuffer.cs
@@ -81,7 +81,6 @@ namespace ILGPU.Runtime.OpenCL
 
             var source = sourceView.Buffer;
             var target = targetView.Buffer;
-            var length = new IntPtr(targetView.LengthInBytes);
 
             if (sourceType == AcceleratorType.CPU &&
                 targetType == AcceleratorType.OpenCL)

--- a/Src/ILGPU/Static/ArithmeticEnums.tt
+++ b/Src/ILGPU/Static/ArithmeticEnums.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2016-2021 ILGPU Project
+//                        Copyright (c) 2016-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: ArithmeticEnums.tt/ArithmeticEnums.cs
@@ -93,13 +93,17 @@ namespace ILGPU.IR.Values
         /// <param name="kind">The kind to test.</param>
         /// <returns>True, if the given kind is commutative.</returns>
         public static bool IsCommutative(this TernaryArithmeticKind kind) =>
+<# if (ternaryOps.Where(t => t.IsCommutative).Any()) { #>
             kind switch
             {
-<# foreach (var op in ternaryOps.Where(t => t.IsCommutative)) { #>
+<#      foreach (var op in ternaryOps.Where(t => t.IsCommutative)) { #>
                 TernaryArithmeticKind.<#= op.Name #> => true,
-<# } #>
+<#      } #>
                 _ => false
             };
+<# } else { #>
+            false;
+<# } #>
     }
 }
 

--- a/Src/ILGPU/Static/BinaryMathOperations.xml
+++ b/Src/ILGPU/Static/BinaryMathOperations.xml
@@ -118,7 +118,7 @@
     <Operation Name="And" IsCommutative="true">
         <Summary>The logical and operation.</Summary>
         <Flags>BoolsAndInts</Flags>
-        <Op>{Value0} &amp; {Value1}</Op>
+        <Op>Bitwise.And({Value0}, {Value1})</Op>
         <Rewriter>
             <Source>{Value0} == {Value1}</Source>
             <Target>{Value0}</Target>
@@ -138,7 +138,7 @@
     <Operation Name="Or" IsCommutative="true">
         <Summary>The logical or operation.</Summary>
         <Flags>BoolsAndInts</Flags>
-        <Op>{Value0} | {Value1}</Op>
+        <Op>Bitwise.Or({Value0}, {Value1})</Op>
         <Rewriter>
             <Source>{Value0} == {Value1}</Source>
             <Target>{Value0}</Target>

--- a/Src/ILGPU/StrideTypes.tt
+++ b/Src/ILGPU/StrideTypes.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2016-2021 ILGPU Project
+//                        Copyright (c) 2016-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: StrideTypes.tt/StrideTypes.cs
@@ -17,6 +17,7 @@
 <#@ import namespace="System.Collections.Generic" #>
 <#@ output extension=".cs" #>
 
+using ILGPU.Util;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
@@ -133,7 +134,7 @@ namespace ILGPU
                     "Reconstruction of general strides is not supported");
                 return <#= indexName #>.Invalid;
             }
-            
+
             /// <summary>
             /// Reconstructs a 64-bit index from a linear element index.
             /// </summary>
@@ -270,7 +271,7 @@ namespace ILGPU
             public readonly <#= indexName #> ReconstructFromElementIndex(
                 int elementIndex) =>
                 elementIndex;
-            
+
             /// <summary>
             /// Reconstructs a 64-bit index from a linear element index.
             /// </summary>
@@ -557,10 +558,13 @@ namespace ILGPU
 <#      for (int i = 0; i < def.Dimension; ++i) { #>
 <#          var iName = IndexDimensions[i].PropertyName; #>
             Trace.Assert(
-                // Default bound checks
-                index.<#= iName #> >= 0 & index.<#= iName #> < extent.<#= iName #> |
-                // Zero length views
-                index.<#= iName #> == 0 & extent.<#= iName #> == 0,
+                Bitwise.Or(
+                    // Default bound checks
+                    Bitwise.And(
+                        index.<#= iName #> >= 0,
+                        index.<#= iName #> < extent.<#= iName #>),
+                    // Zero length views
+                    Bitwise.And(index.<#= iName #> == 0, extent.<#= iName #> == 0)),
                 "<#= iName #> index out of bounds");
 <#      } #>
             return stride.ComputeElementIndex(index);
@@ -584,8 +588,9 @@ namespace ILGPU
 <#      for (int i = 0; i < def.Dimension; ++i) { #>
 <#          var iName = IndexDimensions[i].PropertyName; #>
             Trace.Assert(
-                index.<#= iName #> >= 0 &
-                index.<#= iName #> < extent.<#= iName #>,
+                Bitwise.And(
+                    index.<#= iName #> >= 0,
+                    index.<#= iName #> < extent.<#= iName #>),
                 "<#= iName #> index out of bounds");
 <#      } #>
             return stride.ComputeElementIndex(index);
@@ -601,7 +606,8 @@ namespace ILGPU
         public static int ComputeBufferLength<TStride>(
             this TStride stride,
             <#= indexName #> extent)
-            where TStride : <#= strideName #> {
+            where TStride : <#= strideName #>
+        {
 <#      for (int i = 0; i < def.Dimension; ++i) { #>
 <#          var iName = IndexDimensions[i].PropertyName; #>
             if (extent.<#= iName #> == 0)
@@ -620,7 +626,8 @@ namespace ILGPU
         public static long ComputeBufferLength<TStride>(
             this TStride stride,
             <#= longIndexName #> extent)
-            where TStride : <#= strideName #> {
+            where TStride : <#= strideName #>
+        {
 <#      for (int i = 0; i < def.Dimension; ++i) { #>
 <#          var iName = IndexDimensions[i].PropertyName; #>
             if (extent.<#= iName #> == 0L)

--- a/Src/ILGPU/Util/Bitwise.cs
+++ b/Src/ILGPU/Util/Bitwise.cs
@@ -1,0 +1,112 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                           Copyright (c) 2022 ILGPU Project
+//                                    www.ilgpu.net
+//
+// File: Bitwise.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details.
+// ---------------------------------------------------------------------------------------
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace ILGPU.Util
+{
+    /// <summary>
+    /// Bitwise utility methods.
+    /// Used instead of &amp; and | to avoid false-positives from code analysis tools
+    /// that suggest they potentially be changed to &amp;&amp; and ||.
+    /// </summary>
+    public static class Bitwise
+    {
+        /// <summary>
+        /// Performs bitwise operator &amp; on two values.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool And(bool first, bool second) =>
+            first & second;
+
+        /// <summary>
+        /// Performs bitwise operator &amp; on three values.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool And(bool first, bool second, bool third) =>
+            first & second & third;
+
+        /// <summary>
+        /// Performs bitwise operator &amp; on two values.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int And(int first, int second) =>
+            first & second;
+
+        /// <summary>
+        /// Performs bitwise operator &amp; on two values.
+        /// </summary>\
+        [CLSCompliant(false)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static uint And(uint first, uint second) =>
+            first & second;
+
+        /// <summary>
+        /// Performs bitwise operator &amp; on two values.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static long And(long first, long second) =>
+            first & second;
+
+        /// <summary>
+        /// Performs bitwise operator &amp; on two values.
+        /// </summary>
+        [CLSCompliant(false)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ulong And(ulong first, ulong second) =>
+            first & second;
+
+        /// <summary>
+        /// Performs bitwise operator | on two values.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool Or(bool first, bool second) =>
+            first | second;
+
+        /// <summary>
+        /// Performs bitwise operator | on three values.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool Or(bool first, bool second, bool third) =>
+            first | second | third;
+
+        /// <summary>
+        /// Performs bitwise operator | on two values.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Or(int first, int second) =>
+            first | second;
+
+        /// <summary>
+        /// Performs bitwise operator | on two values.
+        /// </summary>
+        [CLSCompliant(false)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static uint Or(uint first, uint second) =>
+            first | second;
+
+        /// <summary>
+        /// Performs bitwise operator | on two values.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static long Or(long first, long second) =>
+            first | second;
+
+        /// <summary>
+        /// Performs bitwise operator | on two values.
+        /// </summary>
+        [CLSCompliant(false)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ulong Or(ulong first, ulong second) =>
+            first | second;
+    }
+}


### PR DESCRIPTION
This PR fixes most of the CodeQL scanning alerts that have the 'Error' severity.

These scanning alerts show up when changing the CodeQL configuration use the `security-and-quality` queries:
```
uses: github/codeql-action/init@v2
      with:
        languages: csharp
        queries: security-and-quality
```

**Potentially dangerous use of non-short-curcuit logic**
https://codeql.github.com/codeql-query-help/csharp/cs-non-short-circuit/

CodeQL suggests several of our non-short-circuited `&` and `|` operators be changed to `&&` and `||`. To avoid these alerts, I have introduced a new `Bitwise` class.

**Dubious type test of 'this'**
https://codeql.github.com/codeql-query-help/csharp/cs-type-test-of-this

CodeQL suggests that a base class should not have to know about its derived classes. To avoid these alerts, I have changed the implementation to have properties that are overridden by derived classes.

