### PR TITLE
Updated Cuda Library API versions for Linux.

### DIFF
--- a/Src/ILGPU.Algorithms/Runtime/Cuda/API/CuFFTAPI.xml
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/API/CuFFTAPI.xml
@@ -12,6 +12,9 @@
 
         <LibraryVersion Name="V11" Platform="Windows" LibName="cufft64_11.dll" />
         <LibraryVersion Name="V11" Platform="Linux" LibName="libcufft.so.11" />
+
+        <LibraryVersion Name="V12" Platform="Windows" LibName="cufft64_11.dll" />
+        <LibraryVersion Name="V12" Platform="Linux" LibName="libcufft.so.12" />
     </LibraryVersions>
 
     <Region Name="Basic Plans">

--- a/Src/ILGPU.Algorithms/Runtime/Cuda/API/CuFFTWAPI.xml
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/API/CuFFTWAPI.xml
@@ -11,6 +11,9 @@
 
         <LibraryVersion Name="V11" Platform="Windows" LibName="cufftw64_11.dll" />
         <LibraryVersion Name="V11" Platform="Linux" LibName="libcufftw.so.11" />
+
+        <LibraryVersion Name="V12" Platform="Windows" LibName="cufftw64_11.dll" />
+        <LibraryVersion Name="V12" Platform="Linux" LibName="libcufftw.so.12" />
     </LibraryVersions>
 
     <Region Name="Basic Interface - Complex - Double Precision">

--- a/Src/ILGPU.Algorithms/Runtime/Cuda/API/CuRandAPI.xml
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/API/CuRandAPI.xml
@@ -13,6 +13,12 @@
         <LibraryVersion Name="V10" Platform="Windows" LibName="curand64_10.dll" />
         <LibraryVersion Name="V10" Platform="Linux" LibName="libcurand.so.10" />
         <LibraryVersion Name="V10" Platform="OSX" LibName="libcurand.10.dylib" />
+
+        <LibraryVersion Name="V11" Platform="Windows" LibName="curand64_10.dll" />
+        <LibraryVersion Name="V11" Platform="Linux" LibName="libcurand.so.11" />
+
+        <LibraryVersion Name="V12" Platform="Windows" LibName="curand64_10.dll" />
+        <LibraryVersion Name="V12" Platform="Linux" LibName="libcurand.so.12" />
     </LibraryVersions>
 
     <Region Name="Creation">


### PR DESCRIPTION
Related to https://github.com/m4rs-mt/ILGPU/pull/974.

After feedback from v1.4.0-rc1, it appears that the Cuda SDK on Linux uses symlinks for the library files. This PR adds the missing versions. On Windows, we still use the unchanged filename.