### PR TITLE
Docs: debugging .IOOperations() clarification

### DIFF
--- a/Docs/Debugging-and-Profiling.md
+++ b/Docs/Debugging-and-Profiling.md
@@ -29,5 +29,4 @@ This string can be formatted to `Test output 1.0 and test output -45` using:
 ```c#
 Interop.Write("Test output {0} and test output {1}", 1.0, -45);
 ```
-Note that this functionality must be enabled using the `.IOOperations()` method of the `Context.Builder`. (This is disabled by default when a `Debugger` is not attached to the application). Note that enabling IO Operations using this flag will cause it to be enabled in `Release` builds as well.
-Be sure to disable this flag if you want to get the best runtime performance.
+Note that this functionality is enabled by default when a `Debugger` is attached to the application. For this to work without the Debugger, or in Release mode, call the `.IOOperations()` method of `Context.Builder`. Be sure to remove this flag if you want to get the best runtime performance.


### PR DESCRIPTION
Added a clarification to the `PrintF-Like Debugging` section. `Interop.Write()` and `Interop.WriteLine()` do nothing if the `Accelerator` is not built with the `.IOOperations()` builder function. This is not well clarified in the `SimpleWriteLine` sample nor the docs, so I think it's a worthwhile contribution.

I copied a bunch of the wording from some of the other similar parts of the page. But since this directly pertains to the last section I thought it would make most sense down there. Please make any changes to be more concise or accurate.