### PR TITLE
Modified OpenCL generator to forward declare all variables.

### DIFF
--- a/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Emitter.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.Emitter.cs
@@ -47,6 +47,7 @@ namespace ILGPU.Backends.OpenCL
             #region Instance
 
             private readonly StringBuilder stringBuilder;
+            private readonly StringBuilder variableBuilder;
             private bool argMode;
             private int argumentCount;
 
@@ -58,6 +59,7 @@ namespace ILGPU.Backends.OpenCL
             {
                 CodeGenerator = codeGenerator;
                 stringBuilder = codeGenerator.Builder;
+                variableBuilder = codeGenerator.VariableBuilder;
                 argumentCount = 0;
                 argMode = false;
 
@@ -85,11 +87,7 @@ namespace ILGPU.Backends.OpenCL
             private void BeginAppendTarget(Variable target, bool appendNew = true)
             {
                 if (appendNew)
-                {
-                    var variableType = CodeGenerator.GetVariableType(target);
-                    stringBuilder.Append(variableType);
-                    stringBuilder.Append(' ');
-                }
+                    AppendDeclaration(target);
                 stringBuilder.Append(target.ToString());
             }
 
@@ -97,8 +95,15 @@ namespace ILGPU.Backends.OpenCL
             /// Appends a target declaration.
             /// </summary>
             /// <param name="target">The target declaration.</param>
-            internal void AppendDeclaration(Variable target) =>
-                BeginAppendTarget(target);
+            internal void AppendDeclaration(Variable target)
+            {
+                var variableType = CodeGenerator.GetVariableType(target);
+                variableBuilder.Append('\t');
+                variableBuilder.Append(variableType);
+                variableBuilder.Append(' ');
+                variableBuilder.Append(target.ToString());
+                variableBuilder.AppendLine(";");
+            }
 
             /// <summary>
             /// Appends a target.
@@ -825,6 +830,50 @@ namespace ILGPU.Backends.OpenCL
             var emitter = new StatementEmitter(this);
             emitter.AppendOperation(command);
             return emitter;
+        }
+
+        /// <summary>
+        /// Begins the function body, switching to variable capturing mode.
+        /// </summary>
+        protected void BeginFunctionBody()
+        {
+            // Start the function body.
+            Builder.AppendLine("{");
+            PushIndent();
+
+#if DEBUG
+            Builder.AppendLine();
+            Builder.AppendLine("\t// Variable declarations");
+            Builder.AppendLine();
+#endif
+
+            // Switch to the alternate builder, so that we can capture the code and
+            // variable declarations separately.
+            prefixBuilder = Builder;
+            Builder = suffixBuilder;
+        }
+
+        /// <summary>
+        /// Finishes the function body, ending variable capturing mode.
+        /// </summary>
+        protected void FinishFunctionBody()
+        {
+            // Restore the original builder, containing code before the variable
+            // declarations.
+            Builder = prefixBuilder;
+
+            // Add the variable declarations at the start of the function, to avoid
+            // issues with OpenCL compilers that are not C99 compliant, and cannot
+            // handle variable declarations intermingled with other code.
+            Builder.Append(VariableBuilder);
+            Builder.AppendLine();
+
+            // Add the code that was generated along with the variable declarations.
+            Builder.Append(suffixBuilder);
+
+            // Close the function body.
+            PopIndent();
+            Builder.AppendLine("}");
         }
 
         #endregion

--- a/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.cs
@@ -202,6 +202,9 @@ namespace ILGPU.Backends.OpenCL
             new Dictionary<BasicBlock, string>();
         private readonly string labelPrefix;
 
+        private StringBuilder prefixBuilder = new StringBuilder();
+        private StringBuilder suffixBuilder = new StringBuilder();
+
         /// <summary>
         /// Constructs a new code generator.
         /// </summary>
@@ -218,7 +221,7 @@ namespace ILGPU.Backends.OpenCL
 
             labelPrefix = "L_" + Method.Id.ToString();
 
-            Builder = new StringBuilder();
+            Builder = prefixBuilder;
         }
 
         #endregion
@@ -250,7 +253,12 @@ namespace ILGPU.Backends.OpenCL
         /// <summary>
         /// Returns the associated string builder.
         /// </summary>
-        public StringBuilder Builder { get; }
+        public StringBuilder Builder { get; private set; }
+
+        /// <summary>
+        /// Returns the associated string builder.
+        /// </summary>
+        public StringBuilder VariableBuilder { get; } = new StringBuilder();
 
         #endregion
 

--- a/Src/ILGPU/Backends/OpenCL/CLFunctionGenerator.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLFunctionGenerator.cs
@@ -132,11 +132,9 @@ namespace ILGPU.Backends.OpenCL
             BindSharedMemoryAllocation(Allocas.DynamicSharedAllocations);
 
             // Generate code
-            Builder.AppendLine("{");
-            PushIndent();
+            BeginFunctionBody();
             GenerateCodeInternal();
-            PopIndent();
-            Builder.AppendLine("}");
+            FinishFunctionBody();
         }
 
         #endregion

--- a/Src/ILGPU/Backends/OpenCL/CLKernelFunctionGenerator.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLKernelFunctionGenerator.cs
@@ -262,8 +262,7 @@ namespace ILGPU.Backends.OpenCL
             Builder.AppendLine(")");
 
             // Emit code that moves view arguments into their appropriate targets
-            Builder.AppendLine("{");
-            PushIndent();
+            BeginFunctionBody();
             GenerateArgumentMapping();
 
             // Emit index computation
@@ -323,8 +322,7 @@ namespace ILGPU.Backends.OpenCL
 
             // Generate code
             GenerateCodeInternal();
-            PopIndent();
-            Builder.AppendLine("}");
+            FinishFunctionBody();
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1075, #1076

There appears to be an issue with the OpenCL compiler for AMD GPUs. Unsure if this affects all systems, but have been able to reproduce on Windows 11, on AMD integrated GPUs, with the latest drivers.

In particular, the OpenCL compiler is not C99 compliant, and does not allow variable declarations intermingled with code. Forward declaring all the variables at the start of the function appears to fix this issue.