### PR TITLE
Random ranges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -291,6 +291,7 @@ Src/ILGPU.Algorithms/IL/ILContext.Generated.cs
 Src/ILGPU.Algorithms/PTX/PTXContext.Generated.cs
 Src/ILGPU.Algorithms/RadixSortOperations.cs
 Src/ILGPU.Algorithms/Vectors/VectorTypes.cs
+Src/ILGPU.Algorithms/Random/RandomRanges.cs
 Src/ILGPU.Algorithms/Runtime/Cuda/API/CuBlasNativeMethods.cs
 Src/ILGPU.Algorithms/Runtime/Cuda/API/CuFFTAPI.Generated.cs
 Src/ILGPU.Algorithms/Runtime/Cuda/API/CuFFTNativeMethods.cs

--- a/Src/ILGPU.Algorithms/ILGPU.Algorithms.csproj
+++ b/Src/ILGPU.Algorithms/ILGPU.Algorithms.csproj
@@ -114,6 +114,10 @@
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>RadixSortOperations.cs</LastGenOutput>
     </None>
+    <None Update="Random\RandomRanges.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>RandomRanges.cs</LastGenOutput>
+    </None>
     <None Update="Runtime\Cuda\API\CuFFTAPI.Generated.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>CuFFTAPI.Generated.cs</LastGenOutput>
@@ -251,6 +255,11 @@
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
       <DependentUpon>RadixSortOperations.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Random\RandomRanges.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>RandomRanges.tt</DependentUpon>
     </Compile>
     <Compile Update="Resources\ErrorMessages.Designer.cs">
       <DesignTime>True</DesignTime>

--- a/Src/ILGPU.Algorithms/Random/RandomRanges.tt
+++ b/Src/ILGPU.Algorithms/Random/RandomRanges.tt
@@ -1,0 +1,393 @@
+// ---------------------------------------------------------------------------------------
+//                                   ILGPU Algorithms
+//                           Copyright (c) 2023 ILGPU Project
+//                                    www.ilgpu.net
+//
+// File: RandomRanges.tt/RandomRanges.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details.
+// ---------------------------------------------------------------------------------------
+
+<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ include file="../TypeInformation.ttinclude"#>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ output extension=".cs" #>
+<#
+var rngTypes = SignedIntTypes.Concat(FloatTypes);
+var functionMapping = new Dictionary<string, string>()
+    {
+        { "Int8",  "(byte)randomProvider.Next(0, byte.MaxValue)" },
+        { "Int16", "(short)randomProvider.Next(0, short.MaxValue)" },
+        { "Int32", "randomProvider.Next()" },
+        { "Int64", "randomProvider.NextLong()" },
+
+        { "Half", "(Half)randomProvider.NextFloat()" },
+        { "Float", "randomProvider.NextFloat()" },
+        { "Double", "randomProvider.NextDouble()" },
+    };
+#>
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+#pragma warning disable CA1000 // No static members on generic types
+#pragma warning disable IDE0004 // Cast is redundant
+
+#if NET7_0_OR_GREATER
+
+namespace ILGPU.Algorithms.Random
+{
+    /// <summary>
+    /// A generic random number range operating on a generic type
+    /// <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The element type to operate on.</typeparam>
+    public interface IBasicRandomRange<out T>
+        where T : struct
+    {
+        /// <summary>
+        /// Returns the min value of this range (inclusive).
+        /// </summary>
+        T MinValue { get; }
+
+        /// <summary>
+        /// Returns the max value of this range (exclusive).
+        /// </summary>
+        T MaxValue { get; }
+    }
+
+    /// <summary>
+    /// A generic random number range operating on a generic type
+    /// <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The element type to operate on.</typeparam>
+    public interface IRandomRange<out T> : IBasicRandomRange<T>
+        where T : struct
+    {
+        /// <summary>
+        /// Generates a new random value by taking min and max value ranges into account.
+        /// </summary>
+        /// <typeparam name="TRandomProvider">The random provider type.</typeparam>
+        /// <param name="randomProvider">The random provider instance.</param>
+        /// <returns>The retrieved random value.</returns>
+        /// <remarks>
+        /// CAUTION: This function implementation is meant to be thread safe in general to
+        /// support massively parallel evaluations on CPU and GPU.
+        /// </remarks>
+        [SuppressMessage(
+            "Naming",
+            "CA1716:Identifiers should not match keywords",
+            Justification = "Like the method System.Random.Next()")]
+        T Next<TRandomProvider>(ref TRandomProvider randomProvider)
+            where TRandomProvider : struct, IRandomProvider;
+    }
+
+    /// <summary>
+    /// A generic random number range provider operating on a generic type
+    /// <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The element type to operate on.</typeparam>
+    /// <remarks>
+    /// CAUTION: A type implementing this interface is meant to be thread safe in general
+    /// to support massively parallel evaluations on CPU and GPU.
+    /// </remarks>
+    public interface IRandomRangeProvider<T>
+        where T : struct
+    {
+        /// <summary>
+        /// Generates a new random value by taking min and max value ranges into account.
+        /// </summary>
+        /// <returns>The retrieved random value.</returns>
+        [SuppressMessage(
+            "Naming",
+            "CA1716:Identifiers should not match keywords",
+            Justification = "Like the method System.Random.Next()")]
+        T Next();
+    }
+
+    /// <summary>
+    /// A generic random number range provider operating on a generic type
+    /// <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="TSelf">The type implementing this interface.</typeparam>
+    /// <typeparam name="T">The element type to operate on.</typeparam>
+    /// <remarks>
+    /// CAUTION: A type implementing this interface is meant to be thread safe in general
+    /// to support massively parallel evaluations on CPU and GPU.
+    /// </remarks>
+    public interface IRandomRangeProvider<TSelf, T> :
+        IRandomRangeProvider<T>, IBasicRandomRange<T>
+        where TSelf : struct, IRandomRangeProvider<TSelf, T>
+        where T : unmanaged
+    {
+        /// <summary>
+        /// Instantiates a new random range using the given random provider.
+        /// </summary>
+        /// <param name="random">The parent RNG instance.</param>
+        /// <param name="minValue">The minimum value (inclusive).</param>
+        /// <param name="maxValue">The maximum value (exclusive).</param>
+        static abstract TSelf Create(System.Random random, T minValue, T maxValue);
+
+        /// <summary>
+        /// Instantiates a new random range using the given random provider.
+        /// </summary>
+        /// <param name="random">The parent RNG instance.</param>
+        /// <param name="minValue">The minimum value (inclusive).</param>
+        /// <param name="maxValue">The maximum value (exclusive).</param>
+        static abstract TSelf Create<TOtherProvider>(
+            ref TOtherProvider random,
+            T minValue,
+            T maxValue)
+            where TOtherProvider : struct, IRandomProvider<TOtherProvider>;
+
+        /// <summary>
+        /// Creates a new random range vector provider compatible with this provider.
+        /// </summary>
+        RandomRangeVectorProvider<T, TSelf> CreateVectorProvider();
+    }
+
+    /// <summary>
+    /// Represents a default RNG range for vectors types returning specified value
+    /// intervals for type Vector.
+    /// </summary>
+    /// <typeparam name="T">The vector element type.</typeparam>
+    /// <typeparam name="TRangeProvider">The underlying range provider.</typeparam>
+    public struct RandomRangeVectorProvider<T, TRangeProvider> :
+        IRandomRangeProvider<Vector<T>>,
+        IRandomRangeProvider<T>,
+        IBasicRandomRange<T>
+        where T : unmanaged
+        where TRangeProvider : struct, IRandomRangeProvider<TRangeProvider, T>
+    {
+        private TRangeProvider rangeProvider;
+
+        /// <summary>
+        /// Instantiates a new random range provider using the given random provider.
+        /// </summary>
+        /// <param name="provider">The RNG provider to use.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public RandomRangeVectorProvider(TRangeProvider provider)
+        {
+            rangeProvider = provider;
+        }
+
+        /// <summary>
+        /// Returns the min value of this range (inclusive).
+        /// </summary>
+        public readonly T MinValue => rangeProvider.MinValue;
+
+        /// <summary>
+        /// Returns the max value of this range (exclusive).
+        /// </summary>
+        public readonly T MaxValue => rangeProvider.MaxValue;
+
+        /// <summary>
+        /// Generates a new random value using the given min and max values.
+        /// </summary>
+        [SuppressMessage(
+            "Naming",
+            "CA1716:Identifiers should not match keywords",
+            Justification = "Like the method System.Random.Next()")]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Vector<T> Next() =>
+            RandomExtensions.NextVector<T, TRangeProvider>(ref rangeProvider);
+
+        /// <summary>
+        /// Generates a new random value using the given min and max values.
+        /// </summary>
+        [SuppressMessage(
+            "Naming",
+            "CA1716:Identifiers should not match keywords",
+            Justification = "Like the method System.Random.Next()")]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        T IRandomRangeProvider<T>.Next() => rangeProvider.Next();
+    }
+
+    /// <summary>
+    /// A container class holding specialized random range instances while providing
+    /// specialized extension methods for different RNG providers.
+    /// </summary>
+    public static class RandomRanges
+    {
+<#  foreach (var type in rngTypes) { #>
+<#      var providerName = $"RandomRange{type.Name}Provider"; #>
+        /// <summary>
+        /// Represents a default RNG range for type <#= type.Name #> returning
+        /// specified value intervals for type <#= type.Name #> (in analogy to calling
+        /// the appropriate NextXYZ method on the random provider given using min and
+        /// max values).
+        /// </summary>
+        /// <param name="MinValue">The minimum value (inclusive).</param>
+        /// <param name="MaxValue">The maximum values (exclusive).</param>
+        public readonly record struct RandomRange<#= type.Name #>(
+            <#= type.Type #> MinValue,
+            <#= type.Type #> MaxValue) :
+            IRandomRange<<#= type.Type #>>
+        {
+            /// <summary>
+            /// Instantiates a new random range provider using the given random provider.
+            /// </summary>
+            /// <param name="random">The parent RNG instance.</param>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public <#= providerName #><TRandomProvider>
+                CreateProvider<TRandomProvider>(System.Random random)
+                where TRandomProvider : struct, IRandomProvider<TRandomProvider> =>
+                <#= providerName #><TRandomProvider>.Create(
+                    random,
+                    MinValue,
+                    MaxValue);
+
+            /// <summary>
+            /// Instantiates a new random range provider using the given random provider.
+            /// </summary>
+            /// <param name="random">The parent RNG instance.</param>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public <#= providerName #><TRandomProvider>
+                CreateProvider<TRandomProvider>(ref TRandomProvider random)
+                where TRandomProvider : struct, IRandomProvider<TRandomProvider> =>
+                <#= providerName #><TRandomProvider>.Create(
+                    ref random,
+                    MinValue,
+                    MaxValue);
+
+            /// <summary>
+            /// Instantiates a new random range provider using the given random provider.
+            /// </summary>
+            /// <param name="random">The parent RNG instance.</param>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public <#= providerName #><TRandomProvider>
+                CreateProvider<TRandomProvider, TOtherRandomProvider>(
+                ref TOtherRandomProvider random)
+                where TRandomProvider : struct, IRandomProvider<TRandomProvider>
+                where TOtherRandomProvider :
+                    struct, IRandomProvider<TOtherRandomProvider> =>
+                <#= providerName #><TRandomProvider>.Create(
+                    ref random,
+                    MinValue,
+                    MaxValue);
+
+            /// <summary>
+            /// Generates a new random value using the given min and max values.
+            /// </summary>
+            [SuppressMessage(
+                "Naming",
+                "CA1716:Identifiers should not match keywords",
+                Justification = "Like the method System.Random.Next()")]
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public <#= type.Type #> Next<TRandomProvider>(
+                ref TRandomProvider randomProvider)
+                where TRandomProvider : struct, IRandomProvider =>
+                (<#= type.Type #>)RandomExtensions.Next(
+                    ref randomProvider,
+                    MinValue,
+                    MaxValue);
+        }
+
+        /// <summary>
+        /// Represents a default RNG range for type <#= type.Name #> returning
+        /// specified value intervals for type <#= type.Name #> (in analogy to calling
+        /// the appropriate NextXYZ method on the random provider given using min and
+        /// max values).
+        /// </summary>
+        /// <typeparam name="TRandomProvider">The underlying random provider.</typeparam>
+        public struct <#= providerName #><TRandomProvider> :
+            IRandomRangeProvider<
+                <#= providerName #><TRandomProvider>,
+                <#= type.Type #>>
+            where TRandomProvider : struct, IRandomProvider<TRandomProvider>
+        {
+            private TRandomProvider randomProvider;
+
+            /// <summary>
+            /// Instantiates a new random range provider using the given random provider.
+            /// </summary>
+            /// <param name="random">The RNG instance to use.</param>
+            /// <param name="minValue">The minimum value (inclusive).</param>
+            /// <param name="maxValue">The maximum value (exclusive).</param>
+            public <#= providerName #>(
+                TRandomProvider random,
+                <#= type.Type #> minValue,
+                <#= type.Type #> maxValue)
+            {
+                randomProvider = random;
+                MinValue = minValue;
+                MaxValue = maxValue;
+            }
+
+            /// <summary>
+            /// Returns the min value of this range (inclusive).
+            /// </summary>
+            public <#= type.Type #> MinValue { get; }
+
+            /// <summary>
+            /// Returns the max value of this range (exclusive).
+            /// </summary>
+            public <#= type.Type #> MaxValue { get; }
+
+            /// <summary>
+            /// Instantiates a new random range provider using the given random provider.
+            /// </summary>
+            /// <param name="random">The parent RNG instance.</param>
+            /// <param name="minValue">The minimum value (inclusive).</param>
+            /// <param name="maxValue">The maximum value (exclusive).</param>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static <#= providerName #><TRandomProvider>
+                Create(
+                System.Random random,
+                <#= type.Type #> minValue,
+                <#= type.Type #> maxValue) =>
+                new(default(TRandomProvider).CreateProvider(random), minValue, maxValue);
+
+            /// <summary>
+            /// Instantiates a new random range provider using the given random provider.
+            /// </summary>
+            /// <param name="random">The parent RNG instance.</param>
+            /// <param name="minValue">The minimum value (inclusive).</param>
+            /// <param name="maxValue">The maximum value (exclusive).</param>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static <#= providerName #><TRandomProvider>
+                Create<TOtherProvider>(
+                ref TOtherProvider random,
+                <#= type.Type #> minValue,
+                <#= type.Type #> maxValue)
+                where TOtherProvider : struct, IRandomProvider<TOtherProvider> =>
+                new(
+                    default(TRandomProvider).CreateProvider(ref random),
+                    minValue,
+                    maxValue);
+
+            /// <summary>
+            /// Creates a new random range vector provider compatible with this provider.
+            /// </summary>
+            public readonly RandomRangeVectorProvider<
+                <#= type.Type #>,
+                <#= providerName #><TRandomProvider>> CreateVectorProvider() =>
+                new(this);
+
+            /// <summary>
+            /// Generates a new random value using the given min and max values.
+            /// </summary>
+            [SuppressMessage(
+                "Naming",
+                "CA1716:Identifiers should not match keywords",
+                Justification = "Like the method System.Random.Next()")]
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public <#= type.Type #> Next() =>
+                (<#= type.Type #>)RandomExtensions.Next(
+                    ref randomProvider,
+                    MinValue,
+                    MaxValue);
+        }
+
+<#  } #>
+    }
+}
+
+#endif
+
+#pragma warning restore IDE0004
+#pragma warning restore CA1000

--- a/Src/ILGPU.Algorithms/Random/XorShift128.cs
+++ b/Src/ILGPU.Algorithms/Random/XorShift128.cs
@@ -112,7 +112,7 @@ namespace ILGPU.Algorithms.Random
         /// Generates a random ulong in [0..ulong.MaxValue].
         /// </summary>
         /// <returns>A random ulong in [0..ulong.MaxValue].</returns>
-        public ulong NextULong() => SeperateUInt(NextUInt());
+        public ulong NextULong() => SeparateUInt(NextUInt());
 
         /// <inheritdoc cref="IRandomProvider.Next"/>
         public int Next() => ToInt(NextUInt());

--- a/Src/ILGPU.Algorithms/Random/XorShift32.cs
+++ b/Src/ILGPU.Algorithms/Random/XorShift32.cs
@@ -83,7 +83,7 @@ namespace ILGPU.Algorithms.Random
         /// Generates a random ulong in [0..ulong.MaxValue].
         /// </summary>
         /// <returns>A random ulong in [0..ulong.MaxValue].</returns>
-        public ulong NextULong() => SeperateUInt(NextUInt());
+        public ulong NextULong() => SeparateUInt(NextUInt());
 
         /// <inheritdoc cref="IRandomProvider.Next"/>
         public int Next() => ToInt(NextUInt());


### PR DESCRIPTION
This PR adds new `IRandomRange` and `IRandomRangeProvider` interfaces to define common methods to combine random number generators with `[min,.. max)` value ranges. It adds a text template to generate `RandomRangeXYZ` types representing tuples of `min` and `max` values with utility RNG functions. The template also generates provider implementations combining the tuples with actual RNG types like `RandomRangeXYZProvider`.

This PR depends on PRs ~~#1033, #1037, and #1057.~~