### PR TITLE
Fixed marshalling ArrayView.Empty as kernel parameter.

### DIFF
--- a/Src/ILGPU.Tests/MemoryBufferOperations.tt
+++ b/Src/ILGPU.Tests/MemoryBufferOperations.tt
@@ -109,6 +109,27 @@ namespace ILGPU.Tests
         {
             output[index] = input[index];
         }
+        
+        internal static void EmptyView_Kernel<T>(
+            Index1D index,
+            ArrayView1D<T, Stride1D.Dense> output)
+            where T : unmanaged
+        {
+            if (index < output.Length)
+                output[index] = default(T);
+        }
+
+<#  foreach (var type in copyTypes) { #>
+        [Fact]
+        [KernelMethod(nameof(EmptyView_Kernel))]
+        public void EmptyView_<#= type.Name #>()
+        {
+            Execute<Index1D, <#= type.Type #>>(
+                42,
+                ArrayView1D<<#= type.Type #>, Stride1D.Dense>.Empty);
+        }
+
+<#  } #>
 
         internal static void ZeroLength_Kernel<T>(
             Index1D index,

--- a/Src/ILGPU/Backends/PointerViews/Utilities.cs
+++ b/Src/ILGPU/Backends/PointerViews/Utilities.cs
@@ -92,7 +92,7 @@ namespace ILGPU.Backends.PointerViews
         /// <returns>The underlying native pointer.</returns>
         private static IntPtr GetNativePtr<T>(in ArrayView<T> view)
             where T : unmanaged =>
-            view.Buffer.NativePtr;
+            view.Buffer?.NativePtr ?? IntPtr.Zero;
 
         /// <summary>
         /// Gets the native-pointer method for the given element type.


### PR DESCRIPTION
Fixes #1121.

The `Empty` member of ArrayView does not initialize its internal MemoryBuffer. When marshaling to OpenCL, there is an exception throw.

Other accelerators use a different mechanism, so are unaffected.