### PR TITLE
Reworked builder.Debug semantics.

### DIFF
--- a/Samples/SimpleDebugAssert/Program.cs
+++ b/Samples/SimpleDebugAssert/Program.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                    ILGPU Samples
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2023 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Program.cs
@@ -43,7 +43,7 @@ namespace SimpleDebugAssert
             // Create main context
             using var context = Context.Create(builder =>
             {
-                builder.Cuda().OpenCL().AutoAssertions();
+                builder.Cuda().OpenCL().DebugConfig(enableAssertions: true);
                 // Alternatives to explore:
                 //   builder.Default();
                 //   builder.AllAccelerators().Debug();

--- a/Src/ILGPU.Algorithms.Tests.CPU/Configurations.tt
+++ b/Src/ILGPU.Algorithms.Tests.CPU/Configurations.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                   ILGPU Algorithms
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2023 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Configurations.tt/Configurations.cs
@@ -44,6 +44,8 @@ namespace ILGPU.Algorithms.Tests.CPU
         public CPUTestContext<#= config #>()
             : base(
                 OptimizationLevel.<#= level #>,
+                enableAssertions: true,
+                forceDebugConfig: true,
                 builder => builder.EnableAlgorithms())
         { }
     }

--- a/Src/ILGPU.Algorithms.Tests.Cuda/Configurations.tt
+++ b/Src/ILGPU.Algorithms.Tests.Cuda/Configurations.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                   ILGPU Algorithms
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2023 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Configurations.tt/Configurations.cs
@@ -44,6 +44,8 @@ namespace ILGPU.Algorithms.Tests.Cuda
         public CudaTestContext<#= config #>()
             : base(
                 OptimizationLevel.<#= level #>,
+                enableAssertions: false,
+                forceDebugConfig: false,
                 builder => builder.EnableAlgorithms())
         { }
     }

--- a/Src/ILGPU.Algorithms.Tests.OpenCL/Configurations.tt
+++ b/Src/ILGPU.Algorithms.Tests.OpenCL/Configurations.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                   ILGPU Algorithms
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2023 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Configurations.tt/Configurations.cs
@@ -44,6 +44,8 @@ namespace ILGPU.Algorithms.Tests.OpenCL
         public CLTestContext<#= config #>()
             : base(
                 OptimizationLevel.<#= level #>,
+                enableAssertions: false,
+                forceDebugConfig: false,
                 builder => builder.EnableAlgorithms())
         { }
     }

--- a/Src/ILGPU.Tests.CPU/Configurations.tt
+++ b/Src/ILGPU.Tests.CPU/Configurations.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2023 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Configurations.tt/Configurations.cs
@@ -40,7 +40,11 @@ namespace ILGPU.Tests.CPU
     public class CPUTestContext<#= config #> : CPUTestContext
     {
         public CPUTestContext<#= config #>()
-            : base(OptimizationLevel.<#= level #>)
+            : base(
+                OptimizationLevel.<#= level #>,
+                enableAssertions: true,
+                forceDebugConfig: true,
+                _ => { })
         { }
     }
 

--- a/Src/ILGPU.Tests.CPU/RuntimeTests.cs
+++ b/Src/ILGPU.Tests.CPU/RuntimeTests.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2023 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: RuntimeTests.cs
@@ -69,8 +69,9 @@ namespace ILGPU.Tests.CPU
                 Skip.If(customDevice.NumThreads > maxNumThreads);
             }
 
-            using var context = Context.Create(builder =>
-                builder.Assertions().CPU(customDevice));
+            using var context = Context.Create(builder => builder
+                .DebugConfig(enableAssertions: true)
+                .CPU(customDevice));
 
             // Spawn a new accelerator and invoke a simple sequence kernel to check
             // whether all threads are actually executed

--- a/Src/ILGPU.Tests.CPU/TestContext.cs
+++ b/Src/ILGPU.Tests.CPU/TestContext.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2023 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: TestContext.cs
@@ -52,22 +52,24 @@ namespace ILGPU.Tests.CPU
         /// Creates a new test context instance.
         /// </summary>
         /// <param name="optimizationLevel">The optimization level to use.</param>
+        /// <param name="enableAssertions">
+        /// Enables use of assertions.
+        /// </param>
+        /// <param name="forceDebugConfig">
+        /// Forces use of debug configuration in O1 and O2 builds.
+        /// </param>
         /// <param name="prepareContext">The context preparation handler.</param>
         protected CPUTestContext(
             OptimizationLevel optimizationLevel,
+            bool enableAssertions,
+            bool forceDebugConfig,
             Action<Context.Builder> prepareContext)
             : base(
                   optimizationLevel,
+                  enableAssertions,
+                  forceDebugConfig,
                   builder => prepareContext(builder.CPU(GetCPUDeviceKind())),
                   context => context.CreateCPUAccelerator(0))
-        { }
-
-        /// <summary>
-        /// Creates a new test context instance.
-        /// </summary>
-        /// <param name="optimizationLevel">The optimization level to use.</param>
-        protected CPUTestContext(OptimizationLevel optimizationLevel)
-            : this(optimizationLevel, _ => { })
         { }
     }
 }

--- a/Src/ILGPU.Tests.Cuda/Configurations.tt
+++ b/Src/ILGPU.Tests.Cuda/Configurations.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2023 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Configurations.tt/Configurations.cs
@@ -39,7 +39,11 @@ namespace ILGPU.Tests.Cuda
     public class CudaTestContext<#= config #> : CudaTestContext
     {
         public CudaTestContext<#= config #>()
-            : base(OptimizationLevel.<#= level #>)
+            : base(
+                OptimizationLevel.<#= level #>,
+                enableAssertions: true,
+                forceDebugConfig: true,
+                _ => { })
         { }
     }
 

--- a/Src/ILGPU.Tests.Cuda/TestContext.cs
+++ b/Src/ILGPU.Tests.Cuda/TestContext.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2023 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: TestContext.cs
@@ -23,22 +23,24 @@ namespace ILGPU.Tests.Cuda
         /// Creates a new test context instance.
         /// </summary>
         /// <param name="optimizationLevel">The optimization level to use.</param>
+        /// <param name="enableAssertions">
+        /// Enables use of assertions.
+        /// </param>
+        /// <param name="forceDebugConfig">
+        /// Forces use of debug configuration in O1 and O2 builds.
+        /// </param>
         /// <param name="prepareContext">The context preparation handler.</param>
         protected CudaTestContext(
             OptimizationLevel optimizationLevel,
+            bool enableAssertions,
+            bool forceDebugConfig,
             Action<Context.Builder> prepareContext)
             : base(
                   optimizationLevel,
+                  enableAssertions,
+                  forceDebugConfig,
                   builder => prepareContext(builder.Cuda()),
                   context => context.CreateCudaAccelerator(0))
-        { }
-
-        /// <summary>
-        /// Creates a new test context instance.
-        /// </summary>
-        /// <param name="optimizationLevel">The optimization level to use.</param>
-        protected CudaTestContext(OptimizationLevel optimizationLevel)
-            : this(optimizationLevel, _ => { })
         { }
     }
 }

--- a/Src/ILGPU.Tests.OpenCL/Configurations.tt
+++ b/Src/ILGPU.Tests.OpenCL/Configurations.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2023 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Configurations.tt/Configurations.cs
@@ -39,7 +39,11 @@ namespace ILGPU.Tests.OpenCL
     public class CLTestContext<#= config #> : CLTestContext
     {
         public CLTestContext<#= config #>()
-            : base(OptimizationLevel.<#= level #>)
+            : base(
+                OptimizationLevel.<#= level #>,
+                enableAssertions: true,
+                forceDebugConfig: true,
+                _ => { })
         { }
     }
 

--- a/Src/ILGPU.Tests.OpenCL/TestContext.cs
+++ b/Src/ILGPU.Tests.OpenCL/TestContext.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2023 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: TestContext.cs
@@ -23,22 +23,24 @@ namespace ILGPU.Tests.OpenCL
         /// Creates a new test context instance.
         /// </summary>
         /// <param name="optimizationLevel">The optimization level to use.</param>
+        /// <param name="enableAssertions">
+        /// Enables use of assertions.
+        /// </param>
+        /// <param name="forceDebugConfig">
+        /// Forces use of debug configuration in O1 and O2 builds.
+        /// </param>
         /// <param name="prepareContext">The context preparation handler.</param>
         protected CLTestContext(
             OptimizationLevel optimizationLevel,
+            bool enableAssertions,
+            bool forceDebugConfig,
             Action<Context.Builder> prepareContext)
             : base(
                   optimizationLevel,
+                  enableAssertions,
+                  forceDebugConfig,
                   builder => prepareContext(builder.OpenCL()),
                   context => context.CreateCLAccelerator(0))
-        { }
-
-        /// <summary>
-        /// Creates a new test context instance.
-        /// </summary>
-        /// <param name="optimizationLevel">The optimization level to use.</param>
-        protected CLTestContext(OptimizationLevel optimizationLevel)
-            : this(optimizationLevel, _ => { })
         { }
     }
 }

--- a/Src/ILGPU.Tests.Velocity/Configurations.tt
+++ b/Src/ILGPU.Tests.Velocity/Configurations.tt
@@ -39,7 +39,11 @@ namespace ILGPU.Tests.Velocity
     public class VelocityTestContext<#= config #> : VelocityTestContext
     {
         public VelocityTestContext<#= config #>()
-            : base(OptimizationLevel.<#= level #>)
+            : base(
+                OptimizationLevel.<#= level #>,
+                enableAssertions: true,
+                forceDebugConfig: true,
+                _ => { })
         { }
     }
 

--- a/Src/ILGPU.Tests.Velocity/TestContext.cs
+++ b/Src/ILGPU.Tests.Velocity/TestContext.cs
@@ -23,23 +23,25 @@ namespace ILGPU.Tests.Velocity
         /// Creates a new test context instance.
         /// </summary>
         /// <param name="optimizationLevel">The optimization level to use.</param>
+        /// <param name="enableAssertions">
+        /// Enables use of assertions.
+        /// </param>
+        /// <param name="forceDebugConfig">
+        /// Forces use of debug configuration in O1 and O2 builds.
+        /// </param>
         /// <param name="prepareContext">The context preparation handler.</param>
         protected VelocityTestContext(
             OptimizationLevel optimizationLevel,
+            bool enableAssertions,
+            bool forceDebugConfig,
             Action<Context.Builder> prepareContext)
             : base(
                   optimizationLevel,
+                  enableAssertions,
+                  forceDebugConfig,
                   builder => prepareContext(
                       builder.Velocity(VelocityDeviceType.Scalar2)),
                   context => context.CreateVelocityAccelerator())
-        { }
-
-        /// <summary>
-        /// Creates a new test context instance.
-        /// </summary>
-        /// <param name="optimizationLevel">The optimization level to use.</param>
-        protected VelocityTestContext(OptimizationLevel optimizationLevel)
-            : this(optimizationLevel, _ => { })
         { }
     }
 }

--- a/Src/ILGPU.Tests/Generic/TestContext.cs
+++ b/Src/ILGPU.Tests/Generic/TestContext.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2021-2022 ILGPU Project
+//                        Copyright (c) 2021-2023 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: TestContext.cs
@@ -24,6 +24,12 @@ namespace ILGPU.Tests
         /// Constructs a new context provider.
         /// </summary>
         /// <param name="level">The optimization level.</param>
+        /// <param name="enableAssertions">
+        /// Enables use of assertions.
+        /// </param>
+        /// <param name="forceDebugConfig">
+        /// Forces use of debug configuration in O1 and O2 builds.
+        /// </param>
         /// <param name="prepareContext">
         /// Prepares the context by setting additional field/initializing specific
         /// items before the accelerator is created.
@@ -31,15 +37,21 @@ namespace ILGPU.Tests
         /// <param name="createAccelerator">Creates a new accelerator.</param>
         protected TestContext(
             OptimizationLevel level,
+            bool enableAssertions,
+            bool forceDebugConfig,
             Action<Context.Builder> prepareContext,
             Func<Context, Accelerator> createAccelerator)
         {
             Context = Context.Create(builder =>
                 prepareContext(
                     builder
-                    .Assertions()
+                    .DebugConfig(
+                        enableAssertions: enableAssertions,
+                        enableIOOperations: true,
+                        debugSymbolsMode: DebugSymbolsMode.Auto,
+                        forceDebuggingOfOptimizedKernels: forceDebugConfig,
+                        enableIRVerifier: true)
                     .Arrays(ArrayMode.InlineMutableStaticArrays)
-                    .Verify()
                     .Optimize(level)
                     .Profiling()));
             Accelerator = createAccelerator(Context);

--- a/Src/ILGPU/Backends/Velocity/VelocityBackend.cs
+++ b/Src/ILGPU/Backends/Velocity/VelocityBackend.cs
@@ -89,7 +89,7 @@ namespace ILGPU.Backends.Velocity
                         PointerType,
                         warpSize,
                         Context.Properties.EnableAssertions,
-                        Context.Properties.EnableIOOperations),
+                        enableIOOperations: false),
                     context.Properties.InliningMode,
                     context.Properties.OptimizationLevel);
 

--- a/Src/ILGPU/IR/Transformations/Inliner.cs
+++ b/Src/ILGPU/IR/Transformations/Inliner.cs
@@ -40,10 +40,8 @@ namespace ILGPU.IR.Transformations
             Method method,
             DisassembledMethod disassembledMethod)
         {
-            var inliningMode = context.Properties.InliningMode;
-
-            // Check whether we are allowed to inline this method
-            if (inliningMode == InliningMode.Disabled || !method.HasImplementation)
+            // Check whether we can inline this method
+            if (!method.HasImplementation)
                 return;
 
             if (method.HasSource)
@@ -66,7 +64,7 @@ namespace ILGPU.IR.Transformations
             }
 
             // Evaluate a simple inlining heuristic
-            if (inliningMode != InliningMode.Conservative ||
+            if (context.Properties.InliningMode != InliningMode.Conservative ||
                 disassembledMethod.Instructions.Length <= MaxNumILInstructionsToInline)
             {
                 method.AddFlags(MethodFlags.Inline);

--- a/Src/ILGPU/IR/Transformations/Optimizer.cs
+++ b/Src/ILGPU/IR/Transformations/Optimizer.cs
@@ -63,8 +63,7 @@ namespace ILGPU.IR.Transformations
             this Transformer.Builder builder,
             InliningMode inliningMode)
         {
-            if (inliningMode != InliningMode.Disabled)
-                builder.Add(new Inliner());
+            builder.Add(new Inliner());
             builder.Add(new SimplifyControlFlow());
             builder.Add(new SSAConstruction());
             builder.Add(new DeadCodeElimination());
@@ -149,8 +148,7 @@ namespace ILGPU.IR.Transformations
 
             // Perform an additional inlining pass to specialize small device-specific
             // functions that could have been introduced
-            if (inliningMode != InliningMode.Disabled)
-                builder.Add(new Inliner());
+            builder.Add(new Inliner());
 
             // Apply UCE and DCE passes to avoid dead branches and fold conditionals that
             // do not affect the actual code being executed


### PR DESCRIPTION
This PR reworks `Debug` functionality on context builders.  Previously, calls to the `Debug` function would turn on `O0` optimizations and some debugging features, leaving room for errors when building release configurations. However, with this new PR, everything changes as it provides a powerful new `DebugConfig` builder extension that offers fine grained control over debugging behavior. Note that `DebugConfig` settings are not affecting any release or `O2` builds. This ensures maximum performance in release scenarios.

Old:
```c#
builder.Assertions().IOOperations()
```
Note that this setting would have affected `Release` and `O2` builds automatically.

New:
```c#
builder.DebugConfiguration(enableAssertions: true, ioOperations: true)()
```
Note that this configuration will not affect `Release` and `O2` builds by default.