### PR TITLE
Added new specialized sparse-matrix extensions.

### DIFF
--- a/Src/ILGPU.Algorithms.Tests/Configurations.txt
+++ b/Src/ILGPU.Algorithms.Tests/Configurations.txt
@@ -2,6 +2,7 @@
 GroupExtensionTests
 HistogramTests
 InitializeTests
+MatrixTests
 OptimizationTests
 RadixSortExtensionTests
 RandomTests

--- a/Src/ILGPU.Algorithms.Tests/MatrixTests.cs
+++ b/Src/ILGPU.Algorithms.Tests/MatrixTests.cs
@@ -1,0 +1,275 @@
+// ---------------------------------------------------------------------------------------
+//                                   ILGPU Algorithms
+//                           Copyright (c) 2023 ILGPU Project
+//                                    www.ilgpu.net
+//
+// File: MatrixTests.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details.
+// ---------------------------------------------------------------------------------------
+
+using ILGPU.Algorithms.MatrixOperations;
+using ILGPU.Runtime;
+using ILGPU.Tests;
+using System;
+using Xunit;
+using Xunit.Abstractions;
+
+#pragma warning disable CA1814 // Jagged arrays
+#pragma warning disable CA5394 // Insecure RNG
+
+namespace ILGPU.Algorithms.Tests
+{
+    public abstract partial class MatrixTests : TestBase
+    {
+        protected MatrixTests(ITestOutputHelper output, TestContext testContext)
+            : base(output, testContext)
+        { }
+
+        #region MemberData
+
+        public static TheoryData<object, object, object, object, object> DimensionsData =>
+            new TheoryData<object, object, object, object, object>
+            {
+                { 39, 42, 17, 2918291, 0.8f },
+                { 39, 42, 17, 2918291, 0.5f },
+                { 39, 42, 17, 2918291, 0.05f },
+
+                { 42, 42, 31, 2918292, 0.8f },
+                { 42, 42, 31, 2918292, 0.5f },
+                { 42, 42, 31, 2918292, 0.05f },
+
+                { 376, 382, 288, 4132107, 0.8f },
+                { 376, 382, 288, 4132107, 0.5f },
+                { 376, 382, 288, 4132107, 0.05f },
+
+                { 829, 277, 928, 31821912, 0.8f },
+                { 829, 277, 928, 31821912, 0.5f },
+                { 829, 277, 928, 31821912, 0.05f },
+
+                { 829, 829, 1121, 31821913, 0.8f },
+                { 829, 829, 1121, 31821913, 0.5f },
+                { 829, 829, 1121, 31821913, 0.05f },
+            };
+
+        #endregion
+
+        #region Helpers
+
+        /// <summary>
+        /// Multiplies two dense matrices and returns the resultant matrix in 2D.
+        /// </summary>
+        /// <param name="left">A dense MxK matrix</param>
+        /// <param name="right">A dense KxN matrix</param>
+        /// <returns>A dense MxN matrix</returns>
+        private static float[,] MultiplyMatrix2D(float[,] left, float[,] right)
+        {
+            var leftRows = left.GetLength(0);
+            var leftColumns = left.GetLength(1);
+            var rightRows = right.GetLength(0);
+            var rightColumns = right.GetLength(1);
+
+            if (leftColumns != rightRows)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(right),
+                    $"Cannot multiply {leftRows}x{leftColumns} matrix by " +
+                    $"{rightColumns}x{rightRows} matrix");
+            }
+
+            var result = new float[leftRows, rightColumns];
+            for (var x = 0; x < leftRows; x++)
+            {
+                for (var y = 0; y < rightColumns; y++)
+                {
+                    for (var z = 0; z < leftColumns; z++)
+                        result[x, y] += left[x, z] * right[z, y];
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Compute the transpose of a matrix in 2D.
+        /// </summary>
+        /// <param name="matrix">A MxN matrix</param>
+        /// <returns>The transpose of A, a NxM matrix</returns>
+        private static float[,] TransposeMatrix2D(float[,] matrix)
+        {
+            int rows = matrix.GetLength(0);
+            int columns = matrix.GetLength(1);
+            var transposed = new float[columns, rows];
+            for (var i = 0; i < rows; i++)
+            {
+                for (var j = 0; j < columns; j++)
+                    transposed[j, i] = matrix[i, j];
+            }
+
+            return transposed;
+        }
+
+        /// <summary>
+        /// Compares two matrices for equality.
+        /// </summary>
+        /// <param name="left">A MxN matrix (the actual matrix we got)</param>
+        /// <param name="right">A MxN matrix (the matrix we expected) </param>
+        /// <returns>True if the matrices are equal</returns>
+        private static void AssertMatrixEqual2D(
+            float[,] left,
+            float[,] right,
+            float eps = 0.0015f)
+        {
+            var leftRows = left.GetLength(0);
+            var leftColumns = left.GetLength(1);
+            var rightRows = right.GetLength(0);
+            var rightColumns = right.GetLength(1);
+
+            if (leftRows != rightRows || leftColumns != rightColumns)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(right),
+                    $"Matrix dimensions {leftRows}x{leftColumns} and " +
+                    $"{rightRows}x{rightColumns} do not match");
+            }
+
+            for (var i = 0; i < leftRows; i++)
+            {
+                for (var j = 0; j < leftColumns; j++)
+                {
+                    Assert.True(
+                        Math.Abs(left[i, j] - right[i, j]) < eps,
+                        "Matrix result not equal");
+                }
+            }
+        }
+
+        #endregion
+
+        [SkippableTheory()]
+        [MemberData(nameof(DimensionsData))]
+        public void MatrixMultiplySparse(
+            int length,
+            int length2,
+            int baseLength,
+            int seed,
+            float sparsityProbability)
+        {
+            // CPU-performance related checks to avoid extremely long test runs
+            Skip.If(
+                Accelerator.AcceleratorType == AcceleratorType.CPU &&
+                (length > 512 || length2 > 512 || baseLength > 384));
+
+            using var stream = Accelerator.CreateStream();
+
+            // Our starting dense matrix
+            var denseMatrix = new float[baseLength, length];
+
+            // Setup sparse 2D matrix
+            var sparseMatrix = new float[length2, length];
+
+            var random = new System.Random(seed);
+            for (int i = 0; i < denseMatrix.GetLength(0); ++i)
+            {
+                for (int j = 0; j < denseMatrix.GetLength(1); ++j)
+                    denseMatrix[i, j] = (float)random.NextDouble();
+            }
+
+            for (int i = 0; i < sparseMatrix.GetLength(0); ++i)
+            {
+                for (int j = 0; j < sparseMatrix.GetLength(1); ++j)
+                {
+                    sparseMatrix[i, j] = random.NextDouble() > sparsityProbability
+                        ? 0.0f
+                        : (float)random.NextDouble() * 8.0f;
+                }
+            }
+
+            // Setup the output mask
+            var sparseMaskMatrix = new float[baseLength, length2];
+            for (int i = 0; i < sparseMaskMatrix.GetLength(0); ++i)
+            {
+                for (int j = 0; j < sparseMaskMatrix.GetLength(1); ++j)
+                    sparseMaskMatrix[i, j] = 1.0f;
+            }
+
+            // Initialize our sparse matrix
+            using var matrixBuffer = Accelerator.Allocate2DDenseY<float>(
+                sparseMatrix.GetExtent());
+            matrixBuffer.View.CopyFromCPU(stream, sparseMatrix);
+
+            // Allocate a temp buffer (or use existing memory from somewhere else)
+            using var tempBuffer = Accelerator.Allocate1D<int>(1);
+
+            // Initialize the basic shape converter and data converters
+            var shapeConverter = Accelerator.CreateSparseMatrixShapeConverter<
+                float,
+                FloatEpsPredicate<Stride2D.General>,
+                Stride2D.General>(tempBuffer.View);
+            var converter = Accelerator.CreateSparseMatrixConverter<
+                float,
+                Stride2D.General>();
+
+            // Get basic shape of the sparse matrix living on the device
+            using var numNeighborsBuffer = Accelerator.Allocate1D<int>(
+                sparseMatrix.GetLength(0));
+            var shapeView = shapeConverter(
+                stream,
+                matrixBuffer.View.AsGeneral(),
+                new(matrixBuffer.View.AsGeneral(), 0.0f),
+                numNeighborsBuffer.View,
+                maxNumNeighbors =>
+                    // Allocate a shape-view buffer to store the neighbor lists
+                    Accelerator.Allocate2DDenseY<int>(
+                            (sparseMatrix.GetLength(0), maxNumNeighbors))
+                        .View.AsGeneral());
+
+            // Allocate the actual sparse data buffer
+            using var dataBuffer = Accelerator.Allocate2DDenseY<float>(
+                (sparseMatrix.GetLength(0), shapeView.Neighbors.Extent.Y));
+
+            // Convert data and fill our sparse matrix structure
+            var sparseView = converter(
+                stream,
+                matrixBuffer.View.AsGeneral(),
+                shapeView,
+                dataBuffer.View.AsGeneral());
+
+            // Allocate dense output matrix
+            using var aMatrixBuffer =
+                Accelerator.Allocate2DDenseY<float>(denseMatrix.GetExtent());
+            using var pMatrixBuffer =
+                Accelerator.Allocate2DDenseY<float>(sparseMaskMatrix.GetExtent());
+            using var outBuffer =
+                Accelerator.Allocate2DDenseY<float>(
+                    (denseMatrix.GetLength(0),
+                        sparseMatrix.GetLength(0)));
+            aMatrixBuffer.View.CopyFromCPU(stream, denseMatrix);
+            pMatrixBuffer.View.CopyFromCPU(stream, sparseMaskMatrix);
+
+            // Create a single-streamed sparse matrix buffer
+            var processor = Accelerator.CreateSparseTransposedMatrixMultiplierMasked<
+                float,
+                FloatEpsPredicate<Stride2D.General>,
+                Stride2D.General,
+                FloatMaskedSparseMatrixProcessor>();
+
+            // Multiply a single masked sparse matrix
+            processor(
+                stream,
+                new(pMatrixBuffer.View.AsGeneral(), 0.0f),
+                aMatrixBuffer.View.AsGeneral(),
+                sparseView,
+                outBuffer.View.AsGeneral());
+
+            // Compute reference values
+            var transposed = TransposeMatrix2D(sparseMatrix);
+            var expected = MultiplyMatrix2D(denseMatrix, transposed);
+
+            // Load our resulting matrix and test for equality
+            var tArr = outBuffer.View.AsDenseY().GetAsArray2D(stream);
+            AssertMatrixEqual2D(tArr, expected);
+        }
+    }
+}

--- a/Src/ILGPU.Algorithms/ConcurrentStreamProcessor.cs
+++ b/Src/ILGPU.Algorithms/ConcurrentStreamProcessor.cs
@@ -1,0 +1,161 @@
+// ---------------------------------------------------------------------------------------
+//                                   ILGPU Algorithms
+//                           Copyright (c) 2023 ILGPU Project
+//                                    www.ilgpu.net
+//
+// File: ConcurrentStreamProcessor.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details.
+// ---------------------------------------------------------------------------------------
+
+using ILGPU.Runtime;
+using ILGPU.Util;
+using System;
+using System.Threading.Tasks;
+
+namespace ILGPU.Algorithms
+{
+    /// <summary>
+    /// Processes actions in parallel on multiple asynchronous accelerator streams.
+    /// </summary>
+    public class ConcurrentStreamProcessor : DisposeBase
+    {
+        #region Instance
+
+        private readonly AcceleratorStream[] streams;
+
+        /// <summary>
+        /// Constructs a new concurrent stream processor.
+        /// </summary>
+        /// <param name="accelerator">The parent accelerator.</param>
+        /// <param name="maxNumConcurrentStreams">
+        /// The maximum number of concurrent streams to use (if any).
+        /// </param>
+        /// <param name="streamProvider">
+        /// A custom stream provider function to construct specialized streams.
+        /// </param>
+        public ConcurrentStreamProcessor(
+            Accelerator accelerator,
+            int maxNumConcurrentStreams = 0,
+            Func<Accelerator, AcceleratorStream> streamProvider = null)
+        {
+            maxNumConcurrentStreams = Math.Max(
+                Math.Max(maxNumConcurrentStreams, 1),
+                Environment.ProcessorCount);
+
+            streams = new AcceleratorStream[maxNumConcurrentStreams];
+            if (maxNumConcurrentStreams > 1)
+            {
+                streamProvider ??= accel => accel.CreateStream();
+                for (int i = 0; i < streams.Length; ++i)
+                    streams[i] = streamProvider(accelerator);
+            }
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Returns the maximum number of concurrent streams supported by this processor.
+        /// </summary>
+        public int MaxNumConcurrentStreams => streams.Length;
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Processes the given action concurrently by using the underlying accelerator
+        /// streams concurrently to submit different jobs in parallel.
+        /// </summary>
+        /// <remarks>
+        /// Note that this method assumes that all previous jobs have been synchronized
+        /// with the current processing thread.
+        /// </remarks>
+        /// <param name="numActions">The number of actions to submit.</param>
+        /// <param name="action">
+        /// The action to invoke on each stream to submit work.
+        /// </param>
+        public void ProcessConcurrently(
+            int numActions,
+            Action<AcceleratorStream, int> action) =>
+            ProcessConcurrently(null, numActions, action);
+
+        /// <summary>
+        /// Processes the given action concurrently by using the underlying accelerator
+        /// streams concurrently to submit different jobs in parallel.
+        /// </summary>
+        /// <param name="stream">The current accelerator stream.</param>
+        /// <param name="numActions">The number of actions to submit.</param>
+        /// <param name="action">
+        /// The action to invoke on each stream to submit work.
+        /// </param>
+        public void ProcessConcurrently(
+            AcceleratorStream stream,
+            int numActions,
+            Action<AcceleratorStream, int> action)
+        {
+            if (numActions < 0)
+                throw new ArgumentOutOfRangeException(nameof(numActions));
+            if (numActions == 0)
+                return;
+            if (action == null)
+                throw new ArgumentOutOfRangeException(nameof(action));
+
+            if (stream != null && numActions == 1 && MaxNumConcurrentStreams == 1)
+            {
+                // Use the given stream to process the action request
+                action(stream, 0);
+            }
+            else
+            {
+                // Wait for the current stream to finish processing
+                stream?.Synchronize();
+
+                // Perform work on all streams
+                int numActionsPerStream = XMath.DivRoundUp(
+                    numActions,
+                    MaxNumConcurrentStreams);
+                var actionStride = new Stride2D.DenseY(numActionsPerStream);
+                Parallel.For(0, MaxNumConcurrentStreams, i =>
+                {
+                    var currentStream = streams[i];
+                    using var binding = currentStream.BindScoped();
+
+                    for (int j = 0; j < numActionsPerStream; ++j)
+                    {
+                        int actionIndex = actionStride.ComputeElementIndex((i, j));
+                        if (actionIndex >= numActions)
+                            break;
+                        action(currentStream, actionIndex);
+                    }
+
+                    // Wait for the result
+                    currentStream.Synchronize();
+                });
+            }
+        }
+
+        #endregion
+
+        #region IDisposable
+
+        /// <summary>
+        /// Frees all internal streams.
+        /// </summary>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                // Free all internal streams
+                foreach (var stream in streams)
+                    stream?.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #endregion
+    }
+}

--- a/Src/ILGPU.Algorithms/MatrixOperations/MaskedMatrixProcessor.cs
+++ b/Src/ILGPU.Algorithms/MatrixOperations/MaskedMatrixProcessor.cs
@@ -1,0 +1,116 @@
+// ---------------------------------------------------------------------------------------
+//                                   ILGPU Algorithms
+//                           Copyright (c) 2023 ILGPU Project
+//                                    www.ilgpu.net
+//
+// File: MaskedMatrixProcessor.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details.
+// ---------------------------------------------------------------------------------------
+
+using ILGPU.Runtime;
+using ILGPU.Util;
+using System;
+using System.Collections.Generic;
+
+namespace ILGPU.Algorithms.MatrixOperations
+{
+    /// <summary>
+    /// A processor for masked matrices to efficiently operate on multiple matrix
+    /// instances in parallel to maximize occupancy.
+    /// </summary>
+    public class MaskedMatrixProcessor<T, TPredicate, TStride, TProcessor>
+        : ConcurrentStreamProcessor
+        where T : unmanaged
+        where TStride : struct, IStride2D
+        where TPredicate : struct, InlineList.IPredicate<Index2D>
+        where TProcessor : struct, IMaskedSparseMatrixProcessor<T>
+    {
+        #region Instance
+
+        /// <summary>
+        /// The internal masked matrix multiplier which contains pre-compiled kernels.
+        /// </summary>
+        private readonly MaskedSparseMatrixMultiplier<T, TPredicate, TStride>
+            matrixMultiplier;
+
+        /// <summary>
+        /// Constructs a new masked processor.
+        /// </summary>
+        /// <param name="accelerator">The parent accelerator.</param>
+        /// <param name="maxNumConcurrentStreams">
+        /// The maximum number of concurrent streams to use (if any).
+        /// </param>
+        /// <param name="streamProvider">
+        /// A custom stream provider function to construct specialized streams.
+        /// </param>
+        public MaskedMatrixProcessor(
+            Accelerator accelerator,
+            int maxNumConcurrentStreams = 0,
+            Func<Accelerator, AcceleratorStream> streamProvider = null)
+            : base(accelerator, maxNumConcurrentStreams, streamProvider)
+        {
+            matrixMultiplier = accelerator.CreateSparseTransposedMatrixMultiplierMasked<
+                T,
+                TPredicate,
+                TStride,
+                TProcessor>();
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Returns the current predicate to use (if any).
+        /// </summary>
+        public TPredicate? Predicate { get; set; }
+
+        #region Methods
+
+        /// <summary>
+        /// Multiplies the given matrices using the currently assigned predicate while
+        /// transposing the matrix given by <paramref name="bView"/>.
+        /// </summary>
+        /// <param name="stream">The current accelerator stream to use.</param>
+        /// <param name="aView">The dense input matrix a of shape MxK.</param>
+        /// <param name="bView">The sparse matrix b of shape NxK (will transpose).</param>
+        /// <param name="outView">A dense output matrix of shape of MxN.</param>
+        public void MultiplyTransposed(
+            AcceleratorStream stream,
+            ArrayView2D<T, TStride> aView,
+            SparseMatrixView<T, TStride> bView,
+            ArrayView2D<T, TStride> outView)
+        {
+            if (!Predicate.HasValue)
+                throw new InvalidOperationException();
+            matrixMultiplier(stream, Predicate.Value, aView, bView, outView);
+        }
+
+        /// <summary>
+        /// Multiplies the given matrices using the currently assigned predicate while
+        /// transposing the matrices given by <paramref name="bViews"/>.
+        /// </summary>
+        /// <param name="stream">The current accelerator stream to use.</param>
+        /// <param name="aViews">The dense input matrices a of shape MxK.</param>
+        /// <param name="bViews">
+        /// The sparse matrices b of shape NxK (will transpose).
+        /// </param>
+        /// <param name="outViews">Dense output matrices of shape of MxN.</param>
+        public void MultiplyBatchedTransposed(
+            AcceleratorStream stream,
+            IReadOnlyList<ArrayView2D<T, TStride>> aViews,
+            IReadOnlyList<SparseMatrixView<T, TStride>> bViews,
+            IReadOnlyList<ArrayView2D<T, TStride>> outViews)
+        {
+            if (aViews.Count != bViews.Count)
+                throw new ArgumentOutOfRangeException(nameof(bViews));
+            if (aViews.Count != outViews.Count)
+                throw new ArgumentOutOfRangeException(nameof(outViews));
+
+            ProcessConcurrently(stream, aViews.Count, (acceleratorStream, i) =>
+                MultiplyTransposed(acceleratorStream, aViews[i], bViews[i], outViews[i]));
+        }
+
+        #endregion
+    }
+}

--- a/Src/ILGPU.Algorithms/MatrixOperations/MaskedSparseMatrixExtensions.cs
+++ b/Src/ILGPU.Algorithms/MatrixOperations/MaskedSparseMatrixExtensions.cs
@@ -1,0 +1,446 @@
+// ---------------------------------------------------------------------------------------
+//                                   ILGPU Algorithms
+//                           Copyright (c) 2023 ILGPU Project
+//                                    www.ilgpu.net
+//
+// File: MaskedSparseMatrixExtensions.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details.
+// ---------------------------------------------------------------------------------------
+
+using ILGPU.Algorithms.ScanReduceOperations;
+using ILGPU.Runtime;
+using ILGPU.Util;
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace ILGPU.Algorithms.MatrixOperations
+{
+    #region Mask Predicates
+
+    /// <summary>
+    /// An internal predicate used to represent a masked array.
+    /// </summary>
+    /// <typeparam name="T">The mask element type.</typeparam>
+    /// <typeparam name="TStride">The 2D stride.</typeparam>
+    public readonly struct MaskPredicate<T, TStride> : InlineList.IPredicate<Index2D>
+        where T : unmanaged, IEquatable<T>
+        where TStride : struct, IStride2D
+    {
+        private readonly ArrayView2D<T, TStride> mask;
+        private readonly T emptyValue;
+
+        /// <summary>
+        /// Creates a new mask predicate.
+        /// </summary>
+        /// <param name="maskView">The mask view to use.</param>
+        /// <param name="emptyValueConstant">
+        /// The masking constant to compare each element to.
+        /// </param>
+        public MaskPredicate(ArrayView2D<T, TStride> maskView, T emptyValueConstant)
+        {
+            mask = maskView;
+            emptyValue = emptyValueConstant;
+        }
+
+        /// <summary>
+        /// Returns true if the current mask element is not equal to the empty mask
+        /// value.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Apply(Index2D item) => !mask[item.X, item.Y].Equals(emptyValue);
+    }
+
+    /// <summary>
+    /// An internal predicate based on float values.
+    /// </summary>
+    /// <typeparam name="TStride">The 2D stride.</typeparam>
+    public readonly struct FloatEpsPredicate<TStride> : InlineList.IPredicate<Index2D>
+        where TStride : struct, IStride2D
+    {
+        private readonly ArrayView2D<float, TStride> values;
+        private readonly float eps;
+
+        /// <summary>
+        /// Creates a new float masking predicate.
+        /// </summary>
+        /// <param name="valueView">The input value view.</param>
+        /// <param name="epsConstant">
+        /// The eps constant to compare each element to.
+        /// </param>
+        public FloatEpsPredicate(ArrayView2D<float, TStride> valueView, float epsConstant)
+        {
+            values = valueView;
+            eps = epsConstant;
+        }
+
+        /// <summary>
+        /// Returns true if the absolute value of the stored mask element is greater
+        /// than the epsilon constant.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Apply(Index2D item) => Math.Abs(values[item.X, item.Y]) > eps;
+    }
+
+    /// <summary>
+    /// An internal predicate based on double values.
+    /// </summary>
+    /// <typeparam name="TStride">The 2D stride.</typeparam>
+    public readonly struct DoubleEpsPredicate<TStride> : InlineList.IPredicate<Index2D>
+        where TStride : struct, IStride2D
+    {
+        private readonly ArrayView2D<double, TStride> values;
+        private readonly double eps;
+
+        /// <summary>
+        /// Creates a new float masking predicate.
+        /// </summary>
+        /// <param name="valueView">The input value view.</param>
+        /// <param name="epsConstant">
+        /// The eps constant to compare each element to.
+        /// </param>
+        public DoubleEpsPredicate(
+            ArrayView2D<double, TStride> valueView,
+            double epsConstant)
+        {
+            values = valueView;
+            eps = epsConstant;
+        }
+
+        /// <summary>
+        /// Returns true if the absolute value of the stored mask element is greater
+        /// than the epsilon constant.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Apply(Index2D item) => Math.Abs(values[item.X, item.Y]) > eps;
+    }
+
+    #endregion
+
+    #region Matrix Processors
+
+    /// <summary>
+    /// An abstract context-specific mul-add operation for sparse matrix multiplications.
+    /// </summary>
+    /// <typeparam name="T">The value type to operate on.</typeparam>
+    public interface IMaskedSparseMatrixProcessor<T>
+        where T : struct
+    {
+        /// <summary>
+        /// Performs a specialized sparse-matrix mul-add operation.
+        /// </summary>
+        /// <param name="summed">The currently summed value.</param>
+        /// <param name="left">The left operand to multiply.</param>
+        /// <param name="right">The right operand to multiply.</param>
+        /// <returns>The summed and multiplied result.</returns>
+        T MultiplyAdd(T summed, T left, T right);
+    }
+
+    /// <summary>
+    /// A float-specific masked sparse matrix processor for matrix multiplications.
+    /// </summary>
+    public readonly struct FloatMaskedSparseMatrixProcessor
+        : IMaskedSparseMatrixProcessor<float>
+    {
+        /// <summary>
+        /// Performs a fma operation on floats.
+        /// </summary>
+        public float MultiplyAdd(float summed, float left, float right) =>
+            summed + left * right;
+    }
+
+    /// <summary>
+    /// A double-specific masked sparse matrix processor for matrix multiplications.
+    /// </summary>
+    public readonly struct DoubleMaskedSparseMatrixProcessor
+        : IMaskedSparseMatrixProcessor<double>
+    {
+        /// <summary>
+        /// Performs a fma operation on doubles.
+        /// </summary>
+        public double MultiplyAdd(double summed, double left, double right) =>
+            summed + left * right;
+    }
+
+    #endregion
+
+    /// <summary>
+    /// A specialized accelerator-centric masked sparse matrix multiplier.
+    /// </summary>
+    /// <typeparam name="T">The abstract matrix value type.</typeparam>
+    /// <typeparam name="TPredicate">The predicate type.</typeparam>
+    /// <typeparam name="TStride">The matrix stride.</typeparam>
+    /// <param name="stream">The current accelerator stream.</param>
+    /// <param name="maskPredicate">
+    /// The input masking predicate (targeting a dense matrix of shape MxK).
+    /// </param>
+    /// <param name="aView">A dense input matrix of shape MxK.</param>
+    /// <param name="bView">A sparse matrix B of shape NxK (will transpose).</param>
+    /// <param name="outView">
+    /// A dense output view containing the results of the multiplication.
+    /// </param>
+    public delegate void MaskedSparseMatrixMultiplier<T, TPredicate, TStride>(
+        AcceleratorStream stream,
+        TPredicate maskPredicate,
+        ArrayView2D<T, TStride> aView,
+        SparseMatrixView<T, TStride> bView,
+        ArrayView2D<T, TStride> outView)
+        where T : unmanaged
+        where TStride : struct, IStride2D
+        where TPredicate : struct, InlineList.IPredicate<Index2D>;
+
+    /// <summary>
+    /// Specialized extensions to operate on sparse matrices while taking predicates
+    /// into account to skip specific elements.
+    /// </summary>
+    public static class MaskedSparseMatrixExtensions
+    {
+        /// <summary>
+        /// The matrix multiplication kernel that runs on the accelerated device while
+        /// using thread compaction to free masked warps.
+        /// </summary>
+        /// <param name="maskPredicate">
+        /// The input masking predicate (targeting a dense matrix of shape MxK).
+        /// </param>
+        /// <param name="aView">A dense input matrix of shape MxK.</param>
+        /// <param name="bView">A sparse matrix B of shape NxK (will transpose).</param>
+        /// <param name="outView">
+        /// A dense output view containing the results of the multiplication.
+        /// </param>
+        /// <param name="processor">An instance of an actual mul-add operation.</param>
+        internal static void MaskedSparseTransposedMatrixMultiplierKernel<
+            T,
+            TPredicate,
+            TStride,
+            TProcessor>(
+            TPredicate maskPredicate,
+            ArrayView2D<T, TStride> aView,
+            SparseMatrixView<T, TStride> bView,
+            ArrayView2D<T, TStride> outView,
+            TProcessor processor)
+            where T : unmanaged
+            where TStride : struct, IStride2D
+            where TPredicate : struct, InlineList.IPredicate<Index2D>
+            where TProcessor : struct, IMaskedSparseMatrixProcessor<T>
+        {
+            var maskView = SharedMemory.GetDynamic<int>();
+            Trace.Assert(
+                Group.DimX <= maskView.IntLength,
+                "Invalid shared memory config");
+
+            // Get all predicate results and perform thread compaction
+            int index = Grid.GlobalLinearIndex;
+            var maskIndex2D = outView.Stride.ReconstructFromElementIndex(index);
+            bool apply =
+                maskIndex2D.X < outView.Extent.X &
+                maskIndex2D.Y < outView.Extent.Y;
+
+            // Check the predicate (if in range) and compute thread-compaction offsets
+            if (apply)
+                apply = maskPredicate.Apply(maskIndex2D);
+            int groupOffset = GroupExtensions.ExclusiveScan<int, AddInt32>(
+                Utilities.Select(apply, 1, 0));
+
+            // Store current result and determine the total number of matrix entries
+            if (apply)
+                maskView[groupOffset] = index;
+            int numEntries = Group.BarrierPopCount(apply);
+
+            // Load the current entry (if any)
+            if (Group.IdxX >= numEntries)
+                return;
+
+            // Get the transposed index from our processing index
+            int processingIndex = maskView[Group.IdxX];
+            var index2D = outView.Stride.ReconstructFromElementIndex(
+                processingIndex);
+
+            // Load next number of neighbors
+            T dotProduct = default;
+            int numNeighbors = bView.NumNeighbors[index2D.Y];
+
+            // Note that profiling yielded that explicit L1 shared-memory caching did not
+            // help to improve performance in this case. This is also due to the fact
+            // that most reused results automatically end up being fetching into L2 cache
+            // and loaded upon request (based on the structure of the algorithm) into the
+            // L1 parts of the processing unit
+
+            for (var neighborIndex = 0; neighborIndex < numNeighbors; ++neighborIndex)
+            {
+                // Load index and sparse edge weight; note that the format for bView
+                // means we will read the transposed entry from bView
+                int columnIndex = bView.Neighbors[index2D.Y, neighborIndex];
+                T bValue = bView.EdgeWeights[index2D.Y, neighborIndex];
+
+                // Load our multiplication value from aView
+                T aValue = aView[index2D.X, columnIndex];
+
+                // Accumulate result
+                dotProduct = processor.MultiplyAdd(dotProduct, bValue, aValue);
+            }
+
+            // Store our result value
+            outView[index2D] = dotProduct;
+        }
+
+        /// <summary>
+        /// Creates a specialized sparse matrix multiplier.
+        /// </summary>
+        /// <typeparam name="T">The abstract matrix value type.</typeparam>
+        /// <typeparam name="TPredicate">The predicate type.</typeparam>
+        /// <typeparam name="TStride">The matrix stride.</typeparam>
+        /// <typeparam name="TProcessor">The processor type to operate on T.</typeparam>
+        /// <param name="accelerator">The current accelerator.</param>
+        /// <returns>A new sparse matrix multiplier.</returns>
+        public static MaskedSparseMatrixMultiplier<T, TPredicate, TStride>
+            CreateSparseTransposedMatrixMultiplierMasked<
+            T,
+            TPredicate,
+            TStride,
+            TProcessor>(
+            this Accelerator accelerator)
+            where T : unmanaged
+            where TStride : struct, IStride2D
+            where TPredicate : struct, InlineList.IPredicate<Index2D>
+            where TProcessor : struct, IMaskedSparseMatrixProcessor<T>
+        {
+            // Load basic sparse matrix convert kernel
+            var kernel = accelerator.LoadKernel<
+                TPredicate,
+                ArrayView2D<T, TStride>,
+                SparseMatrixView<T, TStride>,
+                ArrayView2D<T, TStride>,
+                TProcessor>(MaskedSparseTransposedMatrixMultiplierKernel);
+
+            // Get the optimal group size
+            int groupSize = accelerator.EstimateGroupSize(kernel.GetKernel());
+
+            // Return new launcher delegate
+            return (stream, predicate, view, bView, outView) =>
+            {
+                // Get actual processor
+                TProcessor processor = default;
+                
+                // Bounds checks
+                if (view.Extent.X != outView.Extent.X)
+                    throw new ArgumentOutOfRangeException(nameof(view));
+                if (bView.NumRows != outView.Extent.Y)
+                    throw new ArgumentOutOfRangeException(nameof(bView));
+
+                // Determine launch dimensions
+                var sharedMemoryConfig = SharedMemoryConfig.RequestDynamic<int>(
+                    groupSize);
+                int gridDim = XMath.DivRoundUp(outView.IntLength, groupSize);
+                KernelConfig kernelConfig = (gridDim, groupSize, sharedMemoryConfig);
+
+                // Launch kernel
+                kernel(stream, kernelConfig, predicate, view, bView, outView, processor);
+            };
+        }
+
+        /// <summary>
+        /// Multiplies a masked sparse matrix based on arbitrary types.
+        /// </summary>
+        /// <typeparam name="T">The abstract matrix value type.</typeparam>
+        /// <typeparam name="TPredicate">The predicate type.</typeparam>
+        /// <typeparam name="TStride">The matrix stride.</typeparam>
+        /// <typeparam name="TProcessor">The processor type to operate on T.</typeparam>
+        /// <param name="accelerator">The current accelerator.</param>
+        /// <param name="stream">The current accelerator stream.</param>
+        /// <param name="maskPredicate">The mask predicate input.</param>
+        /// <param name="aView">The dense input matrix a of shape MxK.</param>
+        /// <param name="bView">The sparse matrix b of shape NxK.</param>
+        /// <param name="outView">A dense output matrix of shape of aView.</param>
+        public static void MultiplySparseTransposedMatrixMasked<
+            T,
+            TPredicate,
+            TStride,
+            TProcessor>(
+            this Accelerator accelerator,
+            AcceleratorStream stream,
+            TPredicate maskPredicate,
+            ArrayView2D<T, TStride> aView,
+            SparseMatrixView<T, TStride> bView,
+            ArrayView2D<T, TStride> outView)
+            where T : unmanaged
+            where TStride : struct, IStride2D
+            where TPredicate : struct, InlineList.IPredicate<Index2D>
+            where TProcessor : struct, IMaskedSparseMatrixProcessor<T>
+        {
+            // Get multiplier kernel (from cache, if possible)
+            var multiplierKernel = accelerator.
+                CreateSparseTransposedMatrixMultiplierMasked<
+                T,
+                TPredicate,
+                TStride,
+                TProcessor>();
+
+            // Launch kernel
+            multiplierKernel(stream, maskPredicate, aView, bView, outView);
+        }
+
+        /// <summary>
+        /// Multiplies a masked sparse matrix based on floats.
+        /// </summary>
+        /// <typeparam name="TPredicate">The predicate type.</typeparam>
+        /// <typeparam name="TStride">The matrix stride.</typeparam>
+        /// <param name="accelerator">The current accelerator.</param>
+        /// <param name="stream">The current accelerator stream.</param>
+        /// <param name="maskPredicate">The mask predicate input.</param>
+        /// <param name="aView">The dense input matrix a of shape MxK.</param>
+        /// <param name="bView">The sparse matrix b of shape NxK.</param>
+        /// <param name="outView">A dense output matrix of shape of aView.</param>
+        public static void MultiplySparseTransposedMatrixMasked<TPredicate, TStride>(
+            this Accelerator accelerator,
+            AcceleratorStream stream,
+            TPredicate maskPredicate,
+            ArrayView2D<float, TStride> aView,
+            SparseMatrixView<float, TStride> bView,
+            ArrayView2D<float, TStride> outView)
+            where TStride : struct, IStride2D
+            where TPredicate : struct, InlineList.IPredicate<Index2D> =>
+            accelerator.MultiplySparseTransposedMatrixMasked<
+                float,
+                TPredicate,
+                TStride,
+                FloatMaskedSparseMatrixProcessor>(
+                stream,
+                maskPredicate,
+                aView,
+                bView,
+                outView);
+
+        /// <summary>
+        /// Multiplies a masked sparse matrix based on doubles.
+        /// </summary>
+        /// <typeparam name="TPredicate">The predicate type.</typeparam>
+        /// <typeparam name="TStride">The matrix stride.</typeparam>
+        /// <param name="accelerator">The current accelerator.</param>
+        /// <param name="stream">The current accelerator stream.</param>
+        /// <param name="maskPredicate">The mask predicate input.</param>
+        /// <param name="aView">The dense input matrix a of shape MxK.</param>
+        /// <param name="bView">The sparse matrix b of shape NxK.</param>
+        /// <param name="outView">A dense output matrix of shape of aView.</param>
+        public static void MultiplySparseTransposedMatrixMasked<TPredicate, TStride>(
+            this Accelerator accelerator,
+            AcceleratorStream stream,
+            TPredicate maskPredicate,
+            ArrayView2D<double, TStride> aView,
+            SparseMatrixView<double, TStride> bView,
+            ArrayView2D<double, TStride> outView)
+            where TStride : struct, IStride2D
+            where TPredicate : struct, InlineList.IPredicate<Index2D> =>
+            accelerator.MultiplySparseTransposedMatrixMasked<
+                double,
+                TPredicate,
+                TStride,
+                DoubleMaskedSparseMatrixProcessor>(
+                stream,
+                maskPredicate,
+                aView,
+                bView,
+                outView);
+    }
+}

--- a/Src/ILGPU.Algorithms/MatrixOperations/SparseMatrixExtensions.cs
+++ b/Src/ILGPU.Algorithms/MatrixOperations/SparseMatrixExtensions.cs
@@ -1,0 +1,489 @@
+// ---------------------------------------------------------------------------------------
+//                                   ILGPU Algorithms
+//                           Copyright (c) 2023 ILGPU Project
+//                                    www.ilgpu.net
+//
+// File: SparseMatrixExtensions.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details.
+// ---------------------------------------------------------------------------------------
+
+using ILGPU.Runtime;
+using ILGPU.Util;
+using System;
+
+namespace ILGPU.Algorithms.MatrixOperations
+{
+    #region Sparse Matrix Types
+        
+    /// <summary>
+    /// A generic target to compute sparse matrix information.
+    /// </summary>
+    public interface ISparseMatrixShapeInfoTarget
+    {
+        /// <summary>
+        /// Outputs the given number of row entries for the specified row.
+        /// </summary>
+        /// <param name="rowIndex">The absolute row index.</param>
+        /// <param name="numRowEntries">The number of row entries.</param>
+        void OutputNumNeighbors(int rowIndex, int numRowEntries);
+        
+        /// <summary>
+        /// Atomically computes the maximum of all local num neighbors.
+        /// </summary>
+        /// <param name="maxNumLocalNeighbors">
+        /// The locally determined max number of neighbors.
+        /// </param>
+        void ComputeAtomicMaxNumNeighbors(int maxNumLocalNeighbors);
+    }
+
+    /// <summary>
+    /// A provider for matrix shape information accepting a generic target info receiver.
+    /// </summary>
+    /// <typeparam name="TPredicate">The predicate type.</typeparam>
+    /// <typeparam name="TTarget">The target type.</typeparam>
+    public delegate void SparseMatrixShapeInfoProvider<TPredicate, TTarget>(
+        AcceleratorStream stream,
+        LongIndex2D matrixExtent,
+        TPredicate predicate,
+        TTarget target)
+        where TPredicate : struct, InlineList.IPredicate<Index2D>
+        where TTarget : struct, ISparseMatrixShapeInfoTarget;
+
+    /// <summary>
+    /// A provider for matrix shape information accepting a predicate and a number of
+    /// neighbors per row view (needs to pre-allocated).
+    /// </summary>
+    /// <typeparam name="TPredicate">The predicate type.</typeparam>
+    public delegate int SparseMatrixShapeInfoProvider<TPredicate>(
+        AcceleratorStream stream,
+        LongIndex2D matrixExtent,
+        TPredicate predicate,
+        ArrayView<int> numNeighbors)
+        where TPredicate : struct, InlineList.IPredicate<Index2D>;
+
+    /// <summary>
+    /// A sparse matrix shape converter that translates dense matrices into sparse shapes.
+    /// </summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <typeparam name="TPredicate">The predicate type.</typeparam>
+    /// <typeparam name="TStride">The matrix stride.</typeparam>
+    public delegate SparseMatrixShapeView<TStride> SparseMatrixShapeConverter<
+        T,
+        TPredicate,
+        TStride>(
+        AcceleratorStream stream,
+        ArrayView2D<T, TStride> inputMatrix,
+        TPredicate predicate,
+        ArrayView<int> numNeighbors,
+        Func<int, ArrayView2D<int, TStride>> getNeighborsFunc)
+        where T : unmanaged
+        where TPredicate : struct, InlineList.IPredicate<Index2D>
+        where TStride : struct, IStride2D;
+    
+    /// <summary>
+    /// A sparse matrix converter that translates a sparse shape view and a dense matrix
+    /// into its sparse view representation.
+    /// </summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <typeparam name="TStride">The matrix stride.</typeparam>
+    public delegate SparseMatrixView<T, TStride> SparseMatrixConverter<T, TStride>(
+        AcceleratorStream stream,
+        ArrayView2D<T, TStride> inputMatrix,
+        SparseMatrixShapeView<TStride> shapeView,
+        ArrayView2D<T, TStride> dataView)
+        where T : unmanaged
+        where TStride : struct, IStride2D;
+
+    #endregion
+    
+    /// <summary>
+    /// Sparse matrix extensions to convert dense matrices into sparse versions.
+    /// </summary>
+    public static class SparseMatrixExtensions
+    {
+        /// <summary>
+        /// An explicitly grouped kernel to compute direct neighbor information and the
+        /// maximum number of non-zero entries per row.
+        /// </summary>
+        /// <typeparam name="TPredicate">
+        /// The predicate type used to sparsify a dense input matrix.
+        /// </typeparam>
+        /// <typeparam name="TTarget">The sparsity output type.</typeparam>
+        internal static void SparseMatrixShapeInfoKernel<TPredicate, TTarget>(
+            LongIndex2D matrixExtent,
+            TPredicate predicate,
+            TTarget target)
+            where TPredicate : struct, InlineList.IPredicate<Index2D>
+            where TTarget : struct, ISparseMatrixShapeInfoTarget
+        {
+            // Setup our shared max-num-neighbors memory counter
+            ref var sharedMax = ref SharedMemory.Allocate<int>();
+            if (Group.IsFirstThread)
+                sharedMax = 0;
+            Group.Barrier();
+            
+            // Get the actual row index and reject out-of-bounds reads
+            int rowIndex = Grid.GlobalLinearIndex;
+            if (rowIndex >= matrixExtent.X)
+                return;
+            
+            int numRowEntries = 0;
+            for (int i = 0, numColumns = (int)matrixExtent.Y; i < numColumns; ++i)
+            {
+                if (predicate.Apply(new Index2D(rowIndex, i)))
+                    ++numRowEntries;
+            }
+            
+            // Store number of neighbors per row and adjust shared max row counter
+            target.OutputNumNeighbors(rowIndex, numRowEntries);
+            Atomic.Max(ref sharedMax, numRowEntries);
+            
+            // Wait for all threads and adjust global max-non-zero counter
+            Group.Barrier();
+            if (Group.IsFirstThread)
+                target.ComputeAtomicMaxNumNeighbors(sharedMax);
+        }
+        
+        /// <summary>
+        /// A generic sparse matrix converter kernel to convert a given dense input matrix
+        /// into its sparse shape representation.
+        /// </summary>
+        /// <typeparam name="T">The value type to operate on.</typeparam>
+        /// <typeparam name="TPredicate">The predicate type.</typeparam>
+        /// <typeparam name="TStride">The element striding of the matrices.</typeparam>
+        internal static void SparseMatrixShapeConverterKernel<T, TPredicate, TStride>(
+            Index1D index,
+            ArrayView2D<T, TStride> inputMatrix,
+            TPredicate predicate,
+            ArrayView2D<int, TStride> neighbors)
+            where T : unmanaged
+            where TStride : struct, IStride2D
+            where TPredicate : struct, InlineList.IPredicate<Index2D>
+        {
+            int relativeIndex = 0;
+            for (int i = 0, numColumns = (int)inputMatrix.Extent.Y; i < numColumns; ++i)
+            {
+                if (!predicate.Apply(new Index2D(index, i)))
+                    continue;
+                int columnIndex = relativeIndex++;
+                neighbors[index, columnIndex] = i;
+            }
+        }
+        
+        /// <summary>
+        /// A generic sparse matrix converter kernel to convert a given dense input matrix
+        /// into its sparse data representation.
+        /// </summary>
+        /// <typeparam name="T">The value type to operate on.</typeparam>
+        /// <typeparam name="TStride">The element striding of the matrices.</typeparam>
+        internal static void SparseMatrixConverterKernel<T, TStride>(
+            Index1D index,
+            ArrayView2D<T, TStride> inputMatrix,
+            SparseMatrixShapeView<TStride> shapeView,
+            ArrayView2D<T, TStride> edgeWeights)
+            where T : unmanaged
+            where TStride : struct, IStride2D
+        {
+            int numNeighbors = shapeView.NumNeighbors[index];
+            for (int i = 0; i < numNeighbors; ++i)
+            {
+                int columnIndex = shapeView.Neighbors[index, i];
+                edgeWeights[index, i] = inputMatrix[index, columnIndex];
+            }
+        }
+        
+        /// <summary>
+        /// Creates a new sparse matrix shape info provider.
+        /// </summary>
+        /// <typeparam name="TPredicate">
+        /// The predicate used to sparsify the input matrix.
+        /// </typeparam>
+        /// <typeparam name="TTarget">The target view type.</typeparam>
+        public static SparseMatrixShapeInfoProvider<TPredicate, TTarget>
+            CreateSparseMatrixInfoProvider<
+            TPredicate,
+            TTarget>(this Accelerator accelerator)
+            where TPredicate : struct, InlineList.IPredicate<Index2D>
+            where TTarget : struct, ISparseMatrixShapeInfoTarget
+        {
+            // Load basic sparse matrix info kernel
+            var kernel = accelerator.LoadKernel<
+                LongIndex2D,
+                TPredicate,
+                TTarget>(SparseMatrixShapeInfoKernel);
+
+            // Determine the optimal group size for this kernel
+            int groupSize = accelerator.EstimateGroupSize(kernel.GetKernel());
+
+            return (stream, extent, predicate, target) =>
+            {
+                int numGroups = (int)XMath.DivRoundUp(extent.X, groupSize);
+                kernel(stream, (numGroups, groupSize), extent, predicate, target);
+            };
+        }
+        
+        /// <summary>
+        /// A specific sparse view target.
+        /// </summary>
+        internal readonly struct SparseViewTarget : ISparseMatrixShapeInfoTarget
+        {
+            private readonly ArrayView<int> numNeighbors;
+            private readonly VariableView<int> maxNumNeighbors;
+
+            /// <summary>
+            /// Constructs a new sparse view target.
+            /// </summary>
+            /// <param name="numNeighborsView">The global number of neighbors.</param>
+            /// <param name="maxNumNeighborsView">
+            /// The global max number of neighbors.
+            /// </param>
+            public SparseViewTarget(
+                ArrayView<int> numNeighborsView,
+                VariableView<int> maxNumNeighborsView)
+            {
+                numNeighbors = numNeighborsView;
+                maxNumNeighbors = maxNumNeighborsView;
+            }
+            
+            /// <summary>
+            /// Stores the given number of row entries as number of neighbors.
+            /// </summary>
+            public void OutputNumNeighbors(int rowIndex, int numRowEntries) =>
+                numNeighbors[rowIndex] = numRowEntries;
+
+            /// <summary>
+            /// Atomically computes the global maximum number of neighbors.
+            /// </summary>
+            public void ComputeAtomicMaxNumNeighbors(int maxNumLocalNeighbors) =>
+                Atomic.Max(ref maxNumNeighbors.Value, maxNumLocalNeighbors);
+        }
+        
+        /// <summary>
+        /// Creates a new sparse matrix shape info provider.
+        /// </summary>
+        /// <typeparam name="TPredicate">
+        /// The predicate used to sparsify the input matrix.
+        /// </typeparam>
+        /// <param name="accelerator">The current accelerator.</param>
+        /// <param name="tempView">
+        /// The input temporary value view (at least of length 1).
+        /// </param>
+        public static SparseMatrixShapeInfoProvider<TPredicate>
+            CreateSparseMatrixInfoProvider<TPredicate>(
+            this Accelerator accelerator,
+            ArrayView<int> tempView)
+            where TPredicate : struct, InlineList.IPredicate<Index2D>
+        {
+            // Load basic sparse matrix info kernel
+            var infoProvider = accelerator.CreateSparseMatrixInfoProvider<
+                TPredicate,
+                SparseViewTarget>();
+
+            // Allocate page locked memory for fast count transfers
+            if (tempView.Length < 1)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(tempView),
+                    "Temp view needs to have at least a single element");
+            }
+            var internalView = tempView.SubView(0, 1);
+            
+            // Return custom wrapper
+            return (stream, extent, predicate, numNeighborsView) =>
+            {
+                // Construct sparse target and reset data
+                var sparseTarget = new SparseViewTarget(
+                    numNeighborsView,
+                    internalView.VariableView(0));
+                internalView.MemSetToZero(stream);
+
+                // Get info
+                infoProvider(stream, extent, predicate, sparseTarget);
+                
+                // Fetch max count
+                int maxCount = 0;
+                internalView.CopyToCPU(stream, ref maxCount, 1);
+                return maxCount;
+            };
+        }
+
+        /// <summary>
+        /// Compute new sparse matrix shape info.
+        /// </summary>
+        /// <typeparam name="TPredicate">
+        /// The predicate used to sparsify the input matrix.
+        /// </typeparam>
+        /// <param name="accelerator">The current accelerator.</param>
+        /// <param name="stream">The current accelerator stream.</param>
+        /// <param name="matrixExtent">The dense input matrix extent.</param>
+        /// <param name="predicate">The predicate used to sparsify the matrix.</param>
+        /// <param name="numNeighbors">The number of neighbors per row.</param>
+        /// <param name="tempView">
+        /// The input temporary value view (at least of length 1).
+        /// </param>
+        public static int ComputeSparseMatrixShapeInfo<TPredicate>(
+            this Accelerator accelerator,
+            AcceleratorStream stream,
+            Index2D matrixExtent,
+            TPredicate predicate,
+            ArrayView<int> numNeighbors,
+            ArrayView<int> tempView)
+            where TPredicate : struct, InlineList.IPredicate<Index2D>
+        {
+            // Get or create provider
+            var provider = accelerator.CreateSparseMatrixInfoProvider<TPredicate>(
+                tempView);
+
+            // Compute actual sparsity information
+            return provider(stream, matrixExtent, predicate, numNeighbors);
+        }
+        
+        /// <summary>
+        /// Creates a new sparse matrix shape provider.
+        /// </summary>
+        /// <typeparam name="T">The value type to operate on.</typeparam>
+        /// <typeparam name="TPredicate">
+        /// The predicate used to sparsify the input matrix.
+        /// </typeparam>
+        /// <typeparam name="TStride">The element striding of the matrices.</typeparam>
+        /// <param name="accelerator">The current accelerator.</param>
+        /// <param name="tempView">
+        /// The input temporary value view (at least of length 1).
+        /// </param>
+        public static SparseMatrixShapeConverter<T, TPredicate, TStride>
+            CreateSparseMatrixShapeConverter<T, TPredicate, TStride>(
+            this Accelerator accelerator,
+            ArrayView<int> tempView)
+            where T : unmanaged
+            where TStride : struct, IStride2D
+            where TPredicate : struct, InlineList.IPredicate<Index2D>
+        {
+            // Load basic sparse matrix convert kernel
+            var kernel = accelerator.LoadAutoGroupedKernel<
+                Index1D,
+                ArrayView2D<T, TStride>,
+                TPredicate,
+                ArrayView2D<int, TStride>>(SparseMatrixShapeConverterKernel);
+            
+            // Load basic info provider
+            var infoProvider = accelerator.CreateSparseMatrixInfoProvider<TPredicate>(
+                tempView);
+            
+            // Returns new launcher delegate
+            return (stream, matrix, predicate, numNeighbors, getNeighborsFunc) =>
+            {
+                // Determine an info value
+                int max = infoProvider(stream, matrix.Extent, predicate, numNeighbors);
+                
+                // Convert the actual neighbor information
+                var neighbors = getNeighborsFunc(max);
+                kernel(stream, (int)matrix.Extent.X, matrix, predicate, neighbors);
+                return new SparseMatrixShapeView<TStride>(
+                    neighbors,
+                    numNeighbors,
+                    matrix.IntExtent.X,
+                    matrix.IntExtent.Y);
+            };
+        }
+
+        /// <summary>
+        /// Creates a new sparse matrix shape provider.
+        /// </summary>
+        /// <typeparam name="T">The value type to operate on.</typeparam>
+        /// <typeparam name="TPredicate">
+        /// The predicate used to sparsify the input matrix.
+        /// </typeparam>
+        /// <typeparam name="TStride">The element striding of the matrices.</typeparam>
+        /// <param name="accelerator">The current accelerator.</param>
+        /// <param name="stream">The current accelerator stream.</param>
+        /// <param name="inputMatrix">The dense input matrix.</param>
+        /// <param name="predicate">The predicate used to sparsify the matrix.</param>
+        /// <param name="numNeighbors">The number of neighbors per row.</param>
+        /// <param name="getNeighborsFunc">A 2D sparse neighbors view provider.</param>
+        /// <param name="tempView">
+        /// The input temporary value view (at least of length 1).
+        /// </param>
+        public static SparseMatrixShapeView<TStride>
+            ComputeSparseMatrixShapeConverter<T, TPredicate, TStride>(
+            this Accelerator accelerator,
+            AcceleratorStream stream,
+            ArrayView2D<T, TStride> inputMatrix,
+            TPredicate predicate,
+            ArrayView<int> numNeighbors,
+            Func<int, ArrayView2D<int, TStride>> getNeighborsFunc,
+            ArrayView<int> tempView)
+            where T : unmanaged
+            where TPredicate : struct, InlineList.IPredicate<Index2D>
+            where TStride : struct, IStride2D
+        {
+            // Get or create provider
+            var converter = accelerator.CreateSparseMatrixShapeConverter<
+                T,
+                TPredicate,
+                TStride>(tempView);
+            
+            // Convert to the resulting shape shape view
+            return converter(
+                stream,
+                inputMatrix,
+                predicate,
+                numNeighbors,
+                getNeighborsFunc);
+        }
+
+        /// <summary>
+        /// Creates a new sparse matrix converter.
+        /// </summary>
+        /// <typeparam name="T">The value type to operate on.</typeparam>
+        /// <typeparam name="TStride">The element striding of the matrices.</typeparam>
+        /// <param name="accelerator">The current accelerator.</param>
+        public static SparseMatrixConverter<T, TStride> CreateSparseMatrixConverter<
+            T,
+            TStride>(this Accelerator accelerator)
+            where T : unmanaged
+            where TStride : struct, IStride2D
+        {
+            // Load basic sparse matrix convert kernel
+            var kernel = accelerator.LoadAutoGroupedKernel<
+                Index1D,
+                ArrayView2D<T, TStride>,
+                SparseMatrixShapeView<TStride>,
+                ArrayView2D<T, TStride>>(SparseMatrixConverterKernel);
+            
+            // Returns new launcher delegate
+            return (stream, matrix, shapeView, edgeView) =>
+            {
+                kernel(stream, (int)matrix.Extent.X, matrix, shapeView, edgeView);
+                return new SparseMatrixView<T, TStride>(edgeView, shapeView);
+            };
+        }
+        
+        /// <summary>
+        /// Computes a new sparse matrix view.
+        /// </summary>
+        /// <typeparam name="T">The value type to operate on.</typeparam>
+        /// <typeparam name="TStride">The element striding of the matrices.</typeparam>
+        /// <param name="accelerator">The current accelerator.</param>
+        /// <param name="stream">The current accelerator stream.</param>
+        /// <param name="inputMatrix">The dense input matrix.</param>
+        /// <param name="shapeView">The input shape view (pre allocated).</param>
+        /// <param name="dataView">The sparse data view (pre allocated).</param>
+        public static SparseMatrixView<T, TStride> ComputeSparseMatrixView<T, TStride>(
+            this Accelerator accelerator,
+            AcceleratorStream stream,
+            ArrayView2D<T, TStride> inputMatrix,
+            SparseMatrixShapeView<TStride> shapeView,
+            ArrayView2D<T, TStride> dataView)
+            where T : unmanaged
+            where TStride : struct, IStride2D
+        {
+            // Get or create provider
+            var converter = accelerator.CreateSparseMatrixConverter<T, TStride>();
+            
+            // Convert our dense matrix
+            return converter(stream, inputMatrix, shapeView, dataView);
+        }
+    }
+}

--- a/Src/ILGPU.Algorithms/MatrixOperations/SparseMatrixShapeView.cs
+++ b/Src/ILGPU.Algorithms/MatrixOperations/SparseMatrixShapeView.cs
@@ -1,0 +1,140 @@
+// ---------------------------------------------------------------------------------------
+//                                   ILGPU Algorithms
+//                           Copyright (c) 2023 ILGPU Project
+//                                    www.ilgpu.net
+//
+// File: SparseMatrixShapeView.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details.
+// ---------------------------------------------------------------------------------------
+
+using ILGPU.Runtime;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace ILGPU.Algorithms.MatrixOperations
+{
+    /// <summary>
+    /// Represents an abstract 2D sparse matrix shape
+    /// </summary>
+    /// <typeparam name="TStride">The 2D neighbor stride.</typeparam>
+    public interface ISparseMatrixShapeView<TStride>
+        where TStride : struct, IStride2D
+    {
+        /// <summary>
+        /// NumRows x f matrix containing column indexes where non-zero values in matrix
+        /// are for each row in [0:NumRows].
+        /// </summary>
+        ArrayView2D<int, TStride> Neighbors { get; }
+
+        /// <summary>
+        /// Vector with number of non-zero entries on each row of m_neighbors for all x,
+        /// neighbors[x, numNeighbors[x]:MaxNonZeroEntries] may contain junk.
+        /// </summary>
+        ArrayView<int> NumNeighbors { get; }
+
+        /// <summary>
+        /// The number of rows.
+        /// </summary>
+        Index1D NumRows { get; }
+
+        /// <summary>
+        /// The number of columns.
+        /// </summary>
+        Index1D NumColumns { get; }
+    }
+
+    /// <summary>
+    /// A single sparse matrix shape view containing information about the shape of a
+    /// sparse matrix without specifying its data.
+    /// </summary>
+    /// <typeparam name="TStride">The 2D stride.</typeparam>
+    public readonly struct SparseMatrixShapeView<TStride>
+        : ISparseMatrixShapeView<TStride>
+        where TStride : struct, IStride2D
+    {
+        /// <summary>
+        /// Constructs a new sparse matrix shape.
+        /// </summary>
+        /// <param name="neighbors">The neighbors indexing view.</param>
+        /// <param name="numNeighbors">The number of neighbors per row.</param>
+        /// <param name="numRows">The number of rows of the source matrix.</param>
+        /// <param name="numColumns">The number of columns of the source matrix.</param>
+        public SparseMatrixShapeView(
+            ArrayView2D<int, TStride> neighbors,
+            ArrayView<int> numNeighbors,
+            Index1D numRows,
+            Index1D numColumns)
+        {
+            Trace.Assert(
+                numRows > 0 &
+                neighbors.Extent.X >= numRows &
+                numNeighbors.IntLength >= numRows,
+                "Invalid number of rows");
+            Trace.Assert(
+                numColumns >= 0,
+                "Invalid number of columns");
+
+            Neighbors = neighbors;
+            NumNeighbors = numNeighbors;
+            NumRows = numRows;
+            NumColumns = numColumns;
+        }
+
+        /// <summary>
+        /// NumRows x f matrix containing column indexes where non-zero values in matrix
+        /// are for each row in [0:NumRows].
+        /// </summary>
+        public ArrayView2D<int, TStride> Neighbors { get; }
+
+        /// <summary>
+        /// Vector with number of non-zero entries on each row of m_neighbors for all x,
+        /// neighbors[x, numNeighbors[x]:MaxNonZeroEntries] may contain junk.
+        /// </summary>
+        public ArrayView<int> NumNeighbors { get; }
+
+        /// <summary>
+        /// The number of rows.
+        /// </summary>
+        public Index1D NumRows { get; }
+
+        /// <summary>
+        /// The number of columns.
+        /// </summary>
+        public Index1D NumColumns { get; }
+
+        /// <summary>
+        /// Finds the requested column from the original dense matrix in neighbors.
+        /// </summary>
+        /// <remarks>
+        /// This method uses a single-threaded binary search algorithm which can be
+        /// slow on GPUs if the current num-neighbor view is not loaded into cache.
+        /// </remarks>
+        /// <param name="row">The row used for searching.</param>
+        /// <param name="column">The column to look for.</param>
+        /// <param name="index">The output index (if any).</param>
+        /// <returns>True if the column index could be found.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryFindColumn(Index1D row, Index1D column, out Index1D index)
+        {
+            int nonZero = NumNeighbors[row];
+
+            // Simple binary search algorithm
+            int left = 0;
+            int right = nonZero - 1;
+            while (left <= right)
+            {
+                index = left + (right - left) / 2;
+                switch (Neighbors[row, index].CompareTo(column))
+                {
+                    case -1: left = index + 1; break;
+                    case 0: return true;
+                    case 1: right = index - 1; break;
+                }
+            }
+            index = Index1D.Invalid;
+            return false;
+        }
+    }
+}

--- a/Src/ILGPU.Algorithms/MatrixOperations/SparseMatrixView.cs
+++ b/Src/ILGPU.Algorithms/MatrixOperations/SparseMatrixView.cs
@@ -1,0 +1,119 @@
+// ---------------------------------------------------------------------------------------
+//                                   ILGPU Algorithms
+//                           Copyright (c) 2023 ILGPU Project
+//                                    www.ilgpu.net
+//
+// File: SparseMatrixView.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details.
+// ---------------------------------------------------------------------------------------
+
+using ILGPU.Runtime;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace ILGPU.Algorithms.MatrixOperations
+{
+    /// <summary>
+    /// Represents a sparse matrix in view pointing to data in GPU space
+    /// </summary>
+    public readonly struct SparseMatrixView<T, TStride> : ISparseMatrixShapeView<TStride>
+        where T : unmanaged
+        where TStride : struct, IStride2D
+    {
+        #region Instance
+
+        /// <summary>
+        /// Constructs a new view wrapping existing views that represent a sparse matrix.
+        /// </summary>
+        /// <param name="edgeWeights">A sparse shape.</param>
+        /// <param name="shapeView">The values for all edges.</param>
+        public SparseMatrixView(
+            ArrayView2D<T, TStride> edgeWeights,
+            SparseMatrixShapeView<TStride> shapeView)
+        {
+            EdgeWeights = edgeWeights;
+            ShapeView = shapeView;
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Returns a view pointing to all edge weights.
+        /// </summary>
+        public ArrayView2D<T, TStride> EdgeWeights { get; }
+
+        /// <summary>
+        /// Returns the associated shape view.
+        /// </summary>
+        public SparseMatrixShapeView<TStride> ShapeView { get; }
+
+        /// <summary>
+        /// Gets or sets a data element in the specified row and column. May be slow
+        /// depending on caching. See <see cref="SparseMatrixView{T,TStride}"/> for more
+        /// information.
+        /// </summary>
+        public T this[Index1D row, Index1D column]
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                if (!ShapeView.TryFindColumn(row, column, out var idx))
+                    return default;
+                return DirectAccess(row, idx);
+            }
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            set
+            {
+                if (!ShapeView.TryFindColumn(row, column, out var idx))
+                {
+                    Trace.Assert(false, "Cannot store to non-sparse index");
+                    return;
+                }
+                DirectAccess(row, idx) = value;
+            }
+        }
+
+        #endregion
+
+        #region ISparseMatrixShapeView
+
+        /// <summary>
+        /// NumRows x f matrix containing column indexes where non-zero values in matrix
+        /// are for each row in [0:NumRows].
+        /// </summary>
+        public ArrayView2D<int, TStride> Neighbors => ShapeView.Neighbors;
+
+        /// <summary>
+        /// Vector with number of non-zero entries on each row of m_neighbors for all x,
+        /// neighbors[x, numNeighbors[x]:MaxNonZeroEntries] may contain junk.
+        /// </summary>
+        public ArrayView<int> NumNeighbors => ShapeView.NumNeighbors;
+
+        /// <summary>
+        /// The number of rows.
+        /// </summary>
+        public Index1D NumRows => ShapeView.NumRows;
+
+        /// <summary>
+        /// The number of columns.
+        /// </summary>
+        public Index1D NumColumns => ShapeView.NumColumns;
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Returns a memory reference to the desired data cell.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ref T DirectAccess(Index1D row, Index1D idx) =>
+            ref EdgeWeights[row, idx];
+
+        #endregion
+    }
+}


### PR DESCRIPTION
This PR adds new helper classes and methods to process sparse matrices on the GPU while supporting specific masking operations to avoid computation of intermediate values. It also adds add a newly created `ConcurrentStreamProcessor` to perform generic operations concurrently on multiple concurrent GPU streams.

A sample use case is shown below that multiplies masked sparse matrixes. There are two options available:

1. Create a single-stream-focused masked multiplier to have explicit control over matrix multiplications
2. Create a stream-based concurrent processor to perform batched multiplications

```c#
// Create a single-streamed sparse matrix buffer
var processor = accel.CreateSparseTransposedMatrixMultiplierMasked<
    float, // Matrix type
    FloatEpsPredicate<Stride2D.DenseY>, // A generic predicate - a float-eps-value predicate in this case
    Stride2D.DenseY, // Custom striding of the matrix to use
    FloatMaskedSparseMatrixProcessor>(); // A float-specific FMA operation to accumulate dot products

// Multiply a single masked sparse matrix
processor(
    accel.DefaultStream,
    new(denseMatrixBuffer.View, 2.0f),
    denseMatrixBuffer.View,
    sparseView, // Sparse matrix view, obtained by explicit construction or using one of the available sparsification methods; will be transposed during runtime (see below)
    outBuffer.View);

// Create a concurrent processor that supports batched multiplication
using var maskedProcessor = new MaskedMatrixProcessor<
    float,
    FloatEpsPredicate<Stride2D.DenseY>,
    Stride2D.DenseY,
    FloatMaskedSparseMatrixProcessor>(accel);
maskedProcessor.Predicate = /* custom predicate here */;
maskedProcessor.MultiplyBatchedTransposed(
    accel.DefaultStream, // The main accelerator stream to attach the next multiplication operations to
    aViewList, // A list of dense input matrices used to multiply the sparse matrices (bViewList) with
    bViewList, // A list of sparse input matrices (will be transposed)
    outViewList); //A list of output views to matrix data containing the results 
```

Sample for accelerated creation of huge sparse matrices on accelerators using the newly added extensions:
```c#
// Setup sparse 2D matrix
var matrix = new float[4, 4]
{
    { 1, 0, 0, 0 },
    { 2, 1, 0, 0 },
    { 3, 0, 1, 0 },
    { 4, 0, 0, 1 },
};

// Allocate basic matrix on the accelerator and transfer it to the device
using var matrixBuffer = accel.Allocate2DDenseY<float>(matrix.GetExtent());
matrixBuffer.View.CopyFromCPU(matrix);

// Allocate a temp buffer (or use existing memory from somewhere else)
using var tempBuffer = accel.Allocate1D<int>(1);

// Initialize the basic shape converter and data converters
var shapeConverter = accel.CreateSparseTransposedMatrixShapeConverter<
    float,
    FloatEpsPredicate<Stride2D.DenseY>,
    Stride2D.DenseY>(tempBuffer.View);
var converter = accel.CreateSparseMatrixConverter<float, Stride2D.DenseY>();

// Get basic shape of the sparse matrix living on the device
using var numNeighborsBuffer = accel.Allocate1D<int>(matrix.GetLength(1));
var shapeView = shapeConverter(
    accel.DefaultStream,
    matrixBuffer,
    new(matrixBuffer, 0.0f),
    numNeighborsBuffer.View,
    maxNumNeighbors =>
        // Allocate a shape-view buffer to store the neighbor lists
        accel.Allocate2DDenseY<int>((matrix.GetLength(1), maxNumNeighbors)));

// Allocate the actual sparse data buffer
using var dataBuffer = accel.Allocate2DDenseY<float>(
    (matrix.GetLength(1),
    shapeView.MaxNonZeroEntries));

// Convert data and fill our sparse matrix structure
var sparseView = converter(accel.DefaultStream, matrixBuffer, shapeView, dataBuffer);
```

*Note: This PR requires PR #989 to be merged.*

Co-authored by @corwinjoy who wrote the initial POC.