### PR TITLE
Fixed status checks on protected branches.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,15 +5,11 @@ on:
   push:
     paths-ignore:
       - '.github/workflows/deploy-site.yml'
-      - '.github/workflows/update-copyright-year.yml'
-      - '.github/workflows/update-cuda-versions.yml'
       - 'Docs/**'
       - 'Site/**'
   pull_request:
     paths-ignore:
       - '.github/workflows/deploy-site.yml'
-      - '.github/workflows/update-copyright-year.yml'
-      - '.github/workflows/update-cuda-versions.yml'
       - 'Docs/**'
       - 'Site/**'
   schedule:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,8 +6,6 @@ on:
     branches: [ master ]
     paths-ignore:
       - '.github/workflows/deploy-site.yml'
-      - '.github/workflows/update-copyright-year.yml'
-      - '.github/workflows/update-cuda-versions.yml'
       - 'Docs/**'
       - 'Site/**'
   pull_request:
@@ -15,8 +13,6 @@ on:
     branches: [ master ]
     paths-ignore:
       - '.github/workflows/deploy-site.yml'
-      - '.github/workflows/update-copyright-year.yml'
-      - '.github/workflows/update-cuda-versions.yml'
       - 'Docs/**'
       - 'Site/**'
   schedule:

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -77,6 +77,13 @@ jobs:
         uses: actions/upload-pages-artifact@v1
       ##### GitHub Pages #####
 
+  all-required-checks-done:
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "All required checks done"
+
   deploy: # Deployment job
     if: github.event_name != 'pull_request' # Skip deployment when building pull requests.
     environment:


### PR DESCRIPTION
`master` is a protected branch in GitHub, and requires `all-required-checks-done` to pass.

As described in [this article](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks), when path filtering is used, other CI workflows need their own `all-required-checks-done`.

Added `all-required-checks-done` to website CI workflow. This is separate from the main CI workflow, so it needs its own.

Removed automated PR workflows from main CI ignore list. They will not be updated often, so not worth the trouble of a generic/fallback workflow as suggested in the article above. Otherwise, we would constantly need to update both the main CI workflow and fallback workflows for newly added paths to ignore.