### PR TITLE
Fixed compilation warnings from updated net7.0 SDK.

### DIFF
--- a/Samples/.editorconfig
+++ b/Samples/.editorconfig
@@ -145,3 +145,6 @@ dotnet_diagnostic.CA1814.severity = none
 
 # CA1815: Override equals and operator equals on value types
 dotnet_diagnostic.CA1815.severity = none
+
+# CA1852: Seal internal types
+dotnet_diagnostic.CA1852.severity = none

--- a/Samples/Mandelbrot/Mandelbrot.cs
+++ b/Samples/Mandelbrot/Mandelbrot.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                    ILGPU Samples
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Mandelbrot.cs
@@ -16,7 +16,7 @@ using ILGPU.Runtime.Cuda;
 
 namespace Mandelbrot
 {
-    class Mandelbrot
+    static class Mandelbrot
     {
         /// <summary>
         /// ILGPU kernel for Mandelbrot set.

--- a/Samples/Mandelbrot/Utils.cs
+++ b/Samples/Mandelbrot/Utils.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                    ILGPU Samples
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Utils.cs
@@ -14,7 +14,7 @@ using System.Diagnostics;
 
 namespace Mandelbrot
 {
-    class Utils
+    static class Utils
     {
         /// <summary>
         /// Internal stop watch object.

--- a/Src/ILGPU/Backends/PTX/PTXBackend.cs
+++ b/Src/ILGPU/Backends/PTX/PTXBackend.cs
@@ -195,6 +195,7 @@ namespace ILGPU.Backends.PTX
         /// Creates a new PTX-compatible kernel builder and initializes a
         /// <see cref="PTXCodeGenerator.GeneratorArgs"/> instance.
         /// </summary>
+        [SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase")]
         protected override StringBuilder CreateKernelBuilder(
             EntryPoint entryPoint,
             in BackendContext backendContext,
@@ -226,7 +227,7 @@ namespace ILGPU.Backends.PTX
             builder.Append(".version ");
             builder.AppendLine(InstructionSet.ToString());
             builder.Append(".target ");
-            builder.Append(Architecture.ToString().ToLower());
+            builder.Append(Architecture.ToString().ToLowerInvariant());
             if (useDebugInfo)
                 builder.AppendLine(", debug");
             else

--- a/Src/ILGPU/Backends/PTX/PTXRegisterAllocator.cs
+++ b/Src/ILGPU/Backends/PTX/PTXRegisterAllocator.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2018-2021 ILGPU Project
+//                        Copyright (c) 2018-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: PTXRegisterAllocator.cs
@@ -13,6 +13,7 @@ using ILGPU.IR.Types;
 using ILGPU.IR.Values;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 
 namespace ILGPU.Backends.PTX
@@ -154,8 +155,11 @@ namespace ILGPU.Backends.PTX
         /// </summary>
         /// <param name="register">The primitive register.</param>
         /// <returns>The corresponding device constant string value.</returns>
+        [SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase")]
         private static string ResolveDeviceConstantValue(HardwareRegister register) =>
-            ((DeviceConstantDimension3D)register.RegisterValue).ToString().ToLower();
+            ((DeviceConstantDimension3D)register.RegisterValue)
+                .ToString()
+                .ToLowerInvariant();
 
         /// <summary>
         /// Returns the string representation of the given hardware register.

--- a/Src/ILGPU/Context.cs
+++ b/Src/ILGPU/Context.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2017-2021 ILGPU Project
+//                        Copyright (c) 2017-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Context.cs
@@ -430,7 +430,8 @@ namespace ILGPU
 
             var sorted = Devices
                 .OrderByDescending(d => d.MemorySize)
-                .Where(d => d.AcceleratorType != AcceleratorType.CPU);
+                .Where(d => d.AcceleratorType != AcceleratorType.CPU)
+                .ToList();
 
             if (sorted.Any())
             {

--- a/Src/ILGPU/IR/Values/Constants.cs
+++ b/Src/ILGPU/IR/Values/Constants.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2018-2021 ILGPU Project
+//                        Copyright (c) 2018-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Constants.cs
@@ -14,6 +14,7 @@ using ILGPU.IR.Types;
 using ILGPU.Util;
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text;
 
@@ -380,8 +381,9 @@ namespace ILGPU.IR.Values
         #region Object
 
         /// <summary cref="Node.ToPrefixString"/>
+        [SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase")]
         protected override string ToPrefixString() =>
-            "const.str." + Encoding.EncodingName.ToLower();
+            "const.str." + Encoding.EncodingName.ToLowerInvariant();
 
         /// <summary cref="Value.ToArgString"/>
         protected override string ToArgString() => String;

--- a/Src/ILGPU/Runtime/OpenCL/CLDevice.cs
+++ b/Src/ILGPU/Runtime/OpenCL/CLDevice.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2022 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: CLDevice.cs
@@ -406,13 +406,14 @@ namespace ILGPU.Runtime.OpenCL
         /// <summary>
         /// Init general OpenCL extensions.
         /// </summary>
+        [SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase")]
         private void InitExtensions()
         {
             // Resolve extensions
             var extensionString = CurrentAPI.GetDeviceInfo(
                 DeviceId,
                 CLDeviceInfoType.CL_DEVICE_EXTENSIONS);
-            foreach (var extension in extensionString.ToLower().Split(' '))
+            foreach (var extension in extensionString.ToLowerInvariant().Split(' '))
                 extensionSet.Add(extension);
             Extensions = extensionSet.ToImmutableArray();
         }


### PR DESCRIPTION
The .NET 7.0 SDK was updated from 7.0.100 to 7.0.101. This has introduced a number of new warnings that has caused our CI pipeline to fail.