### PR TITLE
Fixed BasicValueType getter of PaddingType.

### DIFF
--- a/Src/ILGPU/IR/Types/PaddingType.cs
+++ b/Src/ILGPU/IR/Types/PaddingType.cs
@@ -44,7 +44,7 @@ namespace ILGPU.IR.Types
         /// <summary>
         /// Returns the associated basic value type.
         /// </summary>
-        public new BasicValueType BasicValueType => PrimitiveType.BasicValueType;
+        public override BasicValueType BasicValueType => PrimitiveType.BasicValueType;
 
         /// <summary>
         /// Returns the associated basic value type.


### PR DESCRIPTION
This PR fixes the `BasicValueType` getter of `PaddingType` instances. Instead of hiding the underling getter, it should actually override the getter.