### PR TITLE
Updated Cuda tool for website design changes.

### DIFF
--- a/Tools/CudaVersionUpdateTool/Services/ParserService.cs
+++ b/Tools/CudaVersionUpdateTool/Services/ParserService.cs
@@ -29,8 +29,8 @@ namespace CudaVersionUpdateTool.Services
             var context = BrowsingContext.New(config);
 
             var doc = await context.OpenAsync(ReleaseNotesUrl);
-            var table = doc.GetElementById("release-notes__ptx-release-history");
-            var rows = table?.QuerySelectorAll("tbody tr");
+            var section = doc.GetElementById("release-notes");
+            var rows = section?.QuerySelectorAll("tbody tr");
 
             foreach (var row in rows ?? Enumerable.Empty<IElement>())
             {

--- a/Tools/CudaVersionUpdateTool/Util/Runner.cs
+++ b/Tools/CudaVersionUpdateTool/Util/Runner.cs
@@ -33,8 +33,10 @@ namespace CudaVersionUpdateTool.Util
         /// <param name="path">The base path to process.</param>
         public async Task UpdateArchitectureAsync(string path)
         {
-            var versionSets = await ParserService.GetVersionSetsAsync();
-            await GeneratorService.GenerateAsync(path, versionSets.ToList());
+            var versionSets = (await ParserService.GetVersionSetsAsync()).ToList();
+            if (!versionSets.Any())
+                throw new InvalidDataException("No version data found.");
+            await GeneratorService.GenerateAsync(path, versionSets);
         }
     }
 }


### PR DESCRIPTION
The Nvidia website has a new design. And when they published the new PTX version, it also changed the name of the HTML element. This PR updates to use the Section ID rather than the Table ID, so that it is more resilient. And also fail if there are no versions detected during parsing.