### PR TITLE
Refined PTX argument mapping and analyses

### DIFF
--- a/Src/ILGPU/Backends/EntryPoints/ArgumentMapper.cs
+++ b/Src/ILGPU/Backends/EntryPoints/ArgumentMapper.cs
@@ -36,11 +36,6 @@ namespace ILGPU.Backends.EntryPoints
         #region Constants
 
         /// <summary>
-        /// The internal prefix name for all runtime fields.
-        /// </summary>
-        private const string FieldPrefixName = "Field";
-
-        /// <summary>
         /// The intrinsic kernel length parameter field name.
         /// </summary>
         private const string KernelLengthField = "KernelLength";
@@ -520,7 +515,7 @@ namespace ILGPU.Backends.EntryPoints
         private static string GetFieldName(int index)
         {
             Debug.Assert(index >= 0, "Invalid field index");
-            return FieldPrefixName + index;
+            return StructureType.GetFieldName(index);
         }
 
         #endregion

--- a/Src/ILGPU/Backends/PTX/Analyses/DefaultPTXBlockSchedule.cs
+++ b/Src/ILGPU/Backends/PTX/Analyses/DefaultPTXBlockSchedule.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2020-2021 ILGPU Project
+//                        Copyright (c) 2020-2023 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: DefaultPTXBlockSchedule.cs
@@ -18,7 +18,7 @@ namespace ILGPU.Backends.PTX.Analyses
     /// <summary>
     /// Represents a default PTX-specific block schedule.
     /// </summary>
-    public sealed class DefaultPTXBlockSchedule :
+    sealed class DefaultPTXBlockSchedule :
         PTXBlockSchedule<ReversePostOrder, Forwards>
     {
         #region Instance
@@ -53,7 +53,7 @@ namespace ILGPU.Backends.PTX.Analyses
         #endregion
     }
 
-    public partial class PTXBlockScheduleExtensions
+    partial class PTXBlockScheduleExtensions
     {
         /// <summary>
         /// Creates a new default block schedule using the given blocks.

--- a/Src/ILGPU/Backends/PTX/Analyses/OptimizedPTXBlockSchedule.cs
+++ b/Src/ILGPU/Backends/PTX/Analyses/OptimizedPTXBlockSchedule.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2020-2021 ILGPU Project
+//                        Copyright (c) 2020-2023 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: OptimizedPTXBlockSchedule.cs
@@ -24,41 +24,11 @@ namespace ILGPU.Backends.PTX.Analyses
     /// </summary>
     /// <typeparam name="TOrder">The current order.</typeparam>
     /// <typeparam name="TDirection">The control-flow direction.</typeparam>
-    public sealed class OptimizedPTXBlockSchedule<TOrder, TDirection> :
+    class OptimizedPTXBlockSchedule<TOrder, TDirection> :
         PTXBlockSchedule<TOrder, TDirection>
         where TOrder : struct, ITraversalOrder
         where TDirection : struct, IControlFlowDirection
     {
-        #region Nested Types
-
-        /// <summary>
-        /// A specific successor provider that inverts the successors of all
-        /// <see cref="IfBranch"/> terminators.
-        /// </summary>
-        private readonly struct SuccessorProvider :
-            ITraversalSuccessorsProvider<Forwards>
-        {
-            /// <summary>
-            /// Returns all successors in the default order except for
-            /// <see cref="IfBranch"/> terminators. The successors of these terminators
-            /// will be reversed to invert all if branch targets.
-            /// </summary>
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public readonly ReadOnlySpan<BasicBlock> GetSuccessors(BasicBlock basicBlock)
-            {
-                var successors = basicBlock.Successors;
-                if (basicBlock.Terminator is IfBranch ifBranch && ifBranch.IsInverted)
-                {
-                    var tempList = successors.ToInlineList();
-                    tempList.Reverse();
-                    successors = tempList;
-                }
-                return successors;
-            }
-        }
-
-        #endregion
-
         #region Instance
 
         /// <summary>
@@ -135,7 +105,7 @@ namespace ILGPU.Backends.PTX.Analyses
         #endregion
     }
 
-    public partial class PTXBlockScheduleExtensions
+    partial class PTXBlockScheduleExtensions
     {
         #region Nested Types
 
@@ -143,16 +113,14 @@ namespace ILGPU.Backends.PTX.Analyses
         /// A specific successor provider that inverts the successors of all
         /// <see cref="IfBranch"/> terminators.
         /// </summary>
-        private readonly struct SuccessorProvider :
-            ITraversalSuccessorsProvider<Forwards>
+        private readonly struct SuccessorProvider : ITraversalSuccessorsProvider<Forwards>
         {
             /// <summary>
             /// Returns all successors in the default order except for
             /// <see cref="IfBranch"/> terminators. The successors of these terminators
             /// will be reversed to invert all if branch targets.
             /// </summary>
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public readonly ReadOnlySpan<BasicBlock> GetSuccessors(BasicBlock basicBlock)
+            public ReadOnlySpan<BasicBlock> GetSuccessors(BasicBlock basicBlock)
             {
                 var successors = basicBlock.Successors;
                 if (basicBlock.Terminator is IfBranch ifBranch && ifBranch.IsInverted)

--- a/Src/ILGPU/Backends/PTX/Analyses/PTXBlockSchedule.cs
+++ b/Src/ILGPU/Backends/PTX/Analyses/PTXBlockSchedule.cs
@@ -19,7 +19,7 @@ namespace ILGPU.Backends.PTX.Analyses
     /// <summary>
     /// Represents a PTX-specific block schedule.
     /// </summary>
-    public abstract class PTXBlockSchedule
+    abstract class PTXBlockSchedule
     {
         #region Instance
 
@@ -96,7 +96,7 @@ namespace ILGPU.Backends.PTX.Analyses
     /// </summary>
     /// <typeparam name="TOrder">The current order.</typeparam>
     /// <typeparam name="TDirection">The control-flow direction.</typeparam>
-    public abstract class PTXBlockSchedule<TOrder, TDirection> : PTXBlockSchedule
+    abstract class PTXBlockSchedule<TOrder, TDirection> : PTXBlockSchedule
         where TOrder : struct, ITraversalOrder
         where TDirection : struct, IControlFlowDirection
     {
@@ -140,5 +140,5 @@ namespace ILGPU.Backends.PTX.Analyses
     /// <summary>
     /// Extensions methods for the <see cref="PTXBlockSchedule"/> class.
     /// </summary>
-    public static partial class PTXBlockScheduleExtensions { }
+    static partial class PTXBlockScheduleExtensions { }
 }

--- a/Src/ILGPU/Backends/PTX/PTXArgumentMapper.cs
+++ b/Src/ILGPU/Backends/PTX/PTXArgumentMapper.cs
@@ -22,7 +22,7 @@ namespace ILGPU.Backends.PTX
     /// Constructs mappings for PTX kernels.
     /// </summary>
     /// <remarks>Members of this class are not thread safe.</remarks>
-    public sealed class PTXArgumentMapper : ViewArgumentMapper
+    public class PTXArgumentMapper : ViewArgumentMapper
     {
         #region Nested Types
 

--- a/Src/ILGPU/Backends/PTX/PTXCodeGenerator.cs
+++ b/Src/ILGPU/Backends/PTX/PTXCodeGenerator.cs
@@ -418,7 +418,7 @@ namespace ILGPU.Backends.PTX
         /// <summary>
         /// Returns all blocks in an appropriate schedule.
         /// </summary>
-        public PTXBlockSchedule Schedule { get; }
+        internal PTXBlockSchedule Schedule { get; }
 
         #endregion
 

--- a/Src/ILGPU/Backends/PTX/Transformations/PTXBlockScheduling.cs
+++ b/Src/ILGPU/Backends/PTX/Transformations/PTXBlockScheduling.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2020-2021 ILGPU Project
+//                        Copyright (c) 2020-2023 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: PTXBlockScheduling.cs
@@ -20,7 +20,7 @@ namespace ILGPU.Backends.PTX.Transformations
     /// Adapts the actual block branch order in a way to avoid negated predicated
     /// branches and which maximizes the number of implicit block branches.
     /// </summary>
-    public sealed class PTXBlockScheduling : UnorderedTransformation
+    sealed class PTXBlockScheduling : UnorderedTransformation
     {
         /// <summary>
         /// Applies the PTX-specific block schedule to the given builder.


### PR DESCRIPTION
This PR unified field-name generation of argument mapper types and refines the current PTX argument mapper functionality. Furthermore, it also adapts visibility and inheritance of PTX-backend analyses and transformations.

This PR depends on #1068.