### PR TITLE
Pass WriteToOutput to backends

### DIFF
--- a/Src/ILGPU/Backends/IBackendCodeGenerator.cs
+++ b/Src/ILGPU/Backends/IBackendCodeGenerator.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2020-2021 ILGPU Project
+//                        Copyright (c) 2020-2023 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: IBackendCodeGenerator.cs
@@ -317,6 +317,12 @@ namespace ILGPU.Backends
         /// <param name="debug">The node.</param>
         void GenerateCode(DebugAssertOperation debug);
 
+        /// <summary>
+        /// Generates code for the output writer.
+        /// </summary>
+        /// <param name="writeToOutput">The node.</param>
+        void GenerateCode(WriteToOutput writeToOutput);
+
         // Terminators
 
         /// <summary>
@@ -594,7 +600,7 @@ namespace ILGPU.Backends
 
             /// <summary cref="IValueVisitor.Visit(WriteToOutput)"/>
             public void Visit(WriteToOutput writeToOutput) =>
-                throw new InvalidCodeGenerationException();
+                CodeGenerator.GenerateCode(writeToOutput);
 
             /// <summary cref="IValueVisitor.Visit(ReturnTerminator)"/>
             public void Visit(ReturnTerminator returnTerminator) =>

--- a/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Values.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Values.cs
@@ -792,6 +792,11 @@ namespace ILGPU.Backends.OpenCL
             // Invalid debug node -> should have been removed
             debug.Assert(false);
 
+        /// <summary cref="IBackendCodeGenerator.GenerateCode(WriteToOutput)"/>
+        public void GenerateCode(WriteToOutput writeToOutput) =>
+            // Invalid write node -> should have been removed
+            writeToOutput.Assert(false);
+
         /// <summary cref="IBackendCodeGenerator.GenerateCode(LanguageEmitValue)"/>
         public void GenerateCode(LanguageEmitValue value) =>
             // Ignore PTX instructions.

--- a/Src/ILGPU/Backends/PTX/PTXCodeGenerator.Values.cs
+++ b/Src/ILGPU/Backends/PTX/PTXCodeGenerator.Values.cs
@@ -1231,7 +1231,13 @@ namespace ILGPU.Backends.PTX
 
         /// <summary cref="IBackendCodeGenerator.GenerateCode(DebugAssertOperation)"/>
         public void GenerateCode(DebugAssertOperation debug) =>
-            Debug.Assert(false, "Invalid debug node -> should have been removed");
+            // Invalid debug node -> should have been removed
+            debug.Assert(false);
+
+        /// <summary cref="IBackendCodeGenerator.GenerateCode(WriteToOutput)"/>
+        public void GenerateCode(WriteToOutput writeToOutput) =>
+            // Invalid write node -> should have been removed
+            writeToOutput.Assert(false);
 
         /// <summary cref="IBackendCodeGenerator.GenerateCode(LanguageEmitValue)"/>
         [SuppressMessage(


### PR DESCRIPTION
This PR changes the current behavior which blocks `WriteToOutput` nodes from being sent to the code generators of each backend directly. This was not required in the past. However, upcoming backends may need to generate custom code for these instructions within the code generators directly.