### PR TITLE
Fixed inlining of blocks with more than two successors.

### DIFF
--- a/Src/ILGPU.Tests/BasicCalls.cs
+++ b/Src/ILGPU.Tests/BasicCalls.cs
@@ -336,9 +336,41 @@ namespace ILGPU.Tests
 
             var expected =
                 Enumerable.Range(0, Length)
-                .Select(x => new Vector4(x))
-                .ToArray();
+                    .Select(x => new Vector4(x))
+                    .ToArray();
             Verify(output.View, expected);
+        }
+
+        internal static void SwitchInlineKernel(
+            Index1D index,
+            ArrayView1D<int, Stride1D.Dense> input,
+            ArrayView1D<int, Stride1D.Dense> output)
+        {
+            switch (input[index])
+            {
+                case 0:
+                    output[index] = 11;
+                    break;
+                case 1:
+                    output[index] = 22;
+                    break;
+                case 2:
+                    output[index] = 33;
+                    break;
+            }
+        }
+
+        [Fact]
+        [KernelMethod(nameof(SwitchInlineKernel))]
+        public void SwitchInline()
+        {
+            var sourceData = new int[] { 0, 1, 2 };
+            using var buffer = Accelerator.Allocate1D(sourceData);
+            using var target = Accelerator.Allocate1D<int>(sourceData.Length);
+
+            Execute(sourceData.Length, buffer.View, target.View);
+            var expected = new int[] { 11, 22, 33 };
+            Verify(target.View, expected);
         }
     }
 }

--- a/Src/ILGPU/IR/Transformations/Inliner.cs
+++ b/Src/ILGPU/IR/Transformations/Inliner.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2018-2021 ILGPU Project
+//                        Copyright (c) 2018-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Inliner.cs
@@ -147,7 +147,7 @@ namespace ILGPU.IR.Transformations
                     {
                         currentBlock = successors[0];
                         for (int i = 1, e = successors.Length; i < e; ++i)
-                            toProcess.Push(successors[1]);
+                            toProcess.Push(successors[i]);
                         continue;
                     }
                 }


### PR DESCRIPTION
This PR fixes a problem in the `Inliner` transformation that blocked the inlining of function calls in blocks with more than two successors.

This PR also fixes #846. After a detailed investigation, we concluded that no further fix is needed for the problem because the IR was already assumed to be in a certain state before the `InferAddressSpaces` pass is applied to the program.