### PR TITLE
Fixed issue with emitting constructor name in OpenCL.

### DIFF
--- a/Src/ILGPU.Tests/BasicCalls.cs
+++ b/Src/ILGPU.Tests/BasicCalls.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: BasicCalls.cs
@@ -12,6 +12,7 @@
 using ILGPU.Runtime;
 using ILGPU.Util;
 using System.Linq;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using Xunit;
 using Xunit.Abstractions;
@@ -301,7 +302,7 @@ namespace ILGPU.Tests
         {
             using var buffer = Accelerator.Allocate1D<int>(length);
             var sourceData = Enumerable.Range(0, length).Select(t =>
-                new Int2(t, t + 1 )).ToArray();
+                new Int2(t, t + 1)).ToArray();
             var expected = Enumerable.Range(1, length).ToArray();
             using (var source = Accelerator.Allocate1D<Int2>(length))
             {
@@ -310,6 +311,34 @@ namespace ILGPU.Tests
             }
 
             Verify(buffer.View, expected);
+        }
+
+        internal static void ConstructorCallKernel(
+            Index1D index,
+            ArrayView1D<Vector4, Stride1D.Dense> output)
+        {
+            output[index] = index.X switch
+            {
+                0 => new Vector4(0),
+                1 => new Vector4(1),
+                2 => new Vector4(2),
+                _ => new Vector4(index.X),
+            };
+        }
+
+        [Fact]
+        [KernelMethod(nameof(ConstructorCallKernel))]
+        public void ConstructorCall()
+        {
+            using var output = Accelerator.Allocate1D<Vector4>(Length);
+            output.MemSetToZero(Accelerator.DefaultStream);
+            Execute(Length, output.View);
+
+            var expected =
+                Enumerable.Range(0, Length)
+                .Select(x => new Vector4(x))
+                .ToArray();
+            Verify(output.View, expected);
         }
     }
 }

--- a/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.cs
@@ -241,9 +241,21 @@ namespace ILGPU.Backends.OpenCL
         protected static string GetMethodName(Method method)
         {
             var handleName = method.Handle.Name;
-            return method.HasFlags(MethodFlags.External)
-                ? handleName
-                : handleName + "_" + method.Id;
+            if (method.HasFlags(MethodFlags.External))
+            {
+                return handleName;
+            }
+            else
+            {
+                // Constructor names in MSIL start with a dot. This is a reserved
+                // character that cannot be used in the OpenCL function name. Replace
+                // the dot with an underscore, assuming that the rest of the name is
+                // using valid characters. Appending the IR node identifier will ensure
+                // that there are no conflicts.
+                return handleName.StartsWith(".", System.StringComparison.Ordinal)
+                    ? handleName.Substring(1) + "_" + method.Id
+                    : handleName + "_" + method.Id;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #857.

Removed the leading `.` from the generated function name for OpenCL. We do not need to worry about conflicts because we are appending the IR node identifier, which is unique.

Not sure if this is related to the Inliner transformation, but rolling back to a few previous versions of ILGPU did not help.