### PR TITLE
Added a warp-wide and group-wide Radixsort implementation.

### DIFF
--- a/Src/ILGPU.Algorithms.Tests/RadixSortExtensionTests.tt
+++ b/Src/ILGPU.Algorithms.Tests/RadixSortExtensionTests.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                   ILGPU Algorithms
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2023 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: RadixSortExtensionTests.tt/RadixSortExtensionTests.cs
@@ -20,7 +20,7 @@ using ILGPU.Tests;
 using Xunit;
 using Xunit.Abstractions;
 
-#pragma warning disable xUnit1026 
+#pragma warning disable xUnit1026
 
 namespace ILGPU.Algorithms.Tests
 {
@@ -262,7 +262,7 @@ namespace ILGPU.Algorithms.Tests
             }
 #>
             input.CopyFromCPU(stream, sequence);
-            
+
             using var radixSortProvider =
                 Accelerator.CreateRadixSortProvider<T, Stride1D.Dense, TRadixSortOp>(
                 length);
@@ -303,7 +303,7 @@ namespace ILGPU.Algorithms.Tests
             }
 #>
             input.CopyFromCPU(stream, sequence);
-            
+
             using var radixSortProvider =
                 Accelerator.CreateRadixSortProvider<T, Stride1D.Dense, TRadixSortOp>(
                 length);
@@ -430,5 +430,275 @@ namespace ILGPU.Algorithms.Tests
 
             Verify(input.View, sequence);
         }
+    }
+
+    partial class WarpExtensionTests
+    {
+        public static TheoryData<object, object, object, object, object, object>
+            AscendingTestData => RadixSortExtensionTests.AscendingTestData;
+
+        public static TheoryData<object, object, object, object, object, object>
+            DescendingTestData => RadixSortExtensionTests.DescendingTestData;
+
+        internal static void WarpWideRadixSort<T, TRadixSortOperation>(
+            ArrayView1D<T, Stride1D.Dense> input)
+            where T : unmanaged
+            where TRadixSortOperation : struct, IRadixSortOperation<T>
+        {
+            var element = input[Warp.LaneIdx];
+            input[Warp.LaneIdx] =
+                WarpExtensions.RadixSort<T, TRadixSortOperation>(element);
+        }
+
+<#
+
+        foreach (var sorting in sortings) {
+#>
+        [Theory]
+        [MemberData(nameof(<#= sorting.Name #>TestData))]
+        [KernelMethod(nameof(WarpWideRadixSort))]
+        public void WarpWideRadixWorstCase<#= sorting.Name #><
+            T,
+            TRadixSortOp,
+            TSequencer>(
+            T _,
+            TRadixSortOp radixSortOp,
+            TSequencer sequencer,
+            T start,
+            T stepSize,
+            int length)
+            where T : unmanaged
+            where TRadixSortOp : unmanaged, IRadixSortOperation<T>
+            where TSequencer : struct, ITestSequencer<T>
+        {
+            using var input = Accelerator.Allocate1D<T>(Accelerator.WarpSize);
+            using var stream = Accelerator.CreateStream();
+
+<#
+            if (sorting.IsAscendingSorting) {
+#>
+            var sequence = sequencer.ComputeInvertedSequence(
+                start,
+                stepSize,
+                Accelerator.WarpSize);
+            var expected = sequencer.ComputeSequence(
+                start,
+                stepSize,
+                Accelerator.WarpSize);
+<#
+            } else {
+#>
+            var sequence = sequencer.ComputeSequence(
+                start,
+                stepSize,
+                Accelerator.WarpSize);
+            var expected = sequencer.ComputeInvertedSequence(
+                start,
+                stepSize,
+                Accelerator.WarpSize);
+<#
+            }
+#>
+            input.CopyFromCPU(stream, sequence);
+
+            Execute<KernelConfig, T, TRadixSortOp>(
+                (1, Accelerator.WarpSize),
+                new KernelSpecialization(Accelerator.WarpSize, 1),
+                input.View);
+            stream.Synchronize();
+
+            Verify(input.View, expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(<#= sorting.Name #>TestData))]
+        [KernelMethod(nameof(WarpWideRadixSort))]
+        public void WarpWideRadixBestCase<#= sorting.Name #><T, TRadixSortOp, TSequencer>(
+            T _,
+            TRadixSortOp radixSortOp,
+            TSequencer sequencer,
+            T start,
+            T stepSize,
+            int length)
+            where T : unmanaged
+            where TRadixSortOp : unmanaged, IRadixSortOperation<T>
+            where TSequencer : struct, ITestSequencer<T>
+        {
+            using var input = Accelerator.Allocate1D<T>(Accelerator.WarpSize);
+            using var stream = Accelerator.CreateStream();
+
+<#
+            if (sorting.IsDescendingSorting) {
+#>
+            var sequence = sequencer.ComputeInvertedSequence(
+                start,
+                stepSize,
+                Accelerator.WarpSize);
+<#
+            } else {
+#>
+            var sequence = sequencer.ComputeSequence(
+                start,
+                stepSize,
+                Accelerator.WarpSize);
+<#
+            }
+#>
+            input.CopyFromCPU(stream, sequence);
+
+            Execute<KernelConfig, T, TRadixSortOp>(
+                (1, Accelerator.WarpSize),
+                new KernelSpecialization(Accelerator.WarpSize, 1),
+                input.View);
+            stream.Synchronize();
+
+            Verify(input.View, sequence);
+        }
+<#
+        }
+#>
+    }
+
+    partial class GroupExtensionTests
+    {
+        public static TheoryData<object, object, object, object, object, object>
+            AscendingTestData => RadixSortExtensionTests.AscendingTestData;
+
+        public static TheoryData<object, object, object, object, object, object>
+            DescendingTestData => RadixSortExtensionTests.DescendingTestData;
+
+        internal static void GroupWideRadixSort<T, TRadixSortOperation>(
+            ArrayView1D<T, Stride1D.Dense> input)
+            where T : unmanaged
+            where TRadixSortOperation : struct, IRadixSortOperation<T>
+        {
+            var dynamicMemory = ILGPU.SharedMemory.GetDynamic<byte>();
+            var element = input[Group.IdxX];
+
+            input[Group.IdxX] = GroupExtensions.RadixSort<T, TRadixSortOperation>(
+                element,
+                dynamicMemory);
+        }
+
+<#
+
+        foreach (var sorting in sortings) {
+#>
+        [Theory]
+        [MemberData(nameof(<#= sorting.Name #>TestData))]
+        [KernelMethod(nameof(GroupWideRadixSort))]
+        public void GroupWideRadixWorstCase<#= sorting.Name #><
+            T,
+            TRadixSortOp,
+            TSequencer>(
+            T _,
+            TRadixSortOp radixSortOp,
+            TSequencer sequencer,
+            T start,
+            T stepSize,
+            int length)
+            where T : unmanaged
+            where TRadixSortOp : unmanaged, IRadixSortOperation<T>
+            where TSequencer : struct, ITestSequencer<T>
+        {
+            using var input =
+                Accelerator.Allocate1D<T>(Accelerator.MaxNumThreadsPerGroup);
+            using var stream = Accelerator.CreateStream();
+
+<#
+            if (sorting.IsAscendingSorting) {
+#>
+            var sequence = sequencer.ComputeInvertedSequence(
+                start,
+                stepSize,
+                Accelerator.MaxNumThreadsPerGroup);
+            var expected = sequencer.ComputeSequence(
+                start,
+                stepSize,
+                Accelerator.MaxNumThreadsPerGroup);
+<#
+            } else {
+#>
+            var sequence = sequencer.ComputeSequence(
+                start,
+                stepSize,
+                Accelerator.MaxNumThreadsPerGroup);
+            var expected = sequencer.ComputeInvertedSequence(
+                start,
+                stepSize,
+                Accelerator.MaxNumThreadsPerGroup);
+<#
+            }
+#>
+            input.CopyFromCPU(stream, sequence);
+            var arrayLength = Accelerator.ComputeGroupWideRadixSortSharedMemorySize<T>(
+                Accelerator.MaxNumThreadsPerGroup);
+            var config = SharedMemoryConfig.RequestDynamic<byte>(arrayLength);
+
+
+            Execute<KernelConfig, T, TRadixSortOp>(
+                (1, Accelerator.MaxNumThreadsPerGroup, config),
+                new KernelSpecialization(Accelerator.MaxNumThreadsPerGroup, 1),
+                input.View);
+            stream.Synchronize();
+
+            Verify(input.View, expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(<#= sorting.Name #>TestData))]
+        [KernelMethod(nameof(GroupWideRadixSort))]
+        public void GroupWideRadixBestCase<#= sorting.Name #><
+            T,
+            TRadixSortOp,
+            TSequencer>(
+            T _,
+            TRadixSortOp radixSortOp,
+            TSequencer sequencer,
+            T start,
+            T stepSize,
+            int length)
+            where T : unmanaged
+            where TRadixSortOp : unmanaged, IRadixSortOperation<T>
+            where TSequencer : struct, ITestSequencer<T>
+        {
+            using var input =
+                Accelerator.Allocate1D<T>(Accelerator.MaxNumThreadsPerGroup);
+            using var stream = Accelerator.CreateStream();
+
+<#
+            if (sorting.IsDescendingSorting) {
+#>
+            var sequence = sequencer.ComputeInvertedSequence(
+                start,
+                stepSize,
+                Accelerator.MaxNumThreadsPerGroup);
+<#
+            } else {
+#>
+            var sequence = sequencer.ComputeSequence(
+                start,
+                stepSize,
+                Accelerator.MaxNumThreadsPerGroup);
+<#
+            }
+#>
+            input.CopyFromCPU(stream, sequence);
+            var arrayLength = Accelerator.ComputeGroupWideRadixSortSharedMemorySize<T>(
+                Accelerator.MaxNumThreadsPerGroup);
+            var config = SharedMemoryConfig.RequestDynamic<byte>(arrayLength);
+
+            Execute<KernelConfig, T, TRadixSortOp>(
+                (1, Accelerator.MaxNumThreadsPerGroup, config),
+                new KernelSpecialization(Accelerator.MaxNumThreadsPerGroup, 1),
+                input.View);
+            stream.Synchronize();
+
+            Verify(input.View, sequence);
+        }
+<#
+        }
+#>
+
     }
 }

--- a/Src/ILGPU.Algorithms/RadixSortExtensions.cs
+++ b/Src/ILGPU.Algorithms/RadixSortExtensions.cs
@@ -446,6 +446,25 @@ namespace ILGPU.Algorithms
             return numGroups * unrollFactor * 2 + numIntTElements + tempScanMemory;
         }
 
+        /// <summary>
+        /// Computes the amount of shared memory in bytes that is needed to perform a
+        /// group-wide radix sorting.
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <param name="accelerator">The accelerator.</param>
+        /// <param name="groupSize">The size of the group.</param>
+        /// <returns>The size of shared memory in bytes.</returns>
+        public static int ComputeGroupWideRadixSortSharedMemorySize<T>(
+            this Accelerator accelerator,
+            int groupSize)
+            where T : unmanaged
+        {
+            var arrayLength = Interop.SizeOf<T>() * groupSize;
+            var keyLength = accelerator.WarpSize * sizeof(int);
+
+            return arrayLength + arrayLength % sizeof(int) + 2 * keyLength + sizeof(int);
+        }
+
         #endregion
 
         #region Nested Types

--- a/Src/ILGPU/IR/Transformations/LoopUnrolling.cs
+++ b/Src/ILGPU/IR/Transformations/LoopUnrolling.cs
@@ -43,7 +43,7 @@ namespace ILGPU.IR.Transformations
         /// <summary>
         /// Represents the default maximum unroll factor.
         /// </summary>
-        public const int DefaultMaxUnrollFactor = 32;
+        public const int DefaultMaxUnrollFactor = 64;
 
         #endregion
 


### PR DESCRIPTION
In this PR, we added a warp-wide and a group-wide radix sort implementation.
These implementations are specialized for their usage in warp-wide or group-wide algorithms.

The adaption of the unroll factor is needed to handle a loop unrolling of 64bit-types sortings. 

~~This PR depends on #1083 and #1103.~~