### PR TITLE
Add Octo Nudge workflow and Github action

### DIFF
--- a/.github/workflows/nudge.yml
+++ b/.github/workflows/nudge.yml
@@ -1,0 +1,19 @@
+name: Nudge
+
+on:
+  workflow_run:
+    workflows: ['CI','CodeQL','Update Copyright Year']
+    types: [completed]
+    branches: [master]
+
+
+jobs:
+  nudge:
+    runs-on: ubuntu-latest
+    environment: nudge
+    if: (!(github.event.workflow_run.name == 'Update Copyright Year' && github.event.workflow_run.event == 'push'))
+    steps:
+      - name: Send notification
+        uses: pavlovic-ivan/octo-nudge@v1
+        with:
+          webhooks: ${{ secrets.NUDGE_WEBHOOKS }}


### PR DESCRIPTION
@jgiannuzzi @MoFtZ @m4rs-mt  This PR introduces a workflow that will be triggered when CI, CodeQL and Update Copyright Year workflows are completed. By default, you will receive a notification in Discord only if they had failed.

[Here](https://github.com/pavlovic-ivan/ILGPU-fork2/actions/runs/3277132286) is the CI workflow that failed. And [here](https://github.com/pavlovic-ivan/ILGPU-fork2/actions/runs/3277113674/jobs/5393977369) is the workflow that got triggered, that had sent the notification to Slack.

In this PR, when the Github Action Octo Nudge is called, it is using default values. In short:

- notify if workflow conclusion is failure
- notify if a workflow is triggered by a push or schedule to the master branch

You can check the rest [here](https://github.com/pavlovic-ivan/octo-nudge#action-input-arguments).

I've tested using my fork, my incoming webhook created within Discord, and a channel i've created. Which means that you will need to create the incoming webhook and the channel, or connect the incoming webhook to an existing channel. Also, you will need a secret called `NUDGE_WEBHOOKS` in an environment, called `nudge`, with a protected branch rule set to master. If you need help, please let me know, i will be available for setting it up.

Lastly, this is how the notification looks like in Discord.

<img width="537" alt="Screenshot 2022-10-19 at 00 41 41" src="https://user-images.githubusercontent.com/23194814/196558740-1873c0a7-3c27-4f3c-9770-76b227f4e0e5.png">
<img width="537" alt="Screenshot 2022-10-19 at 00 41 50" src="https://user-images.githubusercontent.com/23194814/196558747-33ba948f-44b3-4c18-875a-d0b510a13c98.png">
<img width="537" alt="Screenshot 2022-10-19 at 00 41 57" src="https://user-images.githubusercontent.com/23194814/196558760-651aa826-e878-4448-9b2b-e10738d23099.png">

For more configuration options, check the [Readme](https://github.com/pavlovic-ivan/octo-nudge#configuring-octo-nudge).

My apologies if links in the PR description are different than those in the screenshots. I've ran multiple workflows, to test things out.