### PR TITLE
Ignore unsucessful loads of debug symbols

### DIFF
--- a/Src/ILGPU/Frontend/DebugInformation/DebugInformationManager.cs
+++ b/Src/ILGPU/Frontend/DebugInformation/DebugInformationManager.cs
@@ -356,6 +356,11 @@ namespace ILGPU.Frontend.DebugInformation
                 {
                     return loader.Load(assembly, out assemblyDebugInformation);
                 }
+                catch (BadImageFormatException)
+                {
+                    // Ignore unsuccessful loads here
+                    return false;
+                }
                 finally
                 {
                     cacheLock.ExitWriteLock();


### PR DESCRIPTION
This PR adds an exception handler to our metadata loader in order to avoid throwing load exceptions of unsupported or incompatible image types. These cases can occur on the latest MacOS Ventura platform in combination with Net6 and Net7 being installed while using Net7 to compile for Net6 and Net6 to execute ILGPU programs.