### PR TITLE
Features for allocating 2D/3D in shared memory

### DIFF
--- a/Src/ILGPU.Tests/SharedMemory.cs
+++ b/Src/ILGPU.Tests/SharedMemory.cs
@@ -245,13 +245,79 @@ namespace ILGPU.Tests
             var expected = Enumerable.Repeat(42, groupSize).ToArray();
             Verify(buffer.View, expected);
         }
+        
+        internal static void MultiDimensionalSharedMemoryKernel2DDenseX(
+            ArrayView1D<int, Stride1D.Dense> output)
+        {
+            var sharedMemory = ILGPU.SharedMemory.Allocate2DDenseX<int>(
+                new Index2D(20, 100));
+            if (Group.IsFirstThread) {
+                sharedMemory[0, 0] = 0;
+                sharedMemory[1, 0] = 0;
+            }
+            if (Grid.GlobalIndex.X < 100) {
+                sharedMemory[0, Grid.GlobalIndex.X] = Grid.GlobalIndex.X;
+                sharedMemory[1, Grid.GlobalIndex.X] = 7*Grid.GlobalIndex.X;
+            }
+            Group.Barrier();
+            if (Grid.GlobalIndex.X < 100)
+                output[Grid.GlobalIndex.X] = sharedMemory[1, Grid.GlobalIndex.X];
+            else
+                output[Grid.GlobalIndex.X] = sharedMemory[0, 0];
+        }
+
+        [Fact]
+        [KernelMethod(nameof(MultiDimensionalSharedMemoryKernel2DDenseX))]
+        public void MultiDimensionalSharedMemory2DDenseX()
+        {
+            int groupSize = Accelerator.MaxNumThreadsPerGroup;
+            using var buffer = Accelerator.Allocate1D<int>(groupSize);
+            Execute(new KernelConfig(1, groupSize), buffer.View);
+            var expected = 
+                Enumerable.Range(0, groupSize).Select(
+                    x => x < 100 ? 7*x : 0).ToArray();
+            Verify(buffer.View, expected);
+        }
+
+        internal static void MultiDimensionalSharedMemoryKernel2DDenseY(
+            ArrayView1D<int, Stride1D.Dense> output)
+        {
+            var sharedMemory = ILGPU.SharedMemory.Allocate2DDenseY<int>(
+                new Index2D(100, 20));
+            if (Group.IsFirstThread) {
+                sharedMemory[0, 0] = 0;
+                sharedMemory[0, 1] = 0;
+            }
+            if (Grid.GlobalIndex.X < 100) {
+                sharedMemory[Grid.GlobalIndex.X, 0] = Grid.GlobalIndex.X;
+                sharedMemory[Grid.GlobalIndex.X, 1] = 7*Grid.GlobalIndex.X;
+            }
+            Group.Barrier();
+            if (Grid.GlobalIndex.X < 100)
+                output[Grid.GlobalIndex.X] = sharedMemory[Grid.GlobalIndex.X, 1];
+            else
+                output[Grid.GlobalIndex.X] = sharedMemory[0, 0];
+        }
+
+        [Fact]
+        [KernelMethod(nameof(MultiDimensionalSharedMemoryKernel2DDenseY))]
+        public void MultiDimensionalSharedMemory2DDenseY()
+        {
+            int groupSize = Accelerator.MaxNumThreadsPerGroup;
+            using var buffer = Accelerator.Allocate1D<int>(groupSize);
+            Execute(new KernelConfig(1, groupSize), buffer.View);
+            var expected = 
+                Enumerable.Range(0, groupSize).Select(
+                    x => x < 100 ? 7*x : 0).ToArray();
+            Verify(buffer.View, expected);
+        }
 
         internal static void MultiDimensionalSharedMemoryKernel3D(
             ArrayView1D<int, Stride1D.Dense> output)
         {
             var sharedMemory = ILGPU.SharedMemory.Allocate3D<int, Stride3D.DenseZY>(
                 new Index3D(5, 7, 3),
-                new Stride3D.DenseZY(5 * 7, 7));
+                new Stride3D.DenseZY(3 * 7, 3));
             if (Group.IsFirstThread)
                 sharedMemory[2, 6, 1] = 42;
             Group.Barrier();
@@ -261,6 +327,52 @@ namespace ILGPU.Tests
         [Fact]
         [KernelMethod(nameof(MultiDimensionalSharedMemoryKernel3D))]
         public void MultiDimensionalSharedMemory3D()
+        {
+            int groupSize = Accelerator.MaxNumThreadsPerGroup;
+            using var buffer = Accelerator.Allocate1D<int>(groupSize);
+            Execute(new KernelConfig(1, groupSize), buffer.View);
+
+            var expected = Enumerable.Repeat(42, groupSize).ToArray();
+            Verify(buffer.View, expected);
+        }
+        
+        internal static void MultiDimensionalSharedMemoryKernel3DDenseXY(
+            ArrayView1D<int, Stride1D.Dense> output)
+        {
+            var sharedMemory = ILGPU.SharedMemory.Allocate3DDenseXY<int>(
+                new Index3D(11, 17, 13));
+            if (Group.IsFirstThread)
+                sharedMemory[4, 5, 2] = 42;
+            Group.Barrier();
+            output[Grid.GlobalIndex.X] = sharedMemory[4, 5, 2];
+        }
+
+        [Fact]
+        [KernelMethod(nameof(MultiDimensionalSharedMemoryKernel3DDenseXY))]
+        public void MultiDimensionalSharedMemory3DDenseXY()
+        {
+            int groupSize = Accelerator.MaxNumThreadsPerGroup;
+            using var buffer = Accelerator.Allocate1D<int>(groupSize);
+            Execute(new KernelConfig(1, groupSize), buffer.View);
+
+            var expected = Enumerable.Repeat(42, groupSize).ToArray();
+            Verify(buffer.View, expected);
+        }
+
+        internal static void MultiDimensionalSharedMemoryKernel3DDenseZY(
+            ArrayView1D<int, Stride1D.Dense> output)
+        {
+            var sharedMemory = ILGPU.SharedMemory.Allocate3DDenseZY<int>(
+                new Index3D(11, 17, 13));
+            if (Group.IsFirstThread)
+                sharedMemory[4, 5, 2] = 42;
+            Group.Barrier();
+            output[Grid.GlobalIndex.X] = sharedMemory[4, 5, 2];
+        }
+
+        [Fact]
+        [KernelMethod(nameof(MultiDimensionalSharedMemoryKernel3DDenseZY))]
+        public void MultiDimensionalSharedMemory3DDenseZY()
         {
             int groupSize = Accelerator.MaxNumThreadsPerGroup;
             using var buffer = Accelerator.Allocate1D<int>(groupSize);

--- a/Src/ILGPU.Tests/SharedMemory.cs
+++ b/Src/ILGPU.Tests/SharedMemory.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                           Copyright (c) 2021-2022 ILGPU Project
+//                        Copyright (c) 2021-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: SharedMemory.cs

--- a/Src/ILGPU.Tests/SharedMemory.cs
+++ b/Src/ILGPU.Tests/SharedMemory.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                           Copyright (c) 2021 ILGPU Project
+//                           Copyright (c) 2021-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: SharedMemory.cs

--- a/Src/ILGPU/Memory.tt
+++ b/Src/ILGPU/Memory.tt
@@ -96,23 +96,23 @@ var axes = new string[]
 };
 #>
 
-<#  foreach (var AXIS in axes) { #>
+<#  foreach (var axis in axes) { #>
     partial class SharedMemory
     {
         /// <summary>
-        /// Allocates a 2D chunk of shared memory with <#= AXIS #>
+        /// Allocates a 2D chunk of shared memory with <#= axis #>
         /// as the leading dimension.
         /// </summary>
         /// <typeparam name="T">The element type.</typeparam>
         /// <param name="extent">The number of elements to allocate.</param>
         /// <returns>An allocated 2D buffer on shared memory.</returns>
-        public static ArrayView2D<T, Stride2D.Dense<#= AXIS #>> 
-            Allocate2DDense<#= AXIS #><T>(
+        public static ArrayView2D<T, Stride2D.Dense<#= axis #>> 
+            Allocate2DDense<#= axis #><T>(
             in Index2D extent)
             where T : unmanaged =>
-            Allocate2D<T, Stride2D.Dense<#= AXIS #>> (
+            Allocate2D<T, Stride2D.Dense<#= axis #>> (
                 extent,
-                new Stride2D.Dense<#= AXIS #>(extent.<#= AXIS #>));
+                new Stride2D.Dense<#= axis #>(extent.<#= axis #>));
     }
 <#  } #>
 
@@ -124,28 +124,27 @@ var twoaxes = new (string, string, string)[]
 };
 #>
 
-<#  foreach (var (AXIS, AXIS1, AXIS2) in twoaxes) { #>
+<#  foreach (var (axis, axis1, axis2) in twoaxes) { #>
     partial class SharedMemory
     {
         /// <summary>
-        /// Allocates a 3D chunk of shared memory with <#= AXIS #> 
+        /// Allocates a 3D chunk of shared memory with <#= axis #> 
         /// as the leading dimensions.
         /// </summary>
         /// <typeparam name="T">The element type.</typeparam>
         /// <param name="extent">The number of elements to allocate.</param>
         /// <returns>An allocated 3D buffer on shared memory.</returns>
         /// <remarks>
-        /// Since <#= AXIS #> are the leading dimension, <#= AXIS1 #> * <#= AXIS2 #> 
-        /// must be less or equal to <see cref="int.MaxValue"/>.
+        /// Since <#= axis #> are the leading dimension, combined dimension 
+        /// (multiplied sizes) must be less or equal to <see cref="int.MaxValue"/>.
         /// </remarks>
-        public static ArrayView3D<T, Stride3D.Dense<#= AXIS #>> 
-            Allocate3DDense<#= AXIS #><T>(
+        public static ArrayView3D<T, Stride3D.Dense<#= axis #>> 
+            Allocate3DDense<#= axis #><T>(
             in Index3D extent)
             where T : unmanaged =>
-            Allocate3D<T, Stride3D.Dense<#= AXIS #>> (
+            Allocate3D<T, Stride3D.Dense<#= axis #>> (
                 extent,
-                new Stride3D.Dense<#= AXIS #>(<#= AXIS1 #>, <#= AXIS2 #>));
+                new Stride3D.Dense<#= axis #>(<#= axis1 #>, <#= axis2 #>));
     }
 <#  } #>
-
 }

--- a/Src/ILGPU/Memory.tt
+++ b/Src/ILGPU/Memory.tt
@@ -86,4 +86,66 @@ namespace ILGPU
 
 <#      } #>
 <#  } #>
+
+
+<#
+var axes = new string[]
+{
+    "X",
+    "Y",
+};
+#>
+
+<#  foreach (var AXIS in axes) { #>
+    partial class SharedMemory
+    {
+        /// <summary>
+        /// Allocates a 2D chunk of shared memory with <#= AXIS #>
+        /// as the leading dimension.
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <param name="extent">The number of elements to allocate.</param>
+        /// <returns>An allocated 2D buffer on shared memory.</returns>
+        public static ArrayView2D<T, Stride2D.Dense<#= AXIS #>> 
+            Allocate2DDense<#= AXIS #><T>(
+            in Index2D extent)
+            where T : unmanaged =>
+            Allocate2D<T, Stride2D.Dense<#= AXIS #>> (
+                extent,
+                new Stride2D.Dense<#= AXIS #>(extent.<#= AXIS #>));
+    }
+<#  } #>
+
+<#
+var twoaxes = new (string, string, string)[]
+{
+    ("XY", "extent.X", "extent.X * extent.Y"),
+    ("ZY", "extent.Z * extent.Y", "extent.Z")
+};
+#>
+
+<#  foreach (var (AXIS, AXIS1, AXIS2) in twoaxes) { #>
+    partial class SharedMemory
+    {
+        /// <summary>
+        /// Allocates a 3D chunk of shared memory with <#= AXIS #> 
+        /// as the leading dimensions.
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <param name="extent">The number of elements to allocate.</param>
+        /// <returns>An allocated 3D buffer on shared memory.</returns>
+        /// <remarks>
+        /// Since <#= AXIS #> are the leading dimension, <#= AXIS1 #> * <#= AXIS2 #> 
+        /// must be less or equal to <see cref="int.MaxValue"/>.
+        /// </remarks>
+        public static ArrayView3D<T, Stride3D.Dense<#= AXIS #>> 
+            Allocate3DDense<#= AXIS #><T>(
+            in Index3D extent)
+            where T : unmanaged =>
+            Allocate3D<T, Stride3D.Dense<#= AXIS #>> (
+                extent,
+                new Stride3D.Dense<#= AXIS #>(<#= AXIS1 #>, <#= AXIS2 #>));
+    }
+<#  } #>
+
 }


### PR DESCRIPTION
- New features are described in issues: 
    * #686 
    * #543
- Added the following methods in ILGPU/Src/Memory.tt:
    * SharedMemory.Allocate2DDenseX
    * SharedMemory.Allocate2DDenseY
    * SharedMemory.Allocate3DDenseXY
    * SharedMemory.Allocate3DDenseZY
- Added tests in Src/ILGPU.Tests/SharedMemory.cs
- Corrected kernel for a test MultiDimensionalSharedMemoryKernel3D

This PR fixes #686.