### PR TITLE
Implemented override for Cuda device instruction set.

### DIFF
--- a/Src/ILGPU/Runtime/Cuda/CudaAccelerator.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaAccelerator.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2016-2021 ILGPU Project
+//                        Copyright (c) 2016-2023 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: CudaAccelerator.cs
@@ -9,7 +9,6 @@
 // Source License. See LICENSE.txt for details.
 // ---------------------------------------------------------------------------------------
 
-using ILGPU.Backends;
 using ILGPU.Backends.IL;
 using ILGPU.Backends.PTX;
 using ILGPU.Resources;
@@ -188,7 +187,7 @@ namespace ILGPU.Runtime.Cuda
                 Context,
                 Capabilities,
                 Architecture,
-                InstructionSet,
+                (CudaInstructionSet)Device.InstructionSet,
                 nvvmAPI));
         }
 
@@ -220,8 +219,7 @@ namespace ILGPU.Runtime.Cuda
         /// <summary>
         /// Returns the PTX instruction set.
         /// </summary>
-        public CudaInstructionSet InstructionSet =>
-            (CudaInstructionSet)Device.InstructionSet;
+        public CudaInstructionSet InstructionSet => Backend.InstructionSet;
 
         /// <summary>
         /// Returns the clock rate.

--- a/Src/ILGPU/Runtime/Cuda/CudaDeviceOverride.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaDeviceOverride.cs
@@ -1,0 +1,48 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                           Copyright (c) 2023 ILGPU Project
+//                                    www.ilgpu.net
+//
+// File: CudaDeviceOverride.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details.
+// ---------------------------------------------------------------------------------------
+
+namespace ILGPU.Runtime.Cuda
+{
+    /// <summary>
+    /// Represents overridable settings of a Cuda device.
+    /// </summary>
+    public sealed class CudaDeviceOverride
+    {
+        /// <summary>
+        /// The Cuda device to configure.
+        /// </summary>
+        public CudaDevice Device { get; }
+
+        /// <summary>
+        /// Forces the Cuda device to use the specified Instruction Set.
+        /// </summary>
+        public CudaInstructionSet? InstructionSet { get; set; }
+
+        /// <summary>
+        /// Constructs a new instance with the overridable settings.
+        /// </summary>
+        /// <param name="device">The Cuda device.</param>
+        internal CudaDeviceOverride(CudaDevice device)
+        {
+            Device = device;
+            InstructionSet = device.InstructionSet;
+        }
+
+        /// <summary>
+        /// Applies all the overridden settings to the Cuda device.
+        /// </summary>
+        internal void ApplyOverrides()
+        {
+            if (InstructionSet.HasValue)
+                Device.InstructionSet = InstructionSet;
+        }
+    }
+}

--- a/Src/ILGPU/Runtime/Cuda/CudaInstructionSet.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaInstructionSet.cs
@@ -148,7 +148,12 @@ namespace ILGPU.Runtime.Cuda
 
         #region Instance
 
-        private CudaInstructionSet(int major, int minor)
+        /// <summary>
+        /// Creates the instruction set from major/minor values.
+        /// </summary>
+        /// <param name="major">The major version.</param>
+        /// <param name="minor">The minor version.</param>
+        public CudaInstructionSet(int major, int minor)
         {
             Major = major;
             Minor = minor;


### PR DESCRIPTION
This PR attempts to deal with the issue of newly introduced Cuda Instruction Sets that are unknown at the time ILGPU was compiled and published to Nuget (see #880).

Using the RTX 4090 as an example, Nvidia introduced SM 9.0 and ISA 7.8. The architecture SM 9.0 can be determined by querying the device at runtime, so that's fine. However, the instruction set ISA 7.8 is unknown to ILGPU, and cannot be determined at runtime.

This PR introduces a new overload to the `Cuda()` method when configuring a `Context` that allows the caller to force the device to use a specific instruction set. This should hopefully make ILGPU versions usable as new Cuda devices are released, without forcing developers to update to the latest version of ILGPU.

```CSharp
// Force all Cuda devices to use ISA 7.8
using var context = Context.Create(builder => builder.Cuda(overridableDevice => overridableDevice.InstructionSet = new CudaInstructionSet(7, 8)));
```