### PR TITLE
Bump runners version to v2.305.0

### DIFF
--- a/.github/workflows/runners/config.yaml
+++ b/.github/workflows/runners/config.yaml
@@ -1,6 +1,6 @@
 config:
   ephemeral-github-runner:bootDiskSizeInGB: "100"
   ephemeral-github-runner:bootDiskType: gp2
-  ephemeral-github-runner:machineImage: gross-cuda-nvidia-ghrunner-23040-amd64
+  ephemeral-github-runner:machineImage: gross-cuda-nvidia-ghrunner-23050-amd64
   ephemeral-github-runner:machineType: g4dn.xlarge
   ephemeral-github-runner:runnersCount: "1"


### PR DESCRIPTION
HI @m4rs-mt @MoFtZ. This PR updates the machine image in the configuration file for the runners. This image is prebaked with latest Github Runner version, and also has deeplearning tools and libs installed as well out-of-the-box.

Working example: https://github.com/pavlovic-ivan/ILGPU-fork2/actions/runs/5277852716

Fixes: G-Research/gr-oss#416