### PR TITLE
Set machine image to latest image with latest runner

### DIFF
--- a/.github/workflows/runners/config.yaml
+++ b/.github/workflows/runners/config.yaml
@@ -1,6 +1,6 @@
 config:
   ephemeral-github-runner:bootDiskSizeInGB: "100"
   ephemeral-github-runner:bootDiskType: gp2
-  ephemeral-github-runner:machineImage: gross-cuda-nvidia-ghrunner-22950-amd64
+  ephemeral-github-runner:machineImage: gross-cuda-nvidia-ghrunner-22960-amd64
   ephemeral-github-runner:machineType: g4dn.xlarge
   ephemeral-github-runner:runnersCount: "1"


### PR DESCRIPTION
Hi @m4rs-mt @MoFtZ!

This PR only updates the machine image name. New image runs the new runner version 2.296.0.

Working example: https://github.com/pavlovic-ivan/ILGPU-fork2/actions/runs/2922311122