### PR TITLE
Fix formatting on code samples in docs

### DIFF
--- a/Docs/Primer_01.md
+++ b/Docs/Primer_01.md
@@ -81,7 +81,7 @@ If you don't know about Parallel.For it is a function that provides a really eas
 that takes an index. Then the function is called from some thread with an index. There are no guarantees
 about what core an index is run on, or what order the threads are run, but you get a **very** simple
 interface for running parallel functions.
-```C#
+```c#
 using System;
 using System.Threading.Tasks;
 
@@ -103,7 +103,7 @@ public static class Program
 }
 ```
 Running the same program as a kernel is **very** similar:
-```C#
+```c#
 using ILGPU;
 using ILGPU.Runtime;
 using ILGPU.Runtime.CPU;

--- a/Docs/Tutorial_01.md
+++ b/Docs/Tutorial_01.md
@@ -180,7 +180,7 @@ For a single device: context.GetPreferredDevice(preferCPU);
 
 For multiple devices: context.GetPreferredDevices(preferCPU, matchingDevicesOnly);
 
-```C#
+```c#
 using System;
 using ILGPU;
 using ILGPU.Runtime;

--- a/Docs/Tutorial_02.md
+++ b/Docs/Tutorial_02.md
@@ -70,7 +70,7 @@ All device side memory management happens in the host code through the MemoryBuf
 The sample goes over the basics of managing memory via MemoryBuffers. There will be far more
 in depth memory management in the later tutorials.
 
-```C#
+```c#
 using System;
 
 using ILGPU;

--- a/Docs/Tutorial_03.md
+++ b/Docs/Tutorial_03.md
@@ -5,7 +5,7 @@ In this tutorial we actually do work on the GPU!
 I think the easiest way to explain this is taking the simplest example I can think of and decomposing it. 
 
 This is a modified version of the sample from Primer 01.
-```C#
+```c#
 using ILGPU;
 using ILGPU.Runtime;
 using System;
@@ -57,7 +57,7 @@ public static class Program
 ## The following parts already have detailed explainations in other tutorials:
 
 #### [Context and an accelerator.](Tutorial_01.md)
-```C#
+```c#
 Context context = Context.CreateDefault();
 Accelerator accelerator = context.GetPreferredDevice(preferCPU: false)
                             .CreateAccelerator(context);
@@ -65,14 +65,14 @@ Accelerator accelerator = context.GetPreferredDevice(preferCPU: false)
 Creates an Accelerator using GetPreferredDevice to hopefully get the "best" device.
 
 #### [Some kind of data and output device memory](Tutorial_02.md)
-```C#
+```c#
 MemoryBuffer1D<int, Stride1D.Dense> deviceData = accelerator.Allocate1D(new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 });
 MemoryBuffer1D<int, Stride1D.Dense> deviceOutput = accelerator.Allocate1D<int>(10_000);
 ```
 
 Loads some example data into the device memory, using dense striding.
 
-```C#
+```c#
 int[] hostOutput = deviceOutput.GetAsArray1D();
 ```
 
@@ -82,7 +82,7 @@ After we run the kernel we need to get the data as host memory to use it in CPU 
 Ok now we get to the juicy bits.
 
 #### The kernel function definition.
-```C#
+```c#
 static void Kernel(Index1D i, ArrayView<int> data, ArrayView<int> output)
 {
     output[i] = data[i % data.Length];
@@ -122,7 +122,7 @@ try to avoid branches<sup>1</sup> and code that would change in different kernel
 to avoid is threads that are running different instructions, this is called divergence.
 
 #### The loaded instance of a kernel.
-```C#
+```c#
 Action<Index1D, ArrayView<int>, ArrayView<int>> loadedKernel = 
     accelerator.LoadAutoGroupedStreamKernel<Index1D, ArrayView<int>, ArrayView<int>>(Kernel);
 ```
@@ -136,7 +136,7 @@ explicitly compile it.
 If you are having issues compiling code try testing with the CPUAccelerator.
 
 #### The actual kernel call and device synchronize.
-```C#
+```c#
 loadedKernel((int)deviceOutput.Length, deviceData.View, deviceOutput.View);
 accelerator.Synchronize();
 ```


### PR DESCRIPTION
www.ilgpu.net does not always correctly render C# code.  It looks like the issue is using `C#` instead of `c#` in parts of the docs. This is especially visible in `Docs/Tutorial_01.md`:
- correct coloring when using lowercase `c#`:
![image](https://user-images.githubusercontent.com/62249621/190855504-83ee27b4-6d3f-44cf-8736-f9648f311738.png)
- only rendering monospace font without coloring when using uppercase `C#`: 
![image](https://user-images.githubusercontent.com/62249621/190855544-43d0a330-1160-4866-ad3c-7a586cf1864c.png)

