### PR TITLE
Refined IL emitters

### DIFF
--- a/Src/ILGPU/Backends/IL/ILEmitter.cs
+++ b/Src/ILGPU/Backends/IL/ILEmitter.cs
@@ -235,6 +235,12 @@ namespace ILGPU.Backends.IL
         void EmitSwitch(ILLabel[] labels);
 
         /// <summary>
+        /// Emits code to write something to the console.
+        /// </summary>
+        /// <param name="message">The message to write.</param>
+        void EmitWriteLine(string message);
+
+        /// <summary>
         /// Finishes the code generation process.
         /// </summary>
         void Finish();
@@ -405,6 +411,10 @@ namespace ILGPU.Backends.IL
             Generator.Emit(OpCodes.Switch, switchLabels);
         }
 
+        /// <summary cref="IILEmitter.EmitWriteLine"/>
+        public void EmitWriteLine(string message) =>
+            Generator.EmitWriteLine(message);
+
         /// <summary cref="IILEmitter.Finish"/>
         public void Finish() { }
 
@@ -525,7 +535,8 @@ namespace ILGPU.Backends.IL
         {
             EmitPrefix();
             Writer.Write(target.IsVirtual ? "callvirt " : "call ");
-            Writer.Write(target.DeclaringType.AsNotNull().FullName);
+            if (target.DeclaringType is not null)
+                Writer.Write(target.DeclaringType.FullName);
             Writer.Write('.');
             Writer.WriteLine(target.Name);
         }
@@ -635,6 +646,10 @@ namespace ILGPU.Backends.IL
             }
         }
 
+        /// <summary cref="IILEmitter.EmitWriteLine"/>
+        public void EmitWriteLine(string message) =>
+            Writer.WriteLine($" => Write('{message}')");
+
         /// <summary cref="IILEmitter.Finish"/>
         public void Finish()
         {
@@ -716,6 +731,9 @@ namespace ILGPU.Backends.IL
 
         /// <summary cref="IILEmitter.EmitSwitch(ILLabel[])"/>
         public void EmitSwitch(params ILLabel[] labels) { }
+
+        /// <summary cref="IILEmitter.EmitWriteLine"/>
+        public void EmitWriteLine(string message) { }
 
         /// <summary cref="IILEmitter.Finish"/>
         public void Finish() { }

--- a/Src/ILGPU/Backends/IL/ILEmitterExtensions.cs
+++ b/Src/ILGPU/Backends/IL/ILEmitterExtensions.cs
@@ -10,6 +10,8 @@
 // ---------------------------------------------------------------------------------------
 
 using ILGPU.Util;
+using ILGPU.IR.Types;
+using ILGPU.IR.Values;
 using System;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -21,6 +23,8 @@ namespace ILGPU.Backends.IL
     /// </summary>
     public static class ILEmitterExtensions
     {
+        #region Static
+
         private static readonly MethodInfo GetHashCodeInfo =
             typeof(object).GetMethod(
                 nameof(object.GetHashCode),
@@ -31,6 +35,191 @@ namespace ILGPU.Backends.IL
                 nameof(object.Equals),
                 BindingFlags.Public | BindingFlags.Instance)
             .ThrowIfNull();
+
+        /// <summary>
+        /// Caches all constant op codes.
+        /// </summary>
+        private static readonly OpCode[] ConstantOpCodes =
+            new OpCode[]
+            {
+                OpCodes.Ldc_I4_M1,
+                OpCodes.Ldc_I4_0,
+                OpCodes.Ldc_I4_1,
+                OpCodes.Ldc_I4_2,
+                OpCodes.Ldc_I4_3,
+                OpCodes.Ldc_I4_4,
+                OpCodes.Ldc_I4_5,
+                OpCodes.Ldc_I4_6,
+                OpCodes.Ldc_I4_7,
+                OpCodes.Ldc_I4_8,
+            };
+
+        /// <summary>
+        /// Stores the constructor of the <see cref="Half"/> type.
+        /// </summary>
+        private static readonly ConstructorInfo HalfConstructor =
+            typeof(Half).GetConstructor(
+                    BindingFlags.NonPublic | BindingFlags.CreateInstance,
+                    null,
+                    new Type[]
+                    {
+                        typeof(ushort)
+                    },
+                    null)
+                .AsNotNull();
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Emits optimized code to load an integer constant.
+        /// </summary>
+        public static void LoadIntegerConstant<TILEmitter>(
+            this TILEmitter emitter,
+            int constant)
+            where TILEmitter : IILEmitter
+        {
+            if (constant >= -1 && constant  < ConstantOpCodes.Length - 1)
+                emitter.Emit(ConstantOpCodes[constant + 1]);
+            else
+                emitter.EmitConstant(constant);
+        }
+
+        /// <summary>
+        /// Calls a compatible shuffle method.
+        /// </summary>
+        public static void LoadConstant<TILEmitter>(
+            this TILEmitter emitter,
+            PrimitiveValue value,
+            ref ILLocal? temporaryHalf)
+            where TILEmitter : IILEmitter
+        {
+            switch (value.BasicValueType)
+            {
+                case BasicValueType.Int1:
+                    if (value.Int1Value)
+                        emitter.Emit(OpCodes.Ldc_I4_0);
+                    else
+                        emitter.Emit(OpCodes.Ldc_I4_1);
+                    break;
+                case BasicValueType.Int16:
+                    emitter.LoadIntegerConstant(value.Int16Value);
+                    break;
+                case BasicValueType.Int32:
+                    emitter.LoadIntegerConstant(value.Int32Value);
+                    break;
+                case BasicValueType.Int64:
+                    emitter.EmitConstant(value.Int64Value);
+                    break;
+                case BasicValueType.Float16:
+                    // Allocate a temporary variable and invoke the half constructor
+                    temporaryHalf ??= emitter.DeclareLocal(typeof(Half));
+                    emitter.Emit(LocalOperation.LoadAddress, temporaryHalf.Value);
+                    emitter.EmitConstant(value.Float16Value.RawValue);
+                    emitter.EmitNewObject(HalfConstructor);
+                    emitter.Emit(LocalOperation.Load, temporaryHalf.Value);
+                    break;
+                case BasicValueType.Float32:
+                    emitter.EmitConstant(value.Float32Value);
+                    break;
+                case BasicValueType.Float64:
+                    emitter.EmitConstant(value.Float64Value);
+                    break;
+                default:
+                    throw new NotSupportedIntrinsicException(
+                        value.BasicValueType.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Loads an object from an address in memory.
+        /// </summary>
+        /// <param name="emitter">The emitter instance.</param>
+        /// <param name="typeToLoad">The manged type to load.</param>
+        public static void LoadObject<TILEmitter>(
+            this TILEmitter emitter,
+            Type typeToLoad)
+            where TILEmitter : IILEmitter =>
+            emitter.Emit(OpCodes.Ldobj, typeToLoad);
+
+        /// <summary>
+        /// Generates code that loads a null value.
+        /// </summary>
+        public static void LoadNull<TILEmitter>(
+            this TILEmitter emitter,
+            ILLocal target)
+            where TILEmitter : IILEmitter
+        {
+            // Check whether the given value is a reference type
+            if (target.VariableType.IsClass)
+            {
+                // Emit a null reference
+                emitter.Emit(OpCodes.Ldnull, target.VariableType);
+                emitter.Emit(LocalOperation.Store, target);
+            }
+            else
+            {
+                // Emit a new local variable that is initialized with null
+                emitter.Emit(LocalOperation.LoadAddress, target);
+                emitter.Emit(OpCodes.Initobj, target.VariableType);
+            }
+        }
+
+        /// <summary>
+        /// Gets managed field info from a pre-defined converted structure type.
+        /// </summary>
+        /// <param name="type">The managed structure type.</param>
+        /// <param name="fieldIndex">The internal field index.</param>
+        /// <returns>The corresponding field info.</returns>
+        public static FieldInfo GetFieldInfo(Type type, int fieldIndex)
+        {
+            var fieldName = StructureType.GetFieldName(fieldIndex);
+            return type.GetField(fieldName).AsNotNull();
+        }
+
+        /// <summary>
+        /// Emits code to load a field.
+        /// </summary>
+        public static void LoadField<TILEmitter>(
+            this TILEmitter emitter,
+            Type type,
+            int fieldIndex)
+            where TILEmitter : IILEmitter
+        {
+            var fieldInfo = GetFieldInfo(type, fieldIndex);
+            emitter.Emit(OpCodes.Ldfld, fieldInfo);
+        }
+
+        /// <summary>
+        /// Emits code to load the address of a field.
+        /// </summary>
+        public static void LoadFieldAddress<TILEmitter>(
+            this TILEmitter emitter,
+            Type type,
+            int fieldIndex)
+            where TILEmitter : IILEmitter
+        {
+            var fieldInfo = GetFieldInfo(type, fieldIndex);
+            emitter.Emit(OpCodes.Ldflda, fieldInfo);
+        }
+
+        /// <summary>
+        /// Emits code to store a value to a field.
+        /// </summary>
+        public static void StoreField<TILEmitter>(
+            this TILEmitter emitter,
+            Type type,
+            int fieldIndex)
+            where TILEmitter : IILEmitter
+        {
+            var fieldInfo = GetFieldInfo(type, fieldIndex);
+            emitter.Emit(OpCodes.Stfld, fieldInfo);
+        }
+
+        #endregion
+
+        #region Hash Code and Equals
 
         /// <summary>
         /// Generates hash code and equals functions for the given fields.
@@ -204,5 +393,7 @@ namespace ILGPU.Backends.IL
 
             return equals;
         }
+
+        #endregion
     }
 }

--- a/Src/ILGPU/Backends/IL/Transformations/ILAcceleratorSpecializer.cs
+++ b/Src/ILGPU/Backends/IL/Transformations/ILAcceleratorSpecializer.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2023 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: ILAcceleratorSpecializer.cs
@@ -20,9 +20,31 @@ namespace ILGPU.Backends.IL.Transformations
     /// <summary>
     /// The IL accelerator specializer.
     /// </summary>
-    public sealed class ILAcceleratorSpecializer : AcceleratorSpecializer
+    public class ILAcceleratorSpecializer : AcceleratorSpecializer
     {
         #region Instance
+
+        /// <summary>
+        /// Constructs a new IL accelerator specializer.
+        /// </summary>
+        /// <param name="acceleratorType">The current accelerator type.</param>
+        /// <param name="pointerType">The actual pointer type to use.</param>
+        /// <param name="warpSize">The warp size to use.</param>
+        /// <param name="enableAssertions">True, if the assertions are enabled.</param>
+        /// <param name="enableIOOperations">True, if the IO is enabled.</param>
+        internal ILAcceleratorSpecializer(
+            AcceleratorType acceleratorType,
+            PrimitiveType pointerType,
+            int warpSize,
+            bool enableAssertions,
+            bool enableIOOperations)
+            : base(
+                  acceleratorType,
+                  warpSize,
+                  pointerType,
+                  enableAssertions,
+                  enableIOOperations)
+        { }
 
         /// <summary>
         /// Constructs a new IL accelerator specializer.
@@ -36,10 +58,10 @@ namespace ILGPU.Backends.IL.Transformations
             int warpSize,
             bool enableAssertions,
             bool enableIOOperations)
-            : base(
+            : this(
                   AcceleratorType.CPU,
-                  warpSize,
                   pointerType,
+                  warpSize,
                   enableAssertions,
                   enableIOOperations)
         { }


### PR DESCRIPTION
This PR extents the currently available `IL`-specific code generation capabilities by adding new helper methods and utility code generation methods. Furthermore, it also changes the visibility and the inheritance structure of the `ILAcceleratorSpecializer` to make it reusable within ILGPU.

This PR depends on #1068.