### PR TITLE
Added support for Generic Math using net70 SDK.

### DIFF
--- a/Src/ILGPU.Tests/Configurations.txt
+++ b/Src/ILGPU.Tests/Configurations.txt
@@ -5,6 +5,7 @@ DisassemblerTests
 EnumValues
 FixedBuffers
 GetKernelTests
+GenericMath
 Indices
 KernelEntryPoints
 MemoryBufferOperations

--- a/Src/ILGPU.Tests/GenericMath.cs
+++ b/Src/ILGPU.Tests/GenericMath.cs
@@ -1,0 +1,99 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                           Copyright (c) 2022 ILGPU Project
+//                                    www.ilgpu.net
+//
+// File: GenericMath.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details.
+// ---------------------------------------------------------------------------------------
+
+using ILGPU.Runtime;
+using System.Linq;
+using System.Numerics;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ILGPU.Tests
+{
+    public abstract class GenericMath : TestBase
+    {
+        protected GenericMath(ITestOutputHelper output, TestContext testContext)
+            : base(output, testContext)
+        { }
+
+#if NET7_0_OR_GREATER
+
+        private const int Length = 1024;
+
+        public static T GeZeroIfBigger<T>(T value, T max) where T : INumber<T>
+        {
+            if (value > max)
+                return T.Zero;
+            return value;
+        }
+
+        internal static void GenericMathKernel<T>(
+            Index1D index,
+            ArrayView1D<T, Stride1D.Dense> input,
+            ArrayView1D<T, Stride1D.Dense> output,
+            T maxValue)
+            where T : unmanaged, INumber<T>
+        {
+            output[index] = GeZeroIfBigger(input[index], maxValue);
+        }
+
+        private void TestGenericMathKernel<T>(T[] inputValues, T[] expected, T maxValue)
+            where T : unmanaged, INumber<T>
+        {
+            using var input = Accelerator.Allocate1D<T>(inputValues);
+            using var output = Accelerator.Allocate1D<T>(Length);
+
+            using var start = Accelerator.DefaultStream.AddProfilingMarker();
+            Accelerator.LaunchAutoGrouped<
+                Index1D,
+                ArrayView1D<T, Stride1D.Dense>,
+                ArrayView1D<T, Stride1D.Dense>,
+                T>(
+                GenericMathKernel,
+                Accelerator.DefaultStream,
+                (int)input.Length,
+                input.View,
+                output.View,
+                maxValue);
+
+            Verify(output.View, expected);
+        }
+
+        [Fact]
+        public void GenericMathIntTest()
+        {
+            const int MaxValue = 50;
+            var input = Enumerable.Range(0, Length).ToArray();
+
+            var expected = input
+                .Select(x => GeZeroIfBigger(x, MaxValue))
+                .ToArray();
+
+            TestGenericMathKernel(input, expected, MaxValue);
+        }
+
+        [Fact]
+        public void GenericMathDoubleTest()
+        {
+            const double MaxValue = 75.0;
+            var input = Enumerable.Range(0, Length)
+                .Select(x => (double)x)
+                .ToArray();
+
+            var expected = input
+                .Select(x => GeZeroIfBigger(x, MaxValue))
+                .ToArray();
+
+            TestGenericMathKernel(input, expected, MaxValue);
+        }
+
+#endif
+    }
+}

--- a/Src/ILGPU/Frontend/CodeGenerator/CodeGenerator.cs
+++ b/Src/ILGPU/Frontend/CodeGenerator/CodeGenerator.cs
@@ -142,7 +142,8 @@ namespace ILGPU.Frontend
             }
 
             // Initialize locals
-            var localVariables = Method.GetMethodBody().LocalVariables;
+            var methodBody = Disassembler.ExtractMethodBody(Method);
+            var localVariables = methodBody.LocalVariables;
             for (int i = 0, e = localVariables.Count; i < e; ++i)
             {
                 var variable = localVariables[i];

--- a/Src/ILGPU/Frontend/Disassembler.cs
+++ b/Src/ILGPU/Frontend/Disassembler.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2018-2021 ILGPU Project
+//                        Copyright (c) 2018-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Disassembler.cs
@@ -15,6 +15,7 @@ using ILGPU.Resources;
 using ILGPU.Util;
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
@@ -27,7 +28,60 @@ namespace ILGPU.Frontend
     /// <remarks>Members of this class are not thread safe.</remarks>
     public sealed partial class Disassembler : ILocation
     {
-        #region Constants
+        #region Static
+
+        /// <summary>
+        /// Indicates whether the .NET runtime has support for Static Abstract methods
+        /// in Interfaces.
+        /// </summary>
+        [SuppressMessage("Performance", "CA1802:Use literals where appropriate")]
+        private static readonly bool UsingStaticAbstractMethodsInInterfaces =
+#if NET7_0_OR_GREATER
+            RuntimeFeature.IsSupported(RuntimeFeature.VirtualStaticsInInterfaces);
+#else
+            false;
+#endif
+
+        /// <summary>
+        /// Extracts the method body for the given method.
+        /// </summary>
+        /// <param name="method">The method.</param>
+        /// <returns>The method body.</returns>
+        public static MethodBody ExtractMethodBody(MethodBase method)
+        {
+            var methodBody = method.GetMethodBody();
+            if (methodBody == null &&
+                UsingStaticAbstractMethodsInInterfaces &&
+                method.DeclaringType.IsInterface &&
+                method.IsStatic &&
+                method.IsAbstract)
+            {
+                // Support for Static Abstract methods in Interfaces was introduced in
+                // C# 11, in particular, adding support for Generic Math. The interface
+                // itself does not contain the method implementation itself. Instead, we
+                // need to find the concrete type that implements the interface, and find
+                // the matching method.
+                var concreteType = method.DeclaringType.GetGenericArguments()[0];
+                var interfaceMap = concreteType.GetInterfaceMap(method.DeclaringType);
+
+                for (int i = 0; i < interfaceMap.InterfaceMethods.Length; i++)
+                {
+                    if (interfaceMap.InterfaceMethods[i].Name.Equals(
+                        method.Name,
+                        StringComparison.OrdinalIgnoreCase))
+                    {
+                        methodBody = interfaceMap.TargetMethods[i].GetMethodBody();
+                        break;
+                    }
+                }
+            }
+
+            return methodBody;
+        }
+
+#endregion
+
+#region Constants
 
         /// <summary>
         /// Represents the native pointer type that is used during the
@@ -98,7 +152,7 @@ namespace ILGPU.Frontend
                 ? MethodBase.GetGenericArguments()
                 : Array.Empty<Type>();
             TypeGenericArguments = MethodBase.DeclaringType.GetGenericArguments();
-            MethodBody = MethodBase.GetMethodBody();
+            MethodBody = ExtractMethodBody(MethodBase);
             if (MethodBody == null)
             {
                 throw new NotSupportedException(string.Format(


### PR DESCRIPTION
Fixes #802.

Note that the functionality is only available on `net70`. The feature is still marked as "preview" on `net60`, and we would need to compile ILGPU with the "enable preview features" flag turned on, which we do not want to do.