### PR TITLE
Updated Cuda Library API versions.

### DIFF
--- a/Src/ILGPU.Algorithms/Runtime/Cuda/API/CuBlasNativeMethods.tt
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/API/CuBlasNativeMethods.tt
@@ -35,6 +35,9 @@ var libraryVersions = new (string, Platform, string)[]
         ("V11", Platform.Windows,   "cublas64_11.dll"),
         ("V11", Platform.Linux,     "libcublas.so.11"),
         ("V11", Platform.OSX,       "libcublas.11.dylib"),
+    
+        ("V12", Platform.Windows,   "cublas64_12.dll"),
+        ("V12", Platform.Linux,     "libcublas.so.12"),
     };
 
 var regions = new List<Region>();

--- a/Src/ILGPU.Algorithms/Runtime/Cuda/API/CuFFTAPI.xml
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/API/CuFFTAPI.xml
@@ -9,6 +9,9 @@
         <LibraryVersion Name="V10" Platform="Windows" LibName="cufft64_10.dll" />
         <LibraryVersion Name="V10" Platform="Linux" LibName="libcufft.so.10" />
         <LibraryVersion Name="V10" Platform="OSX" LibName="libcufft.10.dylib" />
+
+        <LibraryVersion Name="V11" Platform="Windows" LibName="cufft64_11.dll" />
+        <LibraryVersion Name="V11" Platform="Linux" LibName="libcufft.so.11" />
     </LibraryVersions>
 
     <Region Name="Basic Plans">

--- a/Src/ILGPU.Algorithms/Runtime/Cuda/API/CuFFTWAPI.xml
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/API/CuFFTWAPI.xml
@@ -8,6 +8,9 @@
         <LibraryVersion Name="V10" Platform="Windows" LibName="cufftw64_10.dll" />
         <LibraryVersion Name="V10" Platform="Linux" LibName="libcufftw.so.10" />
         <LibraryVersion Name="V10" Platform="OSX" LibName="libcufftw.10.dylib" />
+
+        <LibraryVersion Name="V11" Platform="Windows" LibName="cufftw64_11.dll" />
+        <LibraryVersion Name="V11" Platform="Linux" LibName="libcufftw.so.11" />
     </LibraryVersions>
 
     <Region Name="Basic Interface - Complex - Double Precision">

--- a/Src/ILGPU.Algorithms/Runtime/Cuda/API/CuRandAPI.xml
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/API/CuRandAPI.xml
@@ -13,10 +13,6 @@
         <LibraryVersion Name="V10" Platform="Windows" LibName="curand64_10.dll" />
         <LibraryVersion Name="V10" Platform="Linux" LibName="libcurand.so.10" />
         <LibraryVersion Name="V10" Platform="OSX" LibName="libcurand.10.dylib" />
-
-        <LibraryVersion Name="V11" Platform="Windows" LibName="curand64_11.dll" />
-        <LibraryVersion Name="V11" Platform="Linux" LibName="libcurand.so.11" />
-        <LibraryVersion Name="V11" Platform="OSX" LibName="libcurand.11.dylib" />
     </LibraryVersions>
 
     <Region Name="Creation">

--- a/Src/ILGPU.Algorithms/Runtime/Cuda/API/NvJpegAPI.xml
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/API/NvJpegAPI.xml
@@ -8,6 +8,9 @@
     <LibraryVersions>
         <LibraryVersion Name="V11" Platform="Windows" LibName="nvjpeg64_11.dll" />
         <LibraryVersion Name="V11" Platform="Linux" LibName="libnvjpeg.so.11" />
+
+        <LibraryVersion Name="V12" Platform="Windows" LibName="nvjpeg64_12.dll" />
+        <LibraryVersion Name="V12" Platform="Linux" LibName="libnvjpeg.so.12" />
     </LibraryVersions>
 
     <Region Name="Creation">


### PR DESCRIPTION
Updated the Cuda Library API versions for the Cuda v12 SDK.

Removed CuRand v11. It appears to have been added incorrectly, since the Cuda v12 SDK comes with `curand64_10.dll`.