### PR TITLE
Fix small wiki error

### DIFF
--- a/Docs/Shared-Memory.md
+++ b/Docs/Shared-Memory.md
@@ -30,7 +30,7 @@ class ...
         // Create shared memory configuration using a custom element type.
         // Note that this does not need to be the same type that is used in the scope of the kernel.
         // Therefore, the following two configurations will allocate the same amount of shared memory:
-        var config = SharedMemoryConfig.RequestDynamic<byte>(<GroupSize> * sizeof(byte));
+        var config = SharedMemoryConfig.RequestDynamic<byte>(<GroupSize> * sizeof(int));
         var config2 = SharedMemoryConfig.RequestDynamic<int>(<GroupSize>);
 
         ...


### PR DESCRIPTION
The amount of memory allocated should now be equal like described. It also matches https://github.com/m4rs-mt/ILGPU/blob/b7ed379375cc72df6744cd311fab1cae4c4b1933/Samples/DynamicSharedMemory/Program.cs#L80