### PR TITLE
Fixed generic static abstract methods

### DIFF
--- a/Src/ILGPU.Tests/Generic/TestBase.cs
+++ b/Src/ILGPU.Tests/Generic/TestBase.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2023 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: TestBase.cs
@@ -221,6 +221,29 @@ namespace ILGPU.Tests
             {
                 typeof(T1),
                 typeof(T2)
+            });
+            Execute(kernelMethod, dimension, arguments);
+        }
+
+        /// <summary>
+        /// Executes an implicitly linked kernel with the given arguments.
+        /// </summary>
+        /// <typeparam name="TIndex">The index type.</typeparam>
+        /// <param name="dimension">The dimension.</param>
+        /// <param name="arguments">The arguments.</param>
+        public void Execute<TIndex, T1, T2, T3>(
+            TIndex dimension,
+            params object[] arguments)
+            where TIndex : struct, IIndex
+            where T1 : unmanaged
+            where T2 : unmanaged
+            where T3 : unmanaged
+        {
+            var kernelMethod = KernelMethodAttribute.GetKernelMethod(new Type[]
+            {
+                typeof(T1),
+                typeof(T2),
+                typeof(T3)
             });
             Execute(kernelMethod, dimension, arguments);
         }

--- a/Src/ILGPU/Frontend/CodeGenerator/Calls.cs
+++ b/Src/ILGPU/Frontend/CodeGenerator/Calls.cs
@@ -174,6 +174,8 @@ namespace ILGPU.Frontend
                     ErrorMessages.NotSupportedVirtualMethodCall,
                     target.Name);
             }
+            if (sourceGenerics.Length > 0 && !actualTarget.IsGenericMethodDefinition)
+                actualTarget = actualTarget.GetGenericMethodDefinition();
             return sourceGenerics.Length > 0
                 ? actualTarget.MakeGenericMethod(sourceGenerics)
                 : actualTarget;


### PR DESCRIPTION
This PR fixes a compiler crash when calling generic static abstract interface methods:

```c#
static void TriggerIssue<TNumericType, TElementType, TRandom>(
    ArrayView<TNumericType> output,
    ArrayView<TRandom> providers,
    TNumericType lowerBound,
    TNumericType upperBound,
    TRandom random)
    where TNumericType : unmanaged, IVectorType<TNumericType, TElementType>
    where TElementType : unmanaged, INumber<TElementType>
    where TRandom : unmanaged, IRandomProvider<TRandom>
{
    var initPosition = TNumericType.GetRandom(
        ref random,
        lowerBound,
        upperBound); // This statement triggers an internal compiler error
    output[Grid.GlobalLinearIndex] = initPosition;
}
```

~~Note that this PR requires PR #1022 and PR #1023.~~