### PR TITLE
Skip build notifications on forks.

### DIFF
--- a/.github/workflows/nudge.yml
+++ b/.github/workflows/nudge.yml
@@ -11,7 +11,7 @@ jobs:
   nudge:
     runs-on: ubuntu-latest
     environment: nudge
-    if: (!(github.event.workflow_run.name == 'Update Copyright Year' && github.event.workflow_run.event == 'push'))
+    if: (!github.event.repository.fork && !(github.event.workflow_run.name == 'Update Copyright Year' && github.event.workflow_run.event == 'push'))
     steps:
       - name: Send notification
         uses: pavlovic-ivan/octo-nudge@v1


### PR DESCRIPTION
The CI pipeline for the build notifications is failing on forks, because the webhook secrets have not been configured.

Do we need build notifications on forks? Alternatively, we could change the condition to check whether secrets have been configured.