### PR TITLE
Added support for net70.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup the latest .NET 7 SDK
+        uses: actions/setup-dotnet@v3.0.3
+        with:
+          dotnet-version: 7.0.x
+
       - name: Check Copyright Headers
         run: |
           dotnet run --configuration=Release -p:TreatWarningsAsErrors=true --project Tools/CopyrightUpdateTool
@@ -124,13 +129,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup the latest .NET 6 SDK
+      - name: Setup the latest .NET 7 SDK
         uses: actions/setup-dotnet@v3.0.3
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 7.0.x
 
       - name: Build
-        run: dotnet build --configuration=Release -p:TreatWarningsAsErrors=true ${{ matrix.path }}
+        run: dotnet build ${{ matrix.path }} --configuration=Release -p:TreatWarningsAsErrors=true
 
   # Run tests for all supported combinations of OS/library/framework.
   test-library:
@@ -139,7 +144,7 @@ jobs:
       matrix:
         os: ${{ fromJson(needs.setup-os-matrix.outputs.os) }}
         library: [ILGPU, ILGPU.Algorithms]
-        framework: [netcoreapp3.1, net5.0, net6.0]
+        framework: [netcoreapp3.1, net5.0, net6.0, net7.0]
         include:
           - os: windows-latest
             library: ILGPU
@@ -153,14 +158,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup the latest .NET 5 SDK
-        if: matrix.framework == 'net5.0'
-        uses: actions/setup-dotnet@v3.0.3
-        env:
-          DOTNET_INSTALL_DIR: ${{ matrix.framework == 'cuda' && '~/.' }}
-        with:
-          dotnet-version: 5.0.x
-
       - name: Setup the latest .NET Core 3.1 SDK
         if: matrix.framework == 'netcoreapp3.1'
         uses: actions/setup-dotnet@v3.0.3
@@ -169,12 +166,28 @@ jobs:
         with:
           dotnet-version: 3.1.x
 
+      - name: Setup the latest .NET 5 SDK
+        if: matrix.framework == 'net5.0'
+        uses: actions/setup-dotnet@v3.0.3
+        env:
+          DOTNET_INSTALL_DIR: ${{ matrix.framework == 'cuda' && '~/.' }}
+        with:
+          dotnet-version: 5.0.x
+
       - name: Setup the latest .NET 6 SDK
+        if: matrix.framework == 'net6.0'
         uses: actions/setup-dotnet@v3.0.3
         env:
           DOTNET_INSTALL_DIR: ${{ matrix.framework == 'cuda' && '~/.' }}
         with:
           dotnet-version: 6.0.x
+
+      - name: Setup the latest .NET 7 SDK
+        uses: actions/setup-dotnet@v3.0.3
+        env:
+          DOTNET_INSTALL_DIR: ${{ matrix.framework == 'cuda' && '~/.' }}
+        with:
+          dotnet-version: 7.0.x
 
       - name: Set test flavor
         id: test-flavor
@@ -182,7 +195,7 @@ jobs:
         run: echo "flavor=$([[ "${{ matrix.os }}" == cuda-* ]] && echo "Cuda" || echo "CPU")" >> $GITHUB_OUTPUT
 
       - name: Build and test
-        run: dotnet test --configuration=Release --framework=${{ matrix.framework }} -p:TreatWarningsAsErrors=true --logger GitHubActions Src/${{ matrix.library }}.Tests.${{ steps.test-flavor.outputs.flavor }}
+        run: dotnet test Src/${{ matrix.library }}.Tests.${{ steps.test-flavor.outputs.flavor }} --configuration=Release --framework=${{ matrix.framework }} -p:TreatWarningsAsErrors=true --logger GitHubActions
         env:
           ILGPU_CLEAN_TESTS: ${{ github.event_name == 'schedule' || (github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))) }}
 
@@ -233,10 +246,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup the latest .NET 6 SDK
+      - name: Setup the latest .NET 7 SDK
         uses: actions/setup-dotnet@v3.0.3
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 7.0.x
 
       - name: Create NuGet packages
         run: |
@@ -246,7 +259,7 @@ jobs:
             $params = "--version-suffix", $suffix
           }
 
-          dotnet pack --configuration=Release @params Src
+          dotnet pack Src --configuration=Release @params
 
       - name: Fix NuGet Symbols Packages
         run: .github/workflows/Scripts/FixNugetSymbolPackages.ps1 -version "${{ needs.check-version.outputs.version }}"
@@ -267,10 +280,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup the latest .NET 6 SDK
+      - name: Setup the latest .NET 7 SDK
         uses: actions/setup-dotnet@v3.0.3
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 7.0.x
 
       # Change the ILGPU project references to NuGet package references
       - name: Update sample references

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
           if [[ -z "$(git status --porcelain)" ]]; then
             exit 0
           else
+            git status --porcelain
             exit 1
           fi
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,25 +18,23 @@ jobs:
       security-events: write
 
     # GUI samples can only be built on Windows.
-    # CodeQL does not yet support Windows Server 2022.
-    # (see https://github.com/github/codeql-action/issues/850)
-    runs-on: windows-2019
+    runs-on: windows-latest
 
     # Parallelize CodeQL building and analysis for performance reasons.
     strategy:
       fail-fast: false
       matrix:
         solution: [Src/ILGPU.sln, Samples/ILGPU.Samples.sln]
-        framework: [net471, netcoreapp3.1, net5.0, net6.0]
+        framework: [net471, netcoreapp3.1, net5.0, net6.0, net7.0]
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
 
-    - name: Setup the latest .NET 6 SDK
-      uses: actions/setup-dotnet@v2
+    - name: Setup the latest .NET 7 SDK
+      uses: actions/setup-dotnet@v3.0.3
       with:
-        dotnet-version: '6.0.x'
+        dotnet-version: 7.0.x
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -60,6 +58,7 @@ jobs:
           "netcoreapp3.1" { $LibraryTargetFrameworks="netstandard2.1" }
           "net5.0" { $LibrarySamplesTargetFrameworksWindows="net5.0-windows" }
           "net6.0" { $LibrarySamplesTargetFrameworksWindows="net6.0-windows" }
+          "net7.0" { $LibrarySamplesTargetFrameworksWindows="net7.0-windows" }
         }
         dotnet build -p:UseSharedCompilation=false `
                      -p:LibraryTargetFrameworks=$LibraryTargetFrameworks `

--- a/Samples/BlazorSampleApp/BlazorSampleApp.csproj
+++ b/Samples/BlazorSampleApp/BlazorSampleApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/Samples/Directory.Build.props
+++ b/Samples/Directory.Build.props
@@ -22,6 +22,7 @@
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
     <LibrarySamplesTargetFrameworks>net471;netcoreapp3.1;net5.0;net6.0;net7.0</LibrarySamplesTargetFrameworks>
     <LibrarySamplesTargetFrameworksWindows>net471;netcoreapp3.1;net5.0-windows;net6.0-windows;net7.0-windows</LibrarySamplesTargetFrameworksWindows>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/Samples/Directory.Build.props
+++ b/Samples/Directory.Build.props
@@ -1,5 +1,9 @@
 ﻿<Project>
-  <PropertyGroup Condition="'$(MSBuildVersion)' &gt;= '17.0'">
+  <PropertyGroup Condition="'$(MSBuildVersion)' &gt;= '17.4'">
+    <LibrarySamplesTargetFrameworks>net7.0</LibrarySamplesTargetFrameworks>
+    <LibrarySamplesTargetFrameworksWindows>net7.0-windows</LibrarySamplesTargetFrameworksWindows>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(MSBuildVersion)' &gt;= '17.0' AND '$(MSBuildVersion)' &lt; '17.4'">
     <LibrarySamplesTargetFrameworks>net6.0</LibrarySamplesTargetFrameworks>
     <LibrarySamplesTargetFrameworksWindows>net6.0-windows</LibrarySamplesTargetFrameworksWindows>
   </PropertyGroup>
@@ -16,8 +20,8 @@
     <LibrarySamplesTargetFrameworksWindows>net471</LibrarySamplesTargetFrameworksWindows>
   </PropertyGroup>
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-    <LibrarySamplesTargetFrameworks>net471;netcoreapp3.1;net5.0;net6.0</LibrarySamplesTargetFrameworks>
-    <LibrarySamplesTargetFrameworksWindows>net471;netcoreapp3.1;net5.0-windows;net6.0-windows</LibrarySamplesTargetFrameworksWindows>
+    <LibrarySamplesTargetFrameworks>net471;netcoreapp3.1;net5.0;net6.0;net7.0</LibrarySamplesTargetFrameworks>
+    <LibrarySamplesTargetFrameworksWindows>net471;netcoreapp3.1;net5.0-windows;net6.0-windows;net7.0-windows</LibrarySamplesTargetFrameworksWindows>
   </PropertyGroup>
 
 </Project>

--- a/Samples/MonitorProgress/CudaProgress.cs
+++ b/Samples/MonitorProgress/CudaProgress.cs
@@ -13,6 +13,7 @@ using ILGPU;
 using ILGPU.Runtime;
 using ILGPU.Runtime.Cuda;
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 #pragma warning disable CA2213
 
@@ -83,6 +84,10 @@ namespace MonitorProgress
         /// <summary>
         /// Holds the Cuda memory buffer that contains the progress value.
         /// </summary>
+        [SuppressMessage(
+            "Microsoft.Usage",
+            "CA2213: Disposable fields should be disposed",
+            Justification = "This is disposed in DisposeAcceleratorObject")]
         private readonly CudaProgressMemoryBuffer memoryBuffer;
 
         /// <summary>

--- a/Src/Directory.Build.props
+++ b/Src/Directory.Build.props
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
     <LibraryTargetFrameworks>$(LibraryTargetFrameworks);net471;netstandard2.1;net5.0;net6.0</LibraryTargetFrameworks>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -20,6 +21,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
     <LibraryUnitTestTargetFrameworks>$(LibraryUnitTestTargetFrameworks);net471;netcoreapp3.1;net5.0;net6.0</LibraryUnitTestTargetFrameworks>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 
   <Import Project="..\Tools\CheckStyles\ILGPU.CheckStyles.targets" />

--- a/Src/Directory.Build.props
+++ b/Src/Directory.Build.props
@@ -1,10 +1,10 @@
 ﻿<Project>
   <!-- Library Project Configuration -->
   <PropertyGroup>
-    <LibraryTargetFrameworks>net6.0</LibraryTargetFrameworks>
+    <LibraryTargetFrameworks>net7.0</LibraryTargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-    <LibraryTargetFrameworks>$(LibraryTargetFrameworks);net471;netstandard2.1;net5.0</LibraryTargetFrameworks>
+    <LibraryTargetFrameworks>$(LibraryTargetFrameworks);net471;netstandard2.1;net5.0;net6.0</LibraryTargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -16,10 +16,10 @@
 
   <!-- Unit Test Project Configuration -->
   <PropertyGroup>
-    <LibraryUnitTestTargetFrameworks>net6.0</LibraryUnitTestTargetFrameworks>
+    <LibraryUnitTestTargetFrameworks>net7.0</LibraryUnitTestTargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-    <LibraryUnitTestTargetFrameworks>$(LibraryUnitTestTargetFrameworks);net471;netcoreapp3.1;net5.0</LibraryUnitTestTargetFrameworks>
+    <LibraryUnitTestTargetFrameworks>$(LibraryUnitTestTargetFrameworks);net471;netcoreapp3.1;net5.0;net6.0</LibraryUnitTestTargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\Tools\CheckStyles\ILGPU.CheckStyles.targets" />

--- a/Src/ILGPU.Algorithms/ILGPU.Algorithms.csproj
+++ b/Src/ILGPU.Algorithms/ILGPU.Algorithms.csproj
@@ -14,7 +14,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NeutralLanguage>en-US</NeutralLanguage>
     <!-- CAUTION: ILGPU supports a limited subset only - due to the .Net 4.7 backwards compatibility -->
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Src/ILGPU.Algorithms/RadixSortExtensions.cs
+++ b/Src/ILGPU.Algorithms/RadixSortExtensions.cs
@@ -17,6 +17,7 @@ using ILGPU.Runtime;
 using ILGPU.Util;
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
@@ -168,6 +169,10 @@ namespace ILGPU.Algorithms
     {
         #region Instance
 
+        [SuppressMessage(
+            "Microsoft.Usage",
+            "CA2213: Disposable fields should be disposed",
+            Justification = "This is disposed in DisposeAccelerator")]
         private readonly MemoryBuffer1D<int, Stride1D.Dense> tempBuffer;
 
         internal RadixSortProvider(Accelerator accelerator, int tempSize)

--- a/Src/ILGPU.Algorithms/Random/RNG.cs
+++ b/Src/ILGPU.Algorithms/Random/RNG.cs
@@ -13,6 +13,7 @@ using ILGPU.Algorithms.Random.Operations;
 using ILGPU.Runtime;
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace ILGPU.Algorithms.Random
@@ -327,6 +328,10 @@ namespace ILGPU.Algorithms.Random
         /// <summary>
         /// Stores a single RNG instance per warp.
         /// </summary>
+        [SuppressMessage(
+            "Microsoft.Usage",
+            "CA2213: Disposable fields should be disposed",
+            Justification = "This is disposed in DisposeAccelerator")]
         private readonly MemoryBuffer1D<
             TRandomProvider,
             Stride1D.Dense> randomProvidersPerWarp;

--- a/Src/ILGPU.Algorithms/Runtime/Cuda/CuFFTWStructs.cs
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/CuFFTWStructs.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                   ILGPU Algorithms
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: CuFFTWStructs.cs
@@ -13,6 +13,7 @@ using System;
 
 #pragma warning disable CA1051 // Do not declare visible instance fields
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+#pragma warning disable CS8981 // The type name only contains lower-cased ascii characters
 #pragma warning disable IDE1006 // Naming Styles
 
 namespace ILGPU.Runtime.Cuda
@@ -34,4 +35,5 @@ namespace ILGPU.Runtime.Cuda
 
 #pragma warning restore CA1051 // Do not declare visible instance fields
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
+#pragma warning restore CS8981 // The type name only contains lower-cased ascii characters
 #pragma warning restore IDE1006 // Naming Styles

--- a/Src/ILGPU.Algorithms/ScanExtensions.cs
+++ b/Src/ILGPU.Algorithms/ScanExtensions.cs
@@ -13,6 +13,7 @@ using ILGPU.Algorithms.Resources;
 using ILGPU.Algorithms.ScanReduceOperations;
 using ILGPU.Runtime;
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using static ILGPU.Algorithms.GroupExtensions;
 
@@ -84,6 +85,10 @@ namespace ILGPU.Algorithms
     {
         #region Instance
 
+        [SuppressMessage(
+            "Microsoft.Usage",
+            "CA2213: Disposable fields should be disposed",
+            Justification = "This is disposed in DisposeAccelerator")]
         private readonly MemoryBuffer1D<int, Stride1D.Dense> tempBuffer;
 
         internal ScanProvider(Accelerator accelerator, LongIndex1D dataLength)

--- a/Src/ILGPU/Frontend/Intrinsic/Intrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/Intrinsics.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2018-2021 ILGPU Project
+//                        Copyright (c) 2018-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Intrinsics.cs
@@ -13,6 +13,7 @@ using ILGPU.IR;
 using ILGPU.IR.Types;
 using ILGPU.IR.Values;
 using ILGPU.Resources;
+using ILGPU.Util;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -85,6 +86,7 @@ namespace ILGPU.Frontend.Intrinsic
                 { typeof(Debug), HandleDebugAndTrace },
                 { typeof(Trace), HandleDebugAndTrace },
                 { typeof(RuntimeHelpers), HandleRuntimeHelper },
+                { typeof(Unsafe), HandleUnsafe }
             };
 
         private static readonly DeviceFunctionHandler<IntrinsicAttribute>[]
@@ -297,6 +299,42 @@ namespace ILGPU.Frontend.Intrinsic
                         targetIndex),
                     irValue);
             }
+        }
+
+        /// <summary>
+        /// Handles unsafe runtime operations.
+        /// </summary>
+        /// <param name="context">The current invocation context.</param>
+        /// <returns>The resulting value.</returns>
+        private static Value HandleUnsafe(ref InvocationContext context)
+        {
+            switch (context.Method.Name)
+            {
+                case nameof(Unsafe.As):
+                    return ConvertUnsafeAs(ref context);
+            }
+            throw context.Location.GetNotSupportedException(
+                ErrorMessages.NotSupportedIntrinsic, context.Method.Name);
+        }
+
+        /// <summary>
+        /// Converts basic reinterpret casts.
+        /// </summary>
+        /// <param name="context">The current invocation context.</param>
+        private static Value ConvertUnsafeAs(ref InvocationContext context)
+        {
+            var codeGenerator = context.CodeGenerator;
+            var location = context.Location;
+            var sourceValue = context[0];
+            var methodReturnType = context.TypeContext.CreateType(
+                context.Method.GetReturnType()).As<PointerType>(location);
+
+            return sourceValue.Type == methodReturnType || methodReturnType.IsRootType
+                ? sourceValue.Resolve()
+                : codeGenerator.CreateConversion(
+                    sourceValue,
+                    methodReturnType,
+                    ConvertFlags.None);
         }
 
         #endregion

--- a/Src/ILGPU/ILGPU.csproj
+++ b/Src/ILGPU/ILGPU.csproj
@@ -50,7 +50,6 @@
     </PackageReference>
     <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
     <PackageReference Include="System.Memory" Version="4.5.5" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageReference Include="System.Reflection.Metadata" Version="7.0.0" />
     <PackageReference Include="T4.Build" Version="0.2.4" PrivateAssets="All" />
   </ItemGroup>

--- a/Src/ILGPU/ILGPU.csproj
+++ b/Src/ILGPU/ILGPU.csproj
@@ -14,7 +14,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NeutralLanguage>en-US</NeutralLanguage>
     <!-- CAUTION: ILGPU supports a limited subset only - due to the .Net 4.7 backwards compatibility -->
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Src/ILGPU/IR/Analyses/CFG.cs
+++ b/Src/ILGPU/IR/Analyses/CFG.cs
@@ -102,7 +102,7 @@ namespace ILGPU.IR.Analyses
 
                 internal NodeCollection(
                     CFG<TOrder, TDirection> cfg,
-                    in ReadOnlySpan<BasicBlock> collection)
+                    ReadOnlySpan<BasicBlock> collection)
                 {
                     CFG = cfg;
                     links = collection;

--- a/Src/ILGPU/IR/Analyses/CFG.cs
+++ b/Src/ILGPU/IR/Analyses/CFG.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2018-2021 ILGPU Project
+//                        Copyright (c) 2018-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: CFG.cs
@@ -41,6 +41,10 @@ namespace ILGPU.IR.Analyses
     /// </summary>
     /// <typeparam name="TOrder">The underlying block order.</typeparam>
     /// <typeparam name="TDirection">The control-flow direction.</typeparam>
+    [SuppressMessage(
+        "Microsoft.Naming",
+        "CA1710: IdentifiersShouldHaveCorrectSuffix",
+        Justification = "This is the correct name of the current entity")]
     public sealed class CFG<TOrder, TDirection> :
         IReadOnlyCollection<CFG<TOrder, TDirection>.Node>
         where TOrder : struct, ITraversalOrder

--- a/Src/ILGPU/IR/Analyses/Phis.cs
+++ b/Src/ILGPU/IR/Analyses/Phis.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2018-2021 ILGPU Project
+//                        Copyright (c) 2018-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Phis.cs
@@ -112,7 +112,7 @@ namespace ILGPU.IR.Analyses
             /// Seals the current builder and creates a <see cref="Phis"/> instance.
             /// </summary>
             /// <returns>The created <see cref="Phis"/> instance.</returns>
-            public Phis Seal() => new Phis(Method, ref phiValues);
+            public Phis Seal() => new Phis(Method, phiValues.AsReadOnlySpan());
 
             #endregion
         }
@@ -165,11 +165,11 @@ namespace ILGPU.IR.Analyses
         /// Constructs a new Phis instance.
         /// </summary>
         /// <param name="method">The parent method.</param>
-        /// <param name="phis">All detected phi values.</param>
-        private Phis(Method method, ref PhiValueList phis)
+        /// <param name="phiValues">All detected phi values.</param>
+        private Phis(Method method, ReadOnlySpan<PhiValue> phiValues)
         {
             Method = method;
-            Values = phis.AsReadOnlySpan();
+            Values = phiValues;
         }
 
         #endregion

--- a/Src/ILGPU/IR/BasicBlockMapping.cs
+++ b/Src/ILGPU/IR/BasicBlockMapping.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2020-2021 ILGPU Project
+//                        Copyright (c) 2020-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: BasicBlockMapping.cs
@@ -14,6 +14,7 @@ using ILGPU.IR.Analyses.TraversalOrders;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 #pragma warning disable CS0282 // There is no defined ordering between fields in
@@ -384,6 +385,10 @@ namespace ILGPU.IR
     /// A mapping of basic block to values.
     /// </summary>
     /// <typeparam name="T">The value type.</typeparam>
+    [SuppressMessage(
+        "Microsoft.Naming",
+        "CA1710: IdentifiersShouldHaveCorrectSuffix",
+        Justification = "This is the correct name of the current entity")]
     public partial struct BasicBlockMap<T> : IReadOnlyCollection<(BasicBlock, T)>
     {
         #region Nested Types

--- a/Src/ILGPU/IR/Construction/SSABuilder.cs
+++ b/Src/ILGPU/IR/Construction/SSABuilder.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2018-2021 ILGPU Project
+//                        Copyright (c) 2018-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: SSABuilder.cs
@@ -368,7 +368,7 @@ namespace ILGPU.IR.Construction
             /// <param name="incompletePhi">An incomplete phi node to complete.</param>
             /// <param name="markerProvider">A provider of new marker values.</param>
             private Value SetupPhiArguments(
-                in IncompletePhi incompletePhi,
+                IncompletePhi incompletePhi,
                 ref MarkerProvider markerProvider)
             {
                 var phiBuilder = incompletePhi.PhiBuilder;

--- a/Src/ILGPU/IR/Transformations/IfConversion.cs
+++ b/Src/ILGPU/IR/Transformations/IfConversion.cs
@@ -1038,7 +1038,7 @@ namespace ILGPU.IR.Transformations
             /// </summary>
             /// <param name="blocks">The current block collection.</param>
             /// <param name="maxBlockSize">The maximum block size.</param>
-            public ConditionalAnalyzer(in BlockCollection blocks, int maxBlockSize)
+            public ConditionalAnalyzer(BlockCollection blocks, int maxBlockSize)
             {
                 kinds = blocks.CreateMap<BlockKind>();
 
@@ -1257,10 +1257,10 @@ namespace ILGPU.IR.Transformations
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             internal ConditionalConverter(
                 Method.Builder builder,
-                in BasicBlockMap<BlockKind> kinds,
-                in BlockCollection blocks,
+                BasicBlockMap<BlockKind> kinds,
+                BlockCollection blocks,
                 ReadOnlySpan<ValueReference> phis,
-                in CaseBlocks caseBlocks)
+                CaseBlocks caseBlocks)
             {
                 Blocks = blocks;
                 Kinds = kinds;

--- a/Src/ILGPU/IR/Values/Use.cs
+++ b/Src/ILGPU/IR/Values/Use.cs
@@ -186,7 +186,7 @@ namespace ILGPU.IR.Values
             /// </summary>
             /// <param name="node">The node.</param>
             /// <param name="uses">The list of all uses.</param>
-            internal Enumerator(Value node, in ReadOnlySpan<Use> uses)
+            internal Enumerator(Value node, ReadOnlySpan<Use> uses)
             {
                 Node = node;
                 enumerator = uses.GetEnumerator();
@@ -225,7 +225,7 @@ namespace ILGPU.IR.Values
         /// </summary>
         /// <param name="node">The associated node.</param>
         /// <param name="uses">The set of associated uses.</param>
-        internal UseCollection(Value node, in ReadOnlySpan<Use> uses)
+        internal UseCollection(Value node, ReadOnlySpan<Use> uses)
         {
             Node = node;
             Uses = uses;

--- a/Src/ILGPU/Runtime/CPU/CPUAccelerator.cs
+++ b/Src/ILGPU/Runtime/CPU/CPUAccelerator.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2016-2021 ILGPU Project
+//                        Copyright (c) 2016-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: CPUAccelerator.cs
@@ -14,6 +14,7 @@ using ILGPU.Backends.IL;
 using ILGPU.Resources;
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Threading;
@@ -69,7 +70,16 @@ namespace ILGPU.Runtime.CPU
         private readonly object taskSynchronizationObject = new object();
         private volatile CPUAcceleratorTask currentTask;
 
+        [SuppressMessage(
+            "Microsoft.Usage",
+            "CA2213: Disposable fields should be disposed",
+            Justification = "This is disposed in DisposeAccelerator_SyncRoot")]
         private readonly Barrier finishedEventPerMultiprocessor;
+
+        [SuppressMessage(
+            "Microsoft.Usage",
+            "CA2213: Disposable fields should be disposed",
+            Justification = "This is disposed in DisposeAccelerator_SyncRoot")]
         private readonly SemaphoreSlim taskConcurrencyLimit = new SemaphoreSlim(1);
 
         /// <summary>

--- a/Src/ILGPU/Runtime/CPU/CPUMemoryBuffer.cs
+++ b/Src/ILGPU/Runtime/CPU/CPUMemoryBuffer.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2017-2021 ILGPU Project
+//                        Copyright (c) 2017-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: CPUMemoryBuffer.cs
@@ -13,6 +13,7 @@ using ILGPU.Resources;
 using ILGPU.Runtime.Cuda;
 using ILGPU.Runtime.OpenCL;
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -374,6 +375,10 @@ namespace ILGPU.Runtime.CPU
         {
             #region Instance
 
+            [SuppressMessage(
+                "Microsoft.Usage",
+                "CA2213: Disposable fields should be disposed",
+                Justification = "This is disposed in DisposeAcceleratorObject")]
             private readonly PageLockScope<byte> pageLockScope;
 
             /// <summary>

--- a/Src/ILGPU/Runtime/CPU/CPUMemoryBufferCache.cs
+++ b/Src/ILGPU/Runtime/CPU/CPUMemoryBufferCache.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: CPUMemoryBufferCache.cs
@@ -11,6 +11,7 @@
 
 using ILGPU.Runtime.CPU;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace ILGPU.Runtime
 {
@@ -25,6 +26,10 @@ namespace ILGPU.Runtime
         /// This represents the actual memory cache.
         /// </summary>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        [SuppressMessage(
+            "Microsoft.Usage",
+            "CA2213: Disposable fields should be disposed",
+            Justification = "This is disposed in DisposeAcceleratorObject")]
         private MemoryBuffer<ArrayView1D<byte, Stride1D.Dense>> cache;
 
         /// <summary>

--- a/Src/ILGPU/Runtime/CPU/CPURuntimeWarpContext.cs
+++ b/Src/ILGPU/Runtime/CPU/CPURuntimeWarpContext.cs
@@ -12,6 +12,7 @@
 using ILGPU.Resources;
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace ILGPU.Runtime.CPU
@@ -179,6 +180,10 @@ namespace ILGPU.Runtime.CPU
         /// <summary>
         /// A temporary location for shuffle values.
         /// </summary>
+        [SuppressMessage(
+            "Microsoft.Usage",
+            "CA2213: Disposable fields should be disposed",
+            Justification = "This is disposed in DisposeAcceleratorObject")]
         private readonly CPUMemoryBufferCache shuffleBuffer;
 
         /// <summary>

--- a/Tools/CopyrightUpdateTool/CopyrightUpdateTool.csproj
+++ b/Tools/CopyrightUpdateTool/CopyrightUpdateTool.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
   </ItemGroup>
 
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.0",
+    "version": "7.0.0",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }


### PR DESCRIPTION
This PR adds support for compiling ILGPU using the .NET 7.0 SDK.

The CI pipeline has been modified to use the newer SDK. The `dotnet` tool appears to have swapped the order of some arguments, so this has been adjusted.

Updated the C# language version to 9, to fix an issue with `IntPtr` - it is now treated as a `nint`, which only became available in C# 9.

Fixed various compiler warnings. In particular, our custom `DisposeAcceleratorObject` function is not recognised by the Dispose pattern.

Fixed issues with the `in` parameter modifier. The mean appears to have changed. Previously, it behaved more like "here is a read-only struct". We would copy the struct when it was used. Now, the "this is passed by reference" is being enforced. So we have modified ILGPU to remove the `in` parameter modified, and to copy the struct as the argument.

Fixed an issue with the `ref` parameter modifier. This appears to be more strictly enforced. We used to return a reference to a local variable, but now that is no longer permitted.

Finally, fixed an issue with `Unsafe.As`. This has become a .NET intrinsic, and no longer provides MSIL code. We have had to replicate it's behavior within ILGPU.