### PR TITLE
Adjusted project language versions to 11.

### DIFF
--- a/Src/ILGPU.Algorithms/ILGPU.Algorithms.csproj
+++ b/Src/ILGPU.Algorithms/ILGPU.Algorithms.csproj
@@ -14,7 +14,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NeutralLanguage>en-US</NeutralLanguage>
     <!-- CAUTION: ILGPU supports a limited subset only - due to the .Net 4.7 backwards compatibility -->
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>11.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Src/ILGPU/ILGPU.csproj
+++ b/Src/ILGPU/ILGPU.csproj
@@ -14,7 +14,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NeutralLanguage>en-US</NeutralLanguage>
     <!-- CAUTION: ILGPU supports a limited subset only - due to the .Net 4.7 backwards compatibility -->
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>11.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
The PR is raising the C# language version to 11 for all project files which means that ILGPU won't compile with older language versions. However, we need to be cautious when using new language features as they should be backwards compatible.