### PR TITLE
Fixed setup of CI matrix.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,8 +105,8 @@ jobs:
           # pushed, we do this since macOS builds last too long and ILGPU
           # is rarely used on a macOS
           (
-            [ "${{ github.event_name }}" == "workflow_dispatch" ||
-              "${{ github.event_name }}" == "schedule" ] ||
+            [ "${{ github.event_name }}" == "workflow_dispatch" ] ||
+            [ "${{ github.event_name }}" == "schedule" ] ||
             (
               [ "${{ github.event_name }}" == "push" ] &&
               (


### PR DESCRIPTION
The fix from #944 appears to have worked, but the `setup-os-matrix` still reports an error in the logs of `line 7: [: missing `]'`.

Bash script does not like the `||` operator being used inside `[` and `]`.