### PR TITLE
Fixed regression in CI skipping MacOS builds.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
           # pushed, we do this since macOS builds last too long and ILGPU
           # is rarely used on a macOS
           (
-            [ "${{ github.event_name }}" == "workflow_dispatch" ] ||
+            [ "${{ github.event_name }}" == "workflow_dispatch" ||
               "${{ github.event_name }}" == "schedule" ] ||
             (
               [ "${{ github.event_name }}" == "push" ] &&


### PR DESCRIPTION
Caused by #940.