### PR TITLE
Updated copyright tool to remove dependency on Ubuntu-18.04.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,7 @@ jobs:
 
   check-style-copyright-headers:
     if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
-    # WORKAROUND: LibGit2Sharp does not currently work on ubuntu-20.04
-    # https://github.com/libgit2/libgit2sharp/issues/1798
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/updateCopyrightYear.yml
+++ b/.github/workflows/updateCopyrightYear.yml
@@ -8,9 +8,7 @@ jobs:
   update-copyright-year:
     # Only run on main repository
     if: github.repository == 'm4rs-mt/ILGPU'
-    # WORKAROUND: LibGit2Sharp does not currently work on ubuntu-20.04
-    # https://github.com/libgit2/libgit2sharp/issues/1798
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       # Checkout full history so that the copyright tool has the required information.
       - name: Checkout

--- a/Tools/CopyrightUpdateTool/CopyrightUpdateTool.csproj
+++ b/Tools/CopyrightUpdateTool/CopyrightUpdateTool.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
+    <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0182" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
From our CI pipeline: https://github.com/m4rs-mt/ILGPU/actions/runs/3708993174:

`This is a scheduled Ubuntu-18.04 brownout. The Ubuntu-18.04 environment is deprecated and will be removed on April 1st, 2023. For more details, see https://github.com/actions/runner-images/issues/6002`