### PR TITLE
Improved performance of Velocity kernels by refining workload dispatcher.

### DIFF
--- a/Src/ILGPU/Backends/Velocity/VelocityBackend.cs
+++ b/Src/ILGPU/Backends/Velocity/VelocityBackend.cs
@@ -96,6 +96,7 @@ namespace ILGPU.Backends.Velocity
                 // Transform all if and switch branches to make them compatible with
                 // the internal vectorization engine
                 transformerBuilder.Add(new VelocityBlockScheduling());
+                transformerBuilder.Add(new DeadCodeElimination());
 
                 builder.Add(transformerBuilder.ToTransformer());
             });

--- a/Src/ILGPU/Backends/Velocity/VelocityCodeGenerator.Threads.cs
+++ b/Src/ILGPU/Backends/Velocity/VelocityCodeGenerator.Threads.cs
@@ -65,8 +65,10 @@ namespace ILGPU.Backends.Velocity
             switch (value.Dimension)
             {
                 case DeviceConstantDimension3D.X:
-                    // Load the first context argument and query the grid index
-                    VelocityTargetSpecializer.GetGridIndex(Emitter);
+                    // Load global index and compute the actual grid index
+                    LoadGlobalIndexScalar();
+                    LoadGroupDimScalar();
+                    Emitter.Emit(OpCodes.Div);
                     break;
                 case DeviceConstantDimension3D.Y:
                 case DeviceConstantDimension3D.Z:
@@ -100,7 +102,7 @@ namespace ILGPU.Backends.Velocity
             switch (value.Dimension)
             {
                 case DeviceConstantDimension3D.X:
-                    VelocityTargetSpecializer.GetGridDim(Emitter);
+                    LoadGridDimScalar();
                     break;
                 case DeviceConstantDimension3D.Y:
                 case DeviceConstantDimension3D.Z:
@@ -117,7 +119,7 @@ namespace ILGPU.Backends.Velocity
             switch (value.Dimension)
             {
                 case DeviceConstantDimension3D.X:
-                    VelocityTargetSpecializer.GetGroupDim(Emitter);
+                    LoadGroupDimScalar();
                     break;
                 case DeviceConstantDimension3D.Y:
                 case DeviceConstantDimension3D.Z:

--- a/Src/ILGPU/Backends/Velocity/VelocityCodeGenerator.Values.cs
+++ b/Src/ILGPU/Backends/Velocity/VelocityCodeGenerator.Values.cs
@@ -22,11 +22,35 @@ namespace ILGPU.Backends.Velocity
 {
     partial class VelocityCodeGenerator<TILEmitter>
     {
+        /// <summary>
+        /// Loads the current global index.
+        /// </summary>
+        protected abstract void LoadGlobalIndexScalar();
+
+        /// <summary>
+        /// Loads the current group dimension.
+        /// </summary>
+        protected abstract void LoadGroupDimScalar();
+
+        /// <summary>
+        /// Loads the current grid dimension.
+        /// </summary>
+        protected abstract void LoadGridDimScalar();
+
         /// <inheritdoc/>
         public void GenerateCode(MethodCall methodCall)
         {
             // Load the execution context
             Emitter.Emit(OpCodes.Ldarg_0);
+
+            // Load the global index
+            LoadGlobalIndexScalar();
+
+            // Load the group dimension
+            LoadGroupDimScalar();
+
+            // Load the grid dimension
+            LoadGridDimScalar();
 
             // Load the current execution mask
             Emitter.Emit(LocalOperation.Load, GetBlockMask(methodCall.BasicBlock));

--- a/Src/ILGPU/Backends/Velocity/VelocityCodeGenerator.cs
+++ b/Src/ILGPU/Backends/Velocity/VelocityCodeGenerator.cs
@@ -40,14 +40,29 @@ namespace ILGPU.Backends.Velocity
         public const int ExecutionContextIndex = 0;
 
         /// <summary>
+        /// The parameter index of the current global index.
+        /// </summary>
+        public const int GlobalIndexScalar = 1;
+
+        /// <summary>
+        /// The parameter index of the current group dimension.
+        /// </summary>
+        public const int GroupDimIndexScalar = 2;
+        /// <summary>
+        ///
+        /// The parameter index of the current grid dimension.
+        /// </summary>
+        public const int GridDimIndexScalar = 3;
+
+        /// <summary>
         /// The parameter index of all masks.
         /// </summary>
-        public const int MaskParameterIndex = 1;
+        public const int MaskParameterIndex = 4;
 
         /// <summary>
         /// The method parameter offset for all parameters.
         /// </summary>
-        public const int MethodParameterOffset = 2;
+        public const int MethodParameterOffset = 5;
 
         #endregion
     }

--- a/Src/ILGPU/Backends/Velocity/VelocityFunctionGenerator.cs
+++ b/Src/ILGPU/Backends/Velocity/VelocityFunctionGenerator.cs
@@ -63,6 +63,30 @@ namespace ILGPU.Backends.Velocity
         }
 
         /// <summary>
+        /// Loads the current global index.
+        /// </summary>
+        protected override void LoadGlobalIndexScalar() =>
+            Emitter.Emit(
+                ArgumentOperation.Load,
+                VelocityCodeGenerator.GlobalIndexScalar);
+
+        /// <summary>
+        /// Loads the current group dimension.
+        /// </summary>
+        protected override void LoadGroupDimScalar() =>
+            Emitter.Emit(
+                ArgumentOperation.Load,
+                VelocityCodeGenerator.GroupDimIndexScalar);
+
+        /// <summary>
+        /// Loads the current grid dimension.
+        /// </summary>
+        protected override void LoadGridDimScalar() =>
+            Emitter.Emit(
+                ArgumentOperation.Load,
+                VelocityCodeGenerator.GridDimIndexScalar);
+
+        /// <summary>
         /// Generates Velocity code for this function.
         /// </summary>
         public override void GenerateCode()

--- a/Src/ILGPU/Backends/Velocity/VelocityGenerationModule.cs
+++ b/Src/ILGPU/Backends/Velocity/VelocityGenerationModule.cs
@@ -435,6 +435,9 @@ namespace ILGPU.Backends.Velocity
                 // Convert all parameter types
                 parameterTypes[VelocityCodeGenerator.ExecutionContextIndex] =
                     typeof(VelocityGroupExecutionContext);
+                parameterTypes[VelocityCodeGenerator.GlobalIndexScalar] = typeof(int);
+                parameterTypes[VelocityCodeGenerator.GroupDimIndexScalar] = typeof(int);
+                parameterTypes[VelocityCodeGenerator.GridDimIndexScalar] = typeof(int);
                 parameterTypes[VelocityCodeGenerator.MaskParameterIndex] =
                     specializer.WarpType32;
                 for (int i = 0; i < method.NumParameters; ++i)

--- a/Src/ILGPU/Backends/Velocity/VelocityTargetSpecializer.cs
+++ b/Src/ILGPU/Backends/Velocity/VelocityTargetSpecializer.cs
@@ -35,14 +35,6 @@ namespace ILGPU.Backends.Velocity
 
         private static readonly MethodInfo MemoryBarrierMethod =
             GetMethod<VelocityTargetSpecializer>(nameof(MemoryBarrier));
-        private static readonly MethodInfo GetGridIndexMethod =
-            GetMethod<VelocityTargetSpecializer>(nameof(GetGridIndexImpl));
-        private static readonly MethodInfo GetGridDimMethod =
-            GetMethod<VelocityTargetSpecializer>(nameof(GetGridDimImpl));
-        private static readonly MethodInfo GetGroupDimMethod =
-            GetMethod<VelocityTargetSpecializer>(nameof(GetGroupDimImpl));
-        private static readonly MethodInfo GetUserSizeMethod =
-            GetMethod<VelocityTargetSpecializer>(nameof(GetUserSizeImpl));
 
         private static readonly MethodInfo GetDynamicSharedMemoryMethod =
             GetMethod<VelocityTargetSpecializer>(
@@ -54,8 +46,6 @@ namespace ILGPU.Backends.Velocity
             GetMethod<VelocityTargetSpecializer>(nameof(GetSharedMemoryFromPoolImpl));
         private static readonly MethodInfo GetLocalMemoryFromPoolMethod =
             GetMethod<VelocityTargetSpecializer>(nameof(GetLocalMemoryFromPoolImpl));
-        private static readonly MethodInfo ComputeGlobalBaseIndexMethod =
-            GetMethod<VelocityTargetSpecializer>(nameof(ComputeGlobalBaseIndexImpl));
         private static readonly MethodInfo DebuggerBreakMethod =
             GetMethod<VelocityTargetSpecializer>(nameof(DebuggerBreakImpl));
 
@@ -63,36 +53,6 @@ namespace ILGPU.Backends.Velocity
         /// Wrapper around an Interlocked memory barrier.
         /// </summary>
         internal static void MemoryBarrier() => Interlocked.MemoryBarrier();
-
-        /// <summary>
-        /// Wrapper around a group extension context.
-        /// </summary>
-        internal static int GetGridIndexImpl(VelocityGroupExecutionContext context) =>
-            context.GridIdx;
-
-        /// <summary>
-        /// Wrapper around a group extension context.
-        /// </summary>
-        internal static int GetGridDimImpl(VelocityGroupExecutionContext context) =>
-            context.GridDim;
-
-        /// <summary>
-        /// Wrapper around a group extension context.
-        /// </summary>
-        internal static int GetGroupDimImpl(VelocityGroupExecutionContext context) =>
-            context.GroupDim;
-
-        /// <summary>
-        /// Wrapper around a group extension context.
-        /// </summary>
-        internal static int GetUserSizeImpl(VelocityGroupExecutionContext context) =>
-            context.UserSize;
-
-        /// <summary>
-        /// Wrapper around a group extension context.
-        /// </summary>
-        internal static int ComputeGlobalBaseIndexImpl(
-            VelocityGroupExecutionContext context) => context.GroupOffset;
 
         /// <summary>
         /// Wrapper around a group extension context.
@@ -557,34 +517,6 @@ namespace ILGPU.Backends.Velocity
             where TILEmitter : struct, IILEmitter =>
             emitter.EmitCall(MemoryBarrierMethod);
 
-        public static void GetGridIndex<TILEmitter>(TILEmitter emitter)
-            where TILEmitter : struct, IILEmitter
-        {
-            emitter.Emit(OpCodes.Ldarg_0);
-            emitter.EmitCall(GetGridIndexMethod);
-        }
-
-        public static void GetGridDim<TILEmitter>(TILEmitter emitter)
-            where TILEmitter : struct, IILEmitter
-        {
-            emitter.Emit(OpCodes.Ldarg_0);
-            emitter.EmitCall(GetGridDimMethod);
-        }
-
-        public static void GetUserSize<TILEmitter>(TILEmitter emitter)
-            where TILEmitter : struct, IILEmitter
-        {
-            emitter.Emit(OpCodes.Ldarg_0);
-            emitter.EmitCall(GetUserSizeMethod);
-        }
-
-        public static void GetGroupDim<TILEmitter>(TILEmitter emitter)
-            where TILEmitter : struct, IILEmitter
-        {
-            emitter.Emit(OpCodes.Ldarg_0);
-            emitter.EmitCall(GetGroupDimMethod);
-        }
-
         public void GetDynamicSharedMemory<TILEmitter>(TILEmitter emitter)
             where TILEmitter : struct, IILEmitter
         {
@@ -638,13 +570,6 @@ namespace ILGPU.Backends.Velocity
 
             // Convert the scalar version into a warp-wide value
             ConvertScalarTo64(emitter, VelocityWarpOperationMode.U);
-        }
-
-        public static void ComputeGlobalBaseIndex<TILEmitter>(TILEmitter emitter)
-            where TILEmitter : struct, IILEmitter
-        {
-            emitter.Emit(OpCodes.Ldarg_0);
-            emitter.EmitCall(ComputeGlobalBaseIndexMethod);
         }
 
         public static void DebuggerBreak<TILEmitter>(TILEmitter emitter)

--- a/Src/ILGPU/Runtime/Velocity/VelocityDevice.cs
+++ b/Src/ILGPU/Runtime/Velocity/VelocityDevice.cs
@@ -67,7 +67,11 @@ namespace ILGPU.Runtime.Velocity
                 .AsNotNullCast<VelocityTargetSpecializer>();
             WarpSize = TargetSpecializer.WarpSize;
             MaxNumThreadsPerGroup = MaxNumThreadsPerMultiprocessor = WarpSize;
+#if DEBUG
+            NumMultiprocessors = 1;
+#else
             NumMultiprocessors = Environment.ProcessorCount;
+#endif
             MaxGroupSize = new Index3D(
                 MaxNumThreadsPerGroup,
                 1,

--- a/Src/ILGPU/Runtime/Velocity/VelocityEntryPointHandler.cs
+++ b/Src/ILGPU/Runtime/Velocity/VelocityEntryPointHandler.cs
@@ -17,9 +17,17 @@ namespace ILGPU.Runtime.Velocity
     /// Represents a single velocity kernel processing delegate.
     /// </summary>
     /// <param name="groupContext">The main group context.</param>
+    /// <param name="groupDim">The main group dimension.</param>
+    /// <param name="gridDim">The main grid dimension.</param>
+    /// <param name="startIndex">The global start index (inclusive).</param>
+    /// <param name="endIndex">The global end index (exclusive).</param>
     /// <param name="parameters">The current parameters.</param>
     delegate void VelocityEntryPointHandler(
         VelocityGroupExecutionContext groupContext,
+        int groupDim,
+        int gridDim,
+        long startIndex,
+        long endIndex,
         VelocityParameters parameters);
 
     /// <summary>
@@ -35,6 +43,10 @@ namespace ILGPU.Runtime.Velocity
         public static readonly Type[] EntryPointParameterTypes = new Type[]
         {
             typeof(VelocityGroupExecutionContext),
+            typeof(int),
+            typeof(int),
+            typeof(long),
+            typeof(long),
             typeof(VelocityParameters),
         };
     }

--- a/Src/ILGPU/Runtime/Velocity/VelocityGroupExecutionContext.cs
+++ b/Src/ILGPU/Runtime/Velocity/VelocityGroupExecutionContext.cs
@@ -38,61 +38,18 @@ namespace ILGPU.Runtime.Velocity
         }
 
         /// <summary>
-        /// Returns the current grid index.
-        /// </summary>
-        public int GridIdx { get; private set; }
-
-        /// <summary>
-        /// Returns the current group dimension.
-        /// </summary>
-        public int GroupDim { get; private set; }
-
-        /// <summary>
-        /// Returns the current grid dimension.
-        /// </summary>
-        public int GridDim { get; private set; }
-
-        /// <summary>
-        /// Returns the user-specific total size.
-        /// </summary>
-        public int UserSize { get; private set; }
-
-        /// <summary>
         /// Returns a view to dynamic shared memory (if any).
         /// </summary>
         public ArrayView<byte> DynamicSharedMemory { get; private set; }
 
         /// <summary>
-        /// Returns the linear group .
-        /// </summary>
-        public int GroupOffset => GridIdx * GroupDim;
-
-        /// <summary>
-        /// Resets this execution context.
-        /// </summary>
-        private void Reset()
-        {
-            sharedMemoryPool.Reset();
-            localMemoryPool.Reset();
-        }
-
-        /// <summary>
         /// Sets up the current thread grid information for the current thread group.
         /// </summary>
-        public void SetupThreadGrid(
-            int gridIdx,
-            int groupDim,
-            int gridDim,
-            int userSize,
-            int dynamicSharedMemoryLength)
+        public void SetupThreadGrid(int dynamicSharedMemoryLength)
         {
-            GridIdx = gridIdx;
-            GridDim = gridDim;
-            GroupDim = groupDim;
-            UserSize = userSize;
-
             // Reset everything
-            Reset();
+            sharedMemoryPool.Reset();
+            localMemoryPool.Reset();
 
             // Allocate dynamic shared memory
             if (dynamicSharedMemoryLength > 0)


### PR DESCRIPTION
This PR addresses a performance issue in the `Velocity` accelerator related to invoking kernels and splitting the actual workload into chunks. It changes the way `Velocity` kernels are executed by creating loops inside the `Velocity` backend directly to perform all work-heavy processing instead of relying on external thread dispatchers.

~~This PR depends on #1055.~~