### PR TITLE
Added support for LibDevice using Cuda Release v12.

### DIFF
--- a/Src/ILGPU/Backends/PTX/PTXBackend.cs
+++ b/Src/ILGPU/Backends/PTX/PTXBackend.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2018-2022 ILGPU Project
+//                        Copyright (c) 2018-2023 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: PTXBackend.cs
@@ -316,15 +316,20 @@ namespace ILGPU.Backends.PTX
             if (NvvmAPI == null || backendContext.Count == 0)
                 return;
 
+            // Determine the NVVM IR Version to use.
+            var result = NvvmAPI.GetIRVersion(out int majorIR, out _, out _, out _);
+            if (result != NvvmResult.NVVM_SUCCESS)
+                return;
+
             // Convert the methods in the context into NVVM.
             var methods = backendContext.GetEnumerator().AsEnumerable();
-            var nvvmModule = PTXLibDeviceNvvm.GenerateNvvm(methods);
+            var nvvmModule = PTXLibDeviceNvvm.GenerateNvvm(majorIR, methods);
 
             if (string.IsNullOrEmpty(nvvmModule))
                 return;
 
             // Create a new NVVM program.
-            var result = NvvmAPI.CreateProgram(out var program);
+            result = NvvmAPI.CreateProgram(out var program);
 
             try
             {

--- a/Src/ILGPU/Backends/PTX/PTXLibDeviceNvvm.tt
+++ b/Src/ILGPU/Backends/PTX/PTXLibDeviceNvvm.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2021-2022 ILGPU Project
+//                        Copyright (c) 2021-2023 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: PTXLibDeviceNvvm.tt/PTXLibDeviceNvvm.cs
@@ -36,6 +36,10 @@ namespace ILGPU.Backends.PTX
     /// </summary>
     internal static class PTXLibDeviceNvvm
     {
+        private const string irVersionFormat = @"
+            !nvvmir.version = !{{!0}}
+            !0 = !{{i32 {0}, i32 0}}";
+
         private const string prefix = @"
             target triple = ""nvptx64-unknown-cuda""
             target datalayout = ""e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v32:32:32-v64:64:64-v128:128:128-n16:32:64""";
@@ -63,9 +67,10 @@ namespace ILGPU.Backends.PTX
         /// <summary>
         /// Generates an NVVM module for the Cuda LibDevice functions (if any).
         /// </summary>
+        /// <param name="majorIR">The NVVM IR major version.</param>
         /// <param name="methods">The methods to check.</param>
         /// <returns>The NVVM module, or an empty string.</returns>
-        public static string GenerateNvvm(IEnumerable<Method> methods)
+        public static string GenerateNvvm(int majorIR, IEnumerable<Method> methods)
         {
             var builder = new StringBuilder();
             bool addPrefix = true;
@@ -77,6 +82,7 @@ namespace ILGPU.Backends.PTX
                 {
                     if (addPrefix)
                     {
+                        builder.AppendLine(string.Format(irVersionFormat, majorIR));
                         builder.AppendLine(prefix);
                         addPrefix = false;
                     }


### PR DESCRIPTION
#971 mentioned that LibDevice was not working with Cuda Release v12. Upon further investigation, the [v12 release notes](https://docs.nvidia.com/cuda/archive/12.0.0/cuda-toolkit-release-notes/index.html) state:

> NVVM IR Update: with CUDA 12.0 we are releasing [NVVM IR 2.0](https://docs.nvidia.com/cuda/nvvm-ir-spec/index.html) which is incompatible with NVVM IR 1.x accepted by the libNVVM compiler in prior CUDA toolkit releases. Users of the libNVVM compiler in CUDA 12.0 toolkit must generate NVVM IR 2.0.

Added `!nvvmir.version` to the NVVM IR that is generated. When previously omitted, this defaulted to v1.0.