### PR TITLE
Bump dotnet-setup version to 3.0.3. Configure DOTNET_INSTALL_DIR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup the latest .NET 6 SDK
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v3.0.3
         with:
           dotnet-version: 6.0.x
 
@@ -155,18 +155,24 @@ jobs:
 
       - name: Setup the latest .NET 5 SDK
         if: matrix.framework == 'net5.0'
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v3.0.3
+        env:
+          DOTNET_INSTALL_DIR: ${{ matrix.framework == 'cuda' && '~/.' }}
         with:
           dotnet-version: 5.0.x
 
       - name: Setup the latest .NET Core 3.1 SDK
         if: matrix.framework == 'netcoreapp3.1'
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v3.0.3
+        env:
+          DOTNET_INSTALL_DIR: ${{ matrix.framework == 'cuda' && '~/.' }}
         with:
           dotnet-version: 3.1.x
 
       - name: Setup the latest .NET 6 SDK
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v3.0.3
+        env:
+          DOTNET_INSTALL_DIR: ${{ matrix.framework == 'cuda' && '~/.' }}
         with:
           dotnet-version: 6.0.x
 
@@ -228,7 +234,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup the latest .NET 6 SDK
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v3.0.3
         with:
           dotnet-version: 6.0.x
 
@@ -262,7 +268,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup the latest .NET 6 SDK
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v3.0.3
         with:
           dotnet-version: 6.0.x
 


### PR DESCRIPTION
This PR Bumps the `dotnet-setup` github action to version to `v3.0.3`. It also fixes the issue introduced with the new environment variable called DOTNET_INSTALL_DIR, that prevented the self hosted runner, running CUDA jobs, tho install dotnet, and execute the jobs.

This [PR](https://github.com/m4rs-mt/ILGPU/pull/862) can be closed as it contains the same changes that dependabot introduces, plus the fix.

Here is a [working example](https://github.com/pavlovic-ivan/ILGPU-fork2/actions/runs/3389105665).