### PR TITLE
Support static abstract interface members

### DIFF
--- a/Src/ILGPU.Tests/Configurations.txt
+++ b/Src/ILGPU.Tests/Configurations.txt
@@ -5,7 +5,6 @@ DisassemblerTests
 EnumValues
 FixedBuffers
 GetKernelTests
-GenericMath
 Indices
 KernelEntryPoints
 MemoryBufferOperations
@@ -14,6 +13,7 @@ ProfilingMarkers
 SharedMemory
 SizeOfValues
 SpecializedKernels
+StaticAbstractInterfaceMembers
 StructureValues
 ValueTuples
 InteropTests

--- a/Src/ILGPU/Frontend/CodeGenerator/Calls.cs
+++ b/Src/ILGPU/Frontend/CodeGenerator/Calls.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2018-2021 ILGPU Project
+//                        Copyright (c) 2018-2023 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Calls.cs
@@ -64,6 +64,22 @@ namespace ILGPU.Frontend
                     : ConvertFlags.None;
                 Block.Push(LoadOntoEvaluationStack(result, flags));
             }
+        }
+
+        /// <summary>
+        /// Realizes a call instruction.
+        /// </summary>
+        /// <param name="instruction">The instruction to realize.</param>
+        private void MakeCall(ILInstruction instruction)
+        {
+            var method = instruction.GetArgumentAs<MethodBase>();
+            if (instruction.HasFlags(ILInstructionFlags.Constrained)
+                && method is MethodInfo methodInfo)
+            {
+                var constrainedType = instruction.FlagsContext.Argument as Type;
+                method = ResolveVirtualCallTarget(methodInfo, constrainedType);
+            }
+            MakeCall(method);
         }
 
         /// <summary>

--- a/Src/ILGPU/Frontend/CodeGenerator/CodeGenerator.cs
+++ b/Src/ILGPU/Frontend/CodeGenerator/CodeGenerator.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2018-2022 ILGPU Project
+//                        Copyright (c) 2018-2023 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: CodeGenerator.cs
@@ -142,8 +142,7 @@ namespace ILGPU.Frontend
             }
 
             // Initialize locals
-            var methodBody = Disassembler.ExtractMethodBody(Method);
-            var localVariables = methodBody.LocalVariables;
+            var localVariables = Method.GetMethodBody().LocalVariables;
             for (int i = 0, e = localVariables.Count; i < e; ++i)
             {
                 var variable = localVariables[i];

--- a/Src/ILGPU/Frontend/CodeGenerator/Driver.cs
+++ b/Src/ILGPU/Frontend/CodeGenerator/Driver.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2018-2021 ILGPU Project
+//                        Copyright (c) 2018-2023 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Driver.cs
@@ -129,7 +129,7 @@ namespace ILGPU.Frontend
                     MakeReturn();
                     return true;
                 case ILInstructionType.Call:
-                    MakeCall(instruction.GetArgumentAs<MethodBase>());
+                    MakeCall(instruction);
                     return true;
                 case ILInstructionType.Callvirt:
                     MakeVirtualCall(instruction);


### PR DESCRIPTION
This replaces specific generic math support introduced in 7bf55786f96a8912dcfd21b9e86e03c5e270fcd5 ( https://github.com/m4rs-mt/ILGPU/pull/898 )  with generic support for static abstract interface members.

Support is implemented using the constrained flag on the call instruction the same way it used to be done on virtual method calls. The call instruction with constrained flag set contains concrete type, that implements given interface, which makes it possible to find concrete method implementation to be called.

fixes https://github.com/m4rs-mt/ILGPU/issues/929