### PR TITLE
Fix restarted workflows not triggering runners

### DIFF
--- a/.github/workflows/runners.yaml
+++ b/.github/workflows/runners.yaml
@@ -1,11 +1,27 @@
 name: Runners Deployment
 
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types: 
-      - completed
-      - requested
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Whether workflows is requested or completed'
+        required: true
+        type: choice
+        options:
+        - requested
+        - completed
+      run_id:
+        description: 'Id of the job that triggered the run'
+        required: true
+      job_id:
+        description: 'Id of the job that triggered the run'
+        required: true
+      run_attempt:
+        description: 'Run attempt'
+        required: true
+      label:
+        description: 'Job label'
+        required: true
 
 jobs:
   check-skipped:
@@ -38,7 +54,7 @@ jobs:
     if: ${{ needs.check-skipped.outputs.skipped == 'false' }}
     steps:
       - name: Checkout main repo for config
-        if: github.event.action == 'requested'
+        if: github.event.inputs.action == 'requested'
         uses: actions/checkout@v3
         with:
           path: ilgpu
@@ -73,13 +89,13 @@ jobs:
           PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
           PULUMI_SKIP_CONFIRMATIONS: "true"
           PULUMI_SKIP_UPDATE_CHECK: "true"
-          PULUMI_STACK_NAME: ilgpu-ghrunner-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}
-          LABEL: cuda-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}
+          PULUMI_STACK_NAME: ilgpu-ghrunner-${{ github.event.inputs.job_id }}
+          LABEL: ${{ github.event.inputs.label }}
           OWNER: ${{ github.event.repository.owner.login }}
           REPO: ${{ github.event.repository.name }}
         working-directory: pulumi
         run: |
-          case ${{ github.event.action }} in
+          case ${{ github.event.inputs.action }} in
             'requested')
               cp ../ilgpu/.github/workflows/runners/config.yaml Pulumi.$PULUMI_STACK_NAME.yaml
               pulumi stack init $PULUMI_STACK_NAME

--- a/.github/workflows/runners/config.yaml
+++ b/.github/workflows/runners/config.yaml
@@ -3,4 +3,4 @@ config:
   ephemeral-github-runner-gcp:bootDiskType: pd-balanced
   ephemeral-github-runner-gcp:machineImage: ubuntu-2004-focal-v20220419-ghr22920-nv47012906-20220527
   ephemeral-github-runner-gcp:machineType: a2-highgpu-1g
-  ephemeral-github-runner-gcp:runnersCount: "6"
+  ephemeral-github-runner-gcp:runnersCount: "1"


### PR DESCRIPTION
This PR fixes the issue with runners not being created when a workflow is re-run. I've tried to keep changes to ILGPU repo as minimal as possible. Have in mind that there will be a more robust solution developed that i will discuss with @jgiannuzzi. With this PR, support is added when:
- triggering a completely new workflow will trigger runners deployment (runner per cuda job)
- restarting entire workflow when there are failed job will trigger runners deployment (runner per cuda job)
- restarting only failing jobs will trigger runners deployment (runner per cuda job)

However, prerequisite before merging this PR is to create a Github action as described [here](https://github.com/pavlovic-ivan/ghrunner-app-gcp/blob/main/INSTALLATION_GUIDE.md) and [here](https://github.com/pavlovic-ivan/ghrunner-app-gcp/blob/main/README.md). Have in mind that some of the already defined secrets might change as well. @jgiannuzzi i believe you would be of assistance here for this as i don't have access on that level to ILGPU repo.

@m4rs-mt i did not include any working examples in this PR as we did the demo of the solution several days ago. If needed, i can provide them.

Fixes https://github.com/G-Research/gr-oss/issues/204