### PR TITLE
Added generic constraints to fix failing unit tests on .NET 7.0.3 SDK.

### DIFF
--- a/Src/ILGPU.Algorithms/HistogramExtensions.cs
+++ b/Src/ILGPU.Algorithms/HistogramExtensions.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                   ILGPU Algorithms
-//                        Copyright (c) 2020-2022 ILGPU Project
+//                        Copyright (c) 2020-2023 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: HistogramExtensions.cs
@@ -38,7 +38,7 @@ namespace ILGPU.Algorithms
         ArrayView<int> histogramOverflow)
         where T : unmanaged
         where TBinType : unmanaged
-        where TStride : unmanaged, IStride1D;
+        where TStride : struct, IStride1D;
 
     /// <summary>
     /// Represents a histogram operation on the given view.
@@ -54,7 +54,7 @@ namespace ILGPU.Algorithms
         ArrayView1D<T, TStride> view,
         ArrayView<TBinType> histogram)
         where T : unmanaged
-        where TStride : unmanaged, IStride1D
+        where TStride : struct, IStride1D
         where TBinType : unmanaged;
 
     #endregion
@@ -99,7 +99,7 @@ namespace ILGPU.Algorithms
             ArrayView<int> histogramOverflow,
             int paddedLength)
             where T : unmanaged
-            where TStride : unmanaged, IStride1D
+            where TStride : struct, IStride1D
             where TBinType : unmanaged
             where TIncrementor : struct, IIncrementOperation<TBinType>
             where TLocator : struct, IComputeMultiBinOperation<T, TBinType, TIncrementor>;
@@ -133,7 +133,7 @@ namespace ILGPU.Algorithms
             ArrayView<TBinType> histogram,
             int paddedLength)
             where T : unmanaged
-            where TStride : unmanaged, IStride1D
+            where TStride : struct, IStride1D
             where TBinType : unmanaged
             where TIncrementor : struct, IIncrementOperation<TBinType>
             where TLocator : struct, IComputeMultiBinOperation<T, TBinType, TIncrementor>;
@@ -181,7 +181,7 @@ namespace ILGPU.Algorithms
             ArrayView<int> histogramOverflow,
             int paddedLength)
             where T : unmanaged
-            where TStride : unmanaged, IStride1D
+            where TStride : struct, IStride1D
             where TBinType : unmanaged
             where TIncrementor : struct, IIncrementOperation<TBinType>
             where TLocator : struct, IComputeMultiBinOperation<T, TBinType, TIncrementor>
@@ -219,7 +219,7 @@ namespace ILGPU.Algorithms
             ArrayView<TBinType> histogram,
             int paddedLength)
             where T : unmanaged
-            where TStride : unmanaged, IStride1D
+            where TStride : struct, IStride1D
             where TBinType : unmanaged
             where TIncrementor : struct, IIncrementOperation<TBinType>
             where TLocator : struct, IComputeMultiBinOperation<T, TBinType, TIncrementor>
@@ -242,7 +242,7 @@ namespace ILGPU.Algorithms
             out bool histogramOverflow,
             int paddedLength)
             where T : unmanaged
-            where TStride : unmanaged, IStride1D
+            where TStride : struct, IStride1D
             where TBinType : unmanaged
             where TIncrementor : struct, IIncrementOperation<TBinType>
             where TLocator : struct, IComputeMultiBinOperation<T, TBinType, TIncrementor>
@@ -295,7 +295,7 @@ namespace ILGPU.Algorithms
             TLocator>(
             this Accelerator accelerator)
             where T : unmanaged
-            where TStride : unmanaged, IStride1D
+            where TStride : struct, IStride1D
             where TBinType : unmanaged
             where TIncrementor : struct, IIncrementOperation<TBinType>
             where TLocator : struct, IComputeMultiBinOperation<T, TBinType, TIncrementor>
@@ -373,7 +373,7 @@ namespace ILGPU.Algorithms
             TLocator>(
             this Accelerator accelerator)
             where T : unmanaged
-            where TStride : unmanaged, IStride1D
+            where TStride : struct, IStride1D
             where TBinType : unmanaged
             where TIncrementor : struct, IIncrementOperation<TBinType>
             where TLocator : struct, IComputeMultiBinOperation<T, TBinType, TIncrementor>
@@ -449,7 +449,7 @@ namespace ILGPU.Algorithms
             ArrayView<TBinType> histogram,
             ArrayView<int> histogramOverflow)
             where T : unmanaged
-            where TStride : unmanaged, IStride1D
+            where TStride : struct, IStride1D
             where TBinType : unmanaged
             where TIncrementor : struct, IIncrementOperation<TBinType>
             where TLocator : struct, IComputeMultiBinOperation<T, TBinType, TIncrementor>
@@ -488,7 +488,7 @@ namespace ILGPU.Algorithms
             ArrayView1D<T, TStride> view,
             ArrayView<TBinType> histogram)
             where T : unmanaged
-            where TStride : unmanaged, IStride1D
+            where TStride : struct, IStride1D
             where TBinType : unmanaged
             where TIncrementor : struct, IIncrementOperation<TBinType>
             where TLocator : struct, IComputeMultiBinOperation<T, TBinType, TIncrementor>

--- a/Src/ILGPU.Algorithms/HistogramLaunchers.tt
+++ b/Src/ILGPU.Algorithms/HistogramLaunchers.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                   ILGPU Algorithms
-//                        Copyright (c) 2020-2021 ILGPU Project
+//                        Copyright (c) 2020-2023 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: HistogramLaunchers.tt/HistogramLaunchers.cs
@@ -59,7 +59,7 @@ namespace ILGPU.Algorithms
             ArrayView<<#= type.Type #>> histogram,
             ArrayView<int> histogramOverflow)
             where T : unmanaged
-            where TStride : unmanaged, IStride1D
+            where TStride : struct, IStride1D
             where TLocator : struct, IComputeSingleBinOperation<T, Index1D>
         {
             var kernel = accelerator.CreateHistogram<

--- a/Src/ILGPU.Algorithms/PTX/PTXGroupExtensions.cs
+++ b/Src/ILGPU.Algorithms/PTX/PTXGroupExtensions.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                   ILGPU Algorithms
-//                        Copyright (c) 2019-2021 ILGPU Project
+//                        Copyright (c) 2019-2023 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: PTXGroupExtensions.cs
@@ -23,14 +23,14 @@ namespace ILGPU.Algorithms.PTX
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static T Reduce<T, TReduction>(T value)
             where T : unmanaged
-            where TReduction : IScanReduceOperation<T> =>
+            where TReduction : struct, IScanReduceOperation<T> =>
             AllReduce<T, TReduction>(value);
 
         /// <summary cref="GroupExtensions.AllReduce{T, TReduction}(T)"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static T AllReduce<T, TReduction>(T value)
             where T : unmanaged
-            where TReduction : IScanReduceOperation<T>
+            where TReduction : struct, IScanReduceOperation<T>
         {
             // A fixed number of memory banks to distribute the workload
             // of the atomic operations in shared memory.

--- a/Src/ILGPU/StrideTypes.tt
+++ b/Src/ILGPU/StrideTypes.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2016-2022 ILGPU Project
+//                        Copyright (c) 2016-2023 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: StrideTypes.tt/StrideTypes.cs
@@ -516,7 +516,7 @@ namespace ILGPU
         public static int ComputeElementIndex<TStride>(
             this TStride stride,
             <#= indexName #> index)
-            where TStride : <#= strideName #> =>
+            where TStride : struct, <#= strideName #> =>
 <#      for (int i = 0; i < def.Dimension; ++i) { #>
 <#          var iName = IndexDimensions[i].PropertyName; #>
 <#          var separator = i + 1 < def.Dimension ? " +" : ";"; #>
@@ -533,7 +533,7 @@ namespace ILGPU
         public static long ComputeElementIndex<TStride>(
             this TStride stride,
             <#= longIndexName #> index)
-            where TStride : <#= strideName #> =>
+            where TStride : struct, <#= strideName #> =>
 <#      for (int i = 0; i < def.Dimension; ++i) { #>
 <#          var iName = IndexDimensions[i].PropertyName; #>
 <#          var separator = i + 1 < def.Dimension ? " +" : ";"; #>
@@ -553,7 +553,7 @@ namespace ILGPU
             this TStride stride,
             <#= indexName #> index,
             <#= indexName #> extent)
-            where TStride : <#= strideName #>
+            where TStride : struct, <#= strideName #>
         {
 <#      for (int i = 0; i < def.Dimension; ++i) { #>
 <#          var iName = IndexDimensions[i].PropertyName; #>
@@ -567,7 +567,7 @@ namespace ILGPU
                     Bitwise.And(index.<#= iName #> == 0, extent.<#= iName #> == 0)),
                 "<#= iName #> index out of bounds");
 <#      } #>
-            return stride.ComputeElementIndex(index);
+            return ComputeElementIndex(stride, index);
         }
 
         /// <summary>
@@ -583,7 +583,7 @@ namespace ILGPU
             this TStride stride,
             <#= longIndexName #> index,
             <#= longIndexName #> extent)
-            where TStride : <#= strideName #>
+            where TStride : struct, <#= strideName #>
         {
 <#      for (int i = 0; i < def.Dimension; ++i) { #>
 <#          var iName = IndexDimensions[i].PropertyName; #>
@@ -593,7 +593,7 @@ namespace ILGPU
                     index.<#= iName #> < extent.<#= iName #>),
                 "<#= iName #> index out of bounds");
 <#      } #>
-            return stride.ComputeElementIndex(index);
+            return ComputeElementIndex(stride, index);
         }
 
         /// <summary>
@@ -606,14 +606,14 @@ namespace ILGPU
         public static int ComputeBufferLength<TStride>(
             this TStride stride,
             <#= indexName #> extent)
-            where TStride : <#= strideName #>
+            where TStride : struct, <#= strideName #>
         {
 <#      for (int i = 0; i < def.Dimension; ++i) { #>
 <#          var iName = IndexDimensions[i].PropertyName; #>
             if (extent.<#= iName #> == 0)
                 return 0;
 <#      } #>
-            return stride.ComputeElementIndex(extent - <#= indexName #>.One) + 1;
+            return ComputeElementIndex(stride, extent - <#= indexName #>.One) + 1;
         }
 
         /// <summary>
@@ -626,14 +626,14 @@ namespace ILGPU
         public static long ComputeBufferLength<TStride>(
             this TStride stride,
             <#= longIndexName #> extent)
-            where TStride : <#= strideName #>
+            where TStride : struct, <#= strideName #>
         {
 <#      for (int i = 0; i < def.Dimension; ++i) { #>
 <#          var iName = IndexDimensions[i].PropertyName; #>
             if (extent.<#= iName #> == 0L)
                 return 0L;
 <#      } #>
-            return stride.ComputeElementIndex(extent - <#= longIndexName #>.One) + 1L;
+            return ComputeElementIndex(stride, extent - <#= longIndexName #>.One) + 1L;
         }
 
     }


### PR DESCRIPTION
Fixes #932.

Looks like the .NET 7.0.3 SDK identified that the C# extension method was potentially calling a class instance, and added IL instructions for boxing.

I have applied the `struct` generic type constraint. This removes the boxing in IL. ILGPU probably had issues converting the boxing into internal IR nodes.

I have also changed the call from `stride.ComputeElementIndex(...)` to `ComputeElementIndex(stride, ...)`. Without this change, the IL would use `callvirt`. Since we are using a `struct` constraint, it should not be possible for the call to `ComputeElementIndex` to be overridden.

