### PR TITLE
Fixed critical issue in CPUAccelerator runtime related to Shared Memory allocations and Warp operations.

### DIFF
--- a/Src/ILGPU.Algorithms.Tests/WarpExtensionTests.Find.cs
+++ b/Src/ILGPU.Algorithms.Tests/WarpExtensionTests.Find.cs
@@ -1,0 +1,153 @@
+// ---------------------------------------------------------------------------------------
+//                                   ILGPU Algorithms
+//                           Copyright (c) 2022 ILGPU Project
+//                                    www.ilgpu.net
+//
+// File: WarpExtensionTests.Find.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details.
+// ---------------------------------------------------------------------------------------
+
+using ILGPU.Algorithms.ScanReduceOperations;
+using ILGPU.AtomicOperations;
+using ILGPU.Runtime;
+using ILGPU.Tests;
+using ILGPU.Util;
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+#pragma warning disable xUnit1026
+#pragma warning disable CA1815
+
+namespace ILGPU.Algorithms.Tests
+{
+    partial class WarpExtensionTests
+    {
+        internal readonly struct LaneEntry :
+            IScanReduceOperation<LaneEntry>,
+            IAtomicOperation<LaneEntry>,
+            ICompareExchangeOperation<LaneEntry>
+        {
+            public LaneEntry(int distance, int laneIndex)
+            {
+                Distance = distance;
+                LaneIndex = laneIndex;
+            }
+
+            public string CLCommand => string.Empty;
+            public LaneEntry Identity => new LaneEntry(int.MaxValue, int.MaxValue);
+
+            public int Distance { get; }
+            public int LaneIndex { get; }
+
+            public LaneEntry Apply(LaneEntry first, LaneEntry second) =>
+                Utilities.Select(first.Distance < second.Distance, first, second);
+
+            public LaneEntry Operation(LaneEntry current, LaneEntry value) =>
+                Apply(current, value);
+
+            public void AtomicApply(ref LaneEntry target, LaneEntry value) =>
+                Atomic.MakeAtomic(ref target, value, this, this);
+
+            public LaneEntry CompareExchange(
+                ref LaneEntry target,
+                LaneEntry compare,
+                LaneEntry value)
+            {
+                ref long targetL = ref Unsafe.As<LaneEntry, long>(ref target);
+                long compareL = Unsafe.As<LaneEntry, long>(ref compare);
+                long valueL = Unsafe.As<LaneEntry, long>(ref value);
+                long result = Atomic.CompareExchange(ref targetL, compareL, valueL);
+                return Unsafe.As<long, LaneEntry>(ref result);
+            }
+
+            public bool IsSame(LaneEntry left, LaneEntry right) =>
+                left.Distance == right.Distance & left.LaneIndex == right.LaneIndex;
+
+            public override string ToString() => $"{LaneIndex}: {Distance}d";
+        }
+
+        public static void FindKernel(
+            ArrayView<int> values,
+            ArrayView<int> origins,
+            ArrayView<int> results)
+        {
+            const int MaxGroupSize = 1024;
+
+            int localDistance = int.MaxValue;
+            ref var bestSharedDistance = ref SharedMemory.Allocate<int>();
+            var sharedDistanceValues = SharedMemory.Allocate<int>(MaxGroupSize);
+            for (int i = Group.IdxX; i < MaxGroupSize; i += Group.DimX)
+                sharedDistanceValues[Group.IdxX] = localDistance;
+            Group.Barrier();
+
+            int source = values[Grid.IdxX];
+            if (source < 0)
+                return;
+            for (int i = Group.IdxX; i < origins.IntLength; i += Group.DimX)
+            {
+                int origin = origins[i];
+                int result = Math.Abs(origin - source);
+
+                localDistance = Utilities.Select(
+                    result < localDistance,
+                    result,
+                    localDistance);
+            }
+
+            // Commit changes to shared memory
+            sharedDistanceValues[Group.IdxX] = localDistance;
+            Group.Barrier();
+
+            // Determine the best value in the first warp
+            if (Warp.WarpIdx == 0)
+            {
+                LaneEntry entry = default(LaneEntry).Identity;
+                for (int i = Warp.LaneIdx; i < Group.DimX; i += Warp.WarpSize)
+                {
+                    var bestFit = WarpExtensions.Reduce<LaneEntry, LaneEntry>(
+                        new(sharedDistanceValues[i], i));
+                    entry = entry.Apply(entry, bestFit);
+                }
+                Warp.Barrier();
+
+                // First lane contains the actual result
+                if (Warp.IsFirstLane)
+                    bestSharedDistance = sharedDistanceValues[entry.LaneIndex];
+            }
+            Group.Barrier();
+
+            // First thread should have all results
+            if (Group.IsFirstThread)
+                results[Grid.IdxX] = bestSharedDistance;
+        }
+
+        [Fact]
+        [KernelMethod(nameof(FindKernel))]
+        public void FindDistances()
+        {
+            var values = new int[] { 1, 2, 3 };
+            var origins = new int[] { 7, 5, 1, 4, 5, 1, 2, 4, 6, 7, 8 };
+            var results = new int[] { 0, 0, 1 };
+
+            using var valuesBuffer = Accelerator.Allocate1D<int>(values);
+            using var originsBuffer = Accelerator.Allocate1D<int>(origins);
+            using var resultsBuffer = Accelerator.Allocate1D<int>(values.Length);
+
+            Execute(
+                new KernelConfig(
+                    values.Length,
+                    Accelerator.MaxNumThreadsPerGroup),
+                valuesBuffer.View.AsContiguous(),
+                originsBuffer.View.AsContiguous(),
+                resultsBuffer.View.AsContiguous());
+
+            Verify(resultsBuffer.View, results);
+        }
+    }
+}
+
+#pragma warning restore xUnit1026
+#pragma warning restore CA1815

--- a/Src/ILGPU.Algorithms.Tests/WarpExtensionTests.tt
+++ b/Src/ILGPU.Algorithms.Tests/WarpExtensionTests.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                   ILGPU Algorithms
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: WarpExtensionTests.tt/WarpExtensionTests.cs
@@ -22,7 +22,7 @@ using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
-#pragma warning disable xUnit1026 
+#pragma warning disable xUnit1026
 
 namespace ILGPU.Algorithms.Tests
 {
@@ -120,7 +120,7 @@ namespace ILGPU.Algorithms.Tests
 
             var sequence = sequencer.ComputeSequence(start, stepSize, size);
             input.CopyFromCPU(stream, sequence);
-            
+
             Execute<KernelConfig, T, TFunction>((1, size), input.View, output.View);
 
             T expected = CalcValue(sequence, func);
@@ -151,9 +151,9 @@ namespace ILGPU.Algorithms.Tests
 
             var sequence = sequencer.ComputeSequence(start, stepSize, size);
             input.CopyFromCPU(stream, sequence);
-            
+
             Execute<KernelConfig, T, TFunction>((1, size), input.View, output.View);
-            
+
             var expected = Enumerable.Repeat(CalcValue(sequence, func), size).ToArray();
             Verify(output.View, expected);
         }
@@ -179,7 +179,7 @@ namespace ILGPU.Algorithms.Tests
 
             var sequence = sequencer.ComputeSequence(start, stepSize, size);
             input.CopyFromCPU(stream, sequence);
-            
+
             Execute<KernelConfig, T, TFunction>((1, size), input.View, output.View);
 
             T[] expected = CalcValues(sequence, func, ScanKind.Exclusive);
@@ -208,7 +208,7 @@ namespace ILGPU.Algorithms.Tests
 
             var sequence = sequencer.ComputeSequence(start, stepSize, size);
             input.CopyFromCPU(stream, sequence);
-            
+
             Execute<KernelConfig, T, TFunction>((1, size), input.View, output.View);
 
             T[] expected = CalcValues(sequence, func, ScanKind.Exclusive);
@@ -238,13 +238,13 @@ namespace ILGPU.Algorithms.Tests
 
             var sequence = sequencer.ComputeSequence(start, stepSize, size);
             input.CopyFromCPU(stream, sequence);
-            
+
             Execute<KernelConfig, T, TFunction>((1, size), input.View, output.View);
-            
+
             T[] expected = CalcValues(sequence, func, ScanKind.Inclusive);
             Verify(output.View, expected);
         }
-        
+
         #region Helper Methods
 
         private static T CalcValue<T, TFunction>(T[] values, TFunction func)
@@ -272,7 +272,7 @@ namespace ILGPU.Algorithms.Tests
 
             if (kind == ScanKind.Exclusive)
             {
-                T[] zero = { default }; 
+                T[] zero = { default };
                 result = zero.Concat(result.Take(result.Length - 1)).ToArray();
             }
             return result;

--- a/Src/ILGPU/Backends/IL/ILBackend.cs
+++ b/Src/ILGPU/Backends/IL/ILBackend.cs
@@ -193,7 +193,10 @@ namespace ILGPU.Backends.IL
                 kernelMethod,
                 taskType,
                 taskConstructor,
-                taskArgumentMapping);
+                taskArgumentMapping,
+                backendContext.SharedAllocations.Length +
+                    backendContext.DynamicSharedAllocations.Length,
+                backendContext.SharedMemorySpecification.StaticSize);
         }
 
         /// <summary>

--- a/Src/ILGPU/Backends/IL/ILCompiledKernel.cs
+++ b/Src/ILGPU/Backends/IL/ILCompiledKernel.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2018-2021 ILGPU Project
+//                        Copyright (c) 2018-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: ILCompiledKernel.cs
@@ -35,13 +35,21 @@ namespace ILGPU.Backends.IL
         /// <param name="taskArgumentMapping">
         /// Mapping of argument indices to fields.
         /// </param>
+        /// <param name="numSharedMemoryAllocations">
+        /// The number of shared-memory allocations.
+        /// </param>
+        /// <param name="allocatedSharedMemorySize">
+        /// The amount of statically allocated bytes of shared memory.
+        /// </param>
         internal ILCompiledKernel(
             Context context,
             EntryPoint entryPoint,
             MethodInfo kernelMethod,
             Type taskType,
             ConstructorInfo taskConstructor,
-            ImmutableArray<FieldInfo> taskArgumentMapping)
+            ImmutableArray<FieldInfo> taskArgumentMapping,
+            int numSharedMemoryAllocations,
+            int allocatedSharedMemorySize)
             : base(context, entryPoint, null)
         {
             KernelMethod = kernelMethod;
@@ -50,6 +58,8 @@ namespace ILGPU.Backends.IL
             TaskType = taskType;
             TaskConstructor = taskConstructor;
             TaskArgumentMapping = taskArgumentMapping;
+            NumSharedMemoryAllocations = numSharedMemoryAllocations;
+            AllocatedSharedMemorySize = allocatedSharedMemorySize;
         }
 
         #endregion
@@ -80,6 +90,16 @@ namespace ILGPU.Backends.IL
         /// Returns a mapping of argument indices to fields.
         /// </summary>
         internal ImmutableArray<FieldInfo> TaskArgumentMapping { get; }
+
+        /// <summary>
+        /// Returns the number of shared-memory allocations.
+        /// </summary>
+        public int NumSharedMemoryAllocations { get; }
+
+        /// <summary>
+        /// Returns the size of statically allocated shared memory in bytes.
+        /// </summary>
+        public int AllocatedSharedMemorySize { get; }
 
         #endregion
     }

--- a/Src/ILGPU/Runtime/CPU/CPURuntimeGroupContext.cs
+++ b/Src/ILGPU/Runtime/CPU/CPURuntimeGroupContext.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2017-2021 ILGPU Project
+//                        Copyright (c) 2017-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: CPURuntimeGroupContext.cs
@@ -48,63 +48,22 @@ namespace ILGPU.Runtime.CPU
 
         #endregion
 
-        #region Nested Types
-
-        /// <summary>
-        /// Represents an operation that allocates and managed shared memory.
-        /// </summary>
-        /// <typeparam name="T">The element type.</typeparam>
-        private readonly struct GetSharedMemory<T> : ILockedOperation<ArrayView<T>>
-            where T : unmanaged
-        {
-            public GetSharedMemory(CPURuntimeGroupContext parent, long extent)
-            {
-                Parent = parent;
-                Extent = extent;
-            }
-
-            /// <summary>
-            /// Returns the parent context.
-            /// </summary>
-            public CPURuntimeGroupContext Parent { get; }
-
-            /// <summary>
-            /// Returns the number of elements to allocate.
-            /// </summary>
-            public long Extent { get; }
-
-            /// <summary>
-            /// Allocates a new chunk of shared memory.
-            /// </summary>
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public readonly void ApplySyncInMainThread()
-            {
-                // Allocate the requested amount of elements
-                var allocation = CPUMemoryBuffer.Create(
-                    Parent.Multiprocessor.Accelerator,
-                    Extent,
-                    Interop.SizeOf<T>());
-
-                // Publish the allocated shared memory source
-                Parent.currentSharedMemorySource = allocation;
-                Parent.sharedMemory.Add(allocation);
-            }
-
-            /// <summary>
-            /// Returns the least recently allocated chunk of shared memory.
-            /// </summary>
-            public readonly ArrayView<T> Result =>
-                new ArrayView<T>(Parent.currentSharedMemorySource, 0, Extent);
-        }
-
-        #endregion
-
         #region Instance
 
         /// <summary>
         /// A counter for the computation of interlocked group counters.
         /// </summary>
         private volatile int groupCounter;
+
+        /// <summary>
+        /// Group-wide accumulator for group allocation indices.
+        /// </summary>
+        private int groupAllocationIndexAccumulator;
+
+        /// <summary>
+        /// Internal storage to track group-wide allocation indices
+        /// </summary>
+        private readonly int[] groupAllocationIndices;
 
         /// <summary>
         /// The current dynamic shared memory array size in bytes.
@@ -115,7 +74,7 @@ namespace ILGPU.Runtime.CPU
         /// A temporary cache for additional shared memory requirements.
         /// </summary>
         /// <remarks>
-        /// Note that this buffer is only required for debug CPU builds. In
+        /// Note that these buffers are only required for debug CPU builds. In
         /// these cases, we cannot move nested
         /// <see cref="SharedMemory.Allocate{T}(int)"/> instructions out of nested loops
         /// to provide the best debugging experience.
@@ -124,9 +83,10 @@ namespace ILGPU.Runtime.CPU
             InlineList<CPUMemoryBuffer>.Create(16);
 
         /// <summary>
-        /// A currently active unmanaged memory source.
+        /// Shared-memory allocation lock object for synchronizing accesses to the
+        /// <see cref="sharedMemory" /> list.
         /// </summary>
-        private volatile CPUMemoryBuffer currentSharedMemorySource;
+        private readonly object sharedMemoryLock = new object();
 
         /// <summary>
         /// Constructs a new CPU-based runtime context for parallel processing.
@@ -134,7 +94,9 @@ namespace ILGPU.Runtime.CPU
         /// <param name="multiprocessor">The target CPU multiprocessor.</param>
         public CPURuntimeGroupContext(CPUMultiprocessor multiprocessor)
             : base(multiprocessor)
-        { }
+        {
+            groupAllocationIndices = new int[multiprocessor.MaxNumThreadsPerGroup];
+        }
 
         #endregion
 
@@ -164,7 +126,49 @@ namespace ILGPU.Runtime.CPU
         /// </summary>
         /// <returns>The number of participating threads.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int Barrier() => Multiprocessor.GroupBarrier();
+        private int BlockBarrier() => Multiprocessor.GroupBarrier();
+
+        /// <summary>
+        /// The internal implementation of a group barrier that takes current allocation
+        /// indices into account.
+        /// </summary>
+        /// <returns>The number of participating threads.</returns>
+        private int GroupAllocationSynchronizedBarrier()
+        {
+            // Determine current index and maximize across all threads in the group
+            var context = CPURuntimeThreadContext.Current;
+            ref int currentIndex = ref groupAllocationIndices[context.LinearGroupIndex];
+
+            // Accumulate results and perform the actual barrier
+            Atomic.Max(ref groupAllocationIndexAccumulator, currentIndex);
+            int count1 = BlockBarrier();
+
+            // Get the actual result as long as it is available and update our own counter
+            currentIndex = Atomic.CompareExchange(
+                ref groupAllocationIndexAccumulator,
+                -1,
+                -1);
+
+            // Wait for all threads to get to this point in order to avoid disturbances
+            // that may affect the group accumulation counter
+            int count2 = BlockBarrier();
+            Debug.Assert(count1 == count2, "Lost threads within group barriers");
+            return count2;
+        }
+
+        /// <summary>
+        /// Executes a thread barrier.
+        /// </summary>
+        /// <returns>The number of participating threads.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Barrier()
+        {
+            // Wait without any modifications
+            BlockBarrier();
+
+            // Perform the actual group sync barrier
+            return GroupAllocationSynchronizedBarrier();
+        }
 
         /// <summary>
         /// Performs a local-memory allocation.
@@ -197,13 +201,33 @@ namespace ILGPU.Runtime.CPU
         /// <returns>The resolved shared-memory array view.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ArrayView<T> AllocateSharedMemory<T>(int extent)
-            where T : unmanaged =>
-            PerformLocked<
-                CPURuntimeGroupContext,
-                GetSharedMemory<T>,
-                ArrayView<T>>(
-                this,
-                new GetSharedMemory<T>(this, extent));
+            where T : unmanaged
+        {
+            var context = CPURuntimeThreadContext.Current;
+            int nextIndex = groupAllocationIndices[context.LinearGroupIndex]++;
+
+            // Perform synchronized
+            lock (sharedMemoryLock)
+            {
+                // Register buffers
+                while (sharedMemory.Count <= nextIndex)
+                    sharedMemory.Add(null);
+
+                // Allocate the requested amount of elements
+                ref var buffer = ref sharedMemory[nextIndex];
+                if (buffer is null)
+                {
+                    buffer = CPUMemoryBuffer.Create(
+                        Multiprocessor.Accelerator,
+                        extent,
+                        Interop.SizeOf<T>());
+                }
+
+                Thread.MemoryBarrier();
+                // Publish the allocated shared memory source
+                return new ArrayView<T>(buffer, 0, extent);
+            }
+        }
 
         /// <summary>
         /// Executes a thread barrier and returns the number of threads for which
@@ -218,12 +242,12 @@ namespace ILGPU.Runtime.CPU
         private int BarrierPopCount(bool predicate, out int numParticipants)
         {
             Interlocked.Exchange(ref groupCounter, 0);
-            Barrier();
+            BlockBarrier();
             if (predicate)
                 Interlocked.Increment(ref groupCounter);
-            Barrier();
+            GroupAllocationSynchronizedBarrier();
             var result = Interlocked.CompareExchange(ref groupCounter, 0, 0);
-            numParticipants = Barrier();
+            numParticipants = BlockBarrier();
             return result;
         }
 
@@ -307,10 +331,11 @@ namespace ILGPU.Runtime.CPU
         /// </summary>
         private void ClearSharedMemoryAllocations()
         {
-            currentSharedMemorySource = null;
             foreach (var entry in sharedMemory)
                 entry.Dispose();
             sharedMemory.Clear();
+            Array.Clear(groupAllocationIndices, 0, groupAllocationIndices.Length);
+            Atomic.Exchange(ref groupAllocationIndexAccumulator, 0);
         }
 
         /// <summary>

--- a/Src/ILGPU/Runtime/CPU/CPURuntimeWarpContext.cs
+++ b/Src/ILGPU/Runtime/CPU/CPURuntimeWarpContext.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2017-2021 ILGPU Project
+//                        Copyright (c) 2017-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: CPURuntimeWarpContext.cs
@@ -237,7 +237,7 @@ namespace ILGPU.Runtime.CPU
             config.Validate(WarpSize);
 
             // Allocate a compatible view
-            var view = PerformLocked<
+            var view = PerformLockStep<
                 CPURuntimeWarpContext,
                 GetShuffleMemory<T>,
                 ArrayView<T>>(


### PR DESCRIPTION
The current GPU emulation runtime environment (currently referred to as `CPUAccelerator`) has a critical bug which can lead to invalid program output in certain scenarios. This bug is considered *critical* because programs _may_ crash, but not in all cases, generally speaking. In other words, this problem can lead to non-deterministic incorrect output that may go unnoticed.

The problem is related to the performance of `SharedMemory` assignments in divergent branches that "return" to the main execution thread, which in turn performs a number of specific operations targeting `Warp` and `SharedMemory` operations.

This PR addresses this critical problem by refining the way `SharedMemory` allocations work in the context of the `CPUAccelerator` runtime.