### PR TITLE
Exposed CapabilityContext constructors

### DIFF
--- a/Src/ILGPU/Backends/PTX/PTXBackend.cs
+++ b/Src/ILGPU/Backends/PTX/PTXBackend.cs
@@ -76,6 +76,27 @@ namespace ILGPU.Backends.PTX
         #region Instance
 
         /// <summary>
+        /// Constructs a new Cuda backend using an implicitly given capability context
+        /// that is derived from the specified architecture.
+        /// </summary>
+        /// <param name="context">The context to use.</param>
+        /// <param name="architecture">The target GPU architecture.</param>
+        /// <param name="instructionSet">The target GPU instruction set.</param>
+        /// <param name="nvvmAPI">Optional NVVM API instance.</param>
+        public PTXBackend(
+            Context context,
+            CudaArchitecture architecture,
+            CudaInstructionSet instructionSet,
+            NvvmAPI nvvmAPI)
+            : this(
+                context,
+                new CudaCapabilityContext(architecture),
+                architecture,
+                instructionSet,
+                nvvmAPI)
+        { }
+
+        /// <summary>
         /// Constructs a new Cuda backend.
         /// </summary>
         /// <param name="context">The context to use.</param>

--- a/Src/ILGPU/Static/CapabilitiesImporter.ttinclude
+++ b/Src/ILGPU/Static/CapabilitiesImporter.ttinclude
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2016-2021 ILGPU Project
+//                        Copyright (c) 2016-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: CapabilitiesImporter.ttinclude
@@ -49,6 +49,9 @@ public class Capability
 
     public bool IsCudaOnly => Cuda != null && OpenCL == null;
     public bool IsOpenCLOnly => Cuda == null && OpenCL != null;
+
+    [XmlIgnore]
+    public string ParameterName => char.ToLower(Name[0]).ToString() + Name.Substring(1);
 }
 
 public class CudaEntry

--- a/Src/ILGPU/Static/CapabilityContext.tt
+++ b/Src/ILGPU/Static/CapabilityContext.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2016-2021 ILGPU Project
+//                        Copyright (c) 2016-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: CapabilityContext.tt/CapabilityContext.cs
@@ -28,7 +28,6 @@ var clCapabilities = capabilities.Where(x => x.IsOpenCLOnly).ToArray();
 #>
 using System;
 using System.Collections.Immutable;
-using ILGPU.Backends;
 using ILGPU.Resources;
 
 namespace ILGPU.Runtime
@@ -93,7 +92,10 @@ namespace ILGPU.Runtime.Cuda
     {
         #region Instance
 
-        internal CudaCapabilityContext(CudaArchitecture arch)
+        /// <summary>
+        /// Create a new capability context of Cuda accelerators.
+        /// </summary>
+        public CudaCapabilityContext(CudaArchitecture arch)
         {
 <# foreach (var c in commonCapabilities.Concat(cudaCapabilities)) { #>
             <#= c.Name #> = arch >= CudaArchitecture.<#= c.Cuda.MinPTX #>;
@@ -140,7 +142,8 @@ namespace ILGPU.Runtime.OpenCL
         #region Static
 
 <#
-    foreach (var c in commonCapabilities.Concat(clCapabilities)) {
+    var allClCapabilities = commonCapabilities.Concat(clCapabilities).ToArray();
+    foreach (var c in allClCapabilities) {
         if (!c.OpenCL.Manual) {
             var extensionList = string.Join(
                 ", ",
@@ -160,11 +163,40 @@ namespace ILGPU.Runtime.OpenCL
 
         #region Instance
 
+        /// <summary>
+        /// Create a new capability context of OpenCL accelerators.
+        /// </summary>
+        public CLCapabilityContext(
+<#
+    for (int i = 0, e = allClCapabilities.Length; i < e; ++i) {
+        string spacer = i + 1 < e ? "," : string.Empty;
+#>
+            bool <#= allClCapabilities[i].ParameterName #><#= spacer #>
+<#
+    }
+#>
+            )
+        {
+            var extensions = ImmutableArray.CreateBuilder<string>();
+<#
+    foreach (var c in allClCapabilities) {
+#>
+            <#= c.Name #> = <#= c.ParameterName #>;
+<#      if (!c.OpenCL.Manual) { #>
+            if (<#= c.Name #>)
+                extensions.AddRange(<#= c.Name #>Extensions);
+<#
+        }
+    }
+#>
+            Extensions = extensions.ToImmutable();
+        }
+
         internal CLCapabilityContext(CLDevice device)
         {
             var extensions = ImmutableArray.CreateBuilder<string>();
 <#
-    foreach (var c in commonCapabilities.Concat(clCapabilities)) {
+    foreach (var c in allClCapabilities) {
         if (c.OpenCL.Manual) {
 #>
             <#= c.Name #> = false;


### PR DESCRIPTION
This PR exposes the `CapabilityContext` constructors of the `Cuda` and `OpenCL` worlds to allow `Backend` instance creation without an `Accelerator` instance. This allows us to precompile kernels offline without having an actual `Accelerator` at hand.

The following code snippet demonstrates offline compilation of a `PTX` (`Cuda`) kernel:
```c#
private static void TestKernel(Index1D index, ArrayView<int> input, ArrayView<int> output)
{
    output[index] = input[index];
}

public static void Main()
{
    using var context = Context.Create(builder => builder
        .CPU(new CPUDevice(2, 1, 1)) // Use a very simplistic CPU accelerator instance
        // .Assertions() // Uncomment to use assertions
        // .Debug() // Uncomment to enable debug symbols
        .Optimize(OptimizationLevel.O2));

    using var backend = new PTXBackend(
        context,
        CudaArchitecture.SM_70,
        CudaInstructionSet.ISA_70,
        null);

    var entryPoint = EntryPointDescription.FromExplicitlyGroupedKernel(
        typeof(Program).GetMethod(nameof(TestKernel),
        BindingFlags.NonPublic | BindingFlags.Static));

    var compiledKernel = backend.Compile(entryPoint, default) as PTXCompiledKernel;
    File.WriteAllText("Output.ptx", compiledKernel!.PTXAssembly);
}
```

The output of this program should like (somewhat) like:
```asm
//
// Generated by ILGPU v1.3.0
//

.version 7.0
.target sm_70
.address_size 64

.visible .entry Kernel_TestKernel(
	.param .b32 _index_1942,
	.param .align 8 .b8 _input_1946[32],
	.param .align 8 .b8 _output_1960[32]
)
{
	.reg .b16	%rs<3>;
	.reg .b32	%r<3>;
	.reg .b64	%rd<10>;

	ld.param.b32	%r1, [_index_1942];
	ld.param.b64	%rd7, [_input_1946];
	cvta.to.global.u64	%rd1, %rd7;
	ld.param.b64	%rd2, [_input_1946+8];
	ld.param.b64	%rd3, [_input_1946+16];
	ld.param.b8	%rs1, [_input_1946+24];
	ld.param.b64	%rd7, [_output_1960];
	cvta.to.global.u64	%rd4, %rd7;
	ld.param.b64	%rd5, [_output_1960+8];
	ld.param.b64	%rd6, [_output_1960+16];
	ld.param.b8	%rs2, [_output_1960+24];

	mul.wide.u32	%rd8, %r1, 4;
	add.u64	%rd7, %rd4, %rd8;
	mul.wide.u32	%rd9, %r1, 4;
	add.u64	%rd8, %rd1, %rd9;
	ld.global.b32	%r2, [%rd8];
	st.global.b32	[%rd7], %r2;
	ret;

}
```