### PR TITLE
Clean up the way matrix.os is setup and matched

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,15 +163,11 @@ jobs:
       - name: Setup the latest .NET 6 SDK
         if: matrix.framework == 'net6.0'
         uses: actions/setup-dotnet@v3.2.0
-        env:
-          DOTNET_INSTALL_DIR: ${{ matrix.framework == 'cuda' && '~/.' }}
         with:
           dotnet-version: 6.0.x
 
       - name: Setup the latest .NET 7 SDK
         uses: actions/setup-dotnet@v3.2.0
-        env:
-          DOTNET_INSTALL_DIR: ${{ matrix.framework == 'cuda' && '~/.' }}
         with:
           dotnet-version: 7.0.x
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
             )
           ) && os+=("macos-latest")
 
-          [ "${{ steps.is-fork.outputs.fork }}" == "false" ] && os+=("cuda-${{ github.run_id }}-${{ github.run_attempt }}")
+          [ "${{ steps.is-fork.outputs.fork }}" == "false" ] && os+=("cuda")
 
           echo "os=$(jq -cn '$ARGS.positional' --args ${os[@]})" >> $GITHUB_OUTPUT
     outputs:
@@ -155,7 +155,7 @@ jobs:
         library: [ILGPU, ILGPU.Algorithms]
         framework: [net6.0, net7.0]
       fail-fast: false
-    runs-on: ${{ contains(matrix.os, 'cuda') && format('{0}-{1}-{2}', matrix.os, matrix.library, matrix.framework) || matrix.os }}
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -178,7 +178,7 @@ jobs:
       - name: Set test flavor
         id: test-flavor
         shell: bash
-        run: echo "flavor=$([[ "${{ matrix.os }}" == cuda-* ]] && echo "Cuda" || echo "CPU")" >> $GITHUB_OUTPUT
+        run: echo "flavor=$([[ "${{ matrix.os }}" == cuda ]] && echo "Cuda" || echo "CPU")" >> $GITHUB_OUTPUT
 
       - name: Build and test
         run: dotnet test Src/${{ matrix.library }}.Tests.${{ steps.test-flavor.outputs.flavor }} --configuration=Release --framework=${{ matrix.framework }} -p:TreatWarningsAsErrors=true


### PR DESCRIPTION
Hi @m4rs-mt @MoFtZ . This PR reverts the CI back to previous state (before self-hosted runners were used), to the way Cuda was added to the `matrix.os` and then verified and matched.