### PR TITLE
Workaround EqualityComparer issues on MacOS and net8.

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -2,7 +2,7 @@
                                   ILGPU License
 ********************************************************************************
 University of Illinois/NCSA Open Source License
-Copyright (c) 2016-2023 ILGPU Project
+Copyright (c) 2016-2024 ILGPU Project
 All rights reserved.
 
 Developed by:           Marcel Koester (m4rs@m4rs.net)

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ ILGPU also provides Source Link support for a better debugging experience. Make 
 ILGPU is licensed under the University of Illinois/NCSA Open Source License.
 Detailed license information can be found in LICENSE.txt.
 
-Copyright (c) 2016-2023 ILGPU Project. All rights reserved.
+Copyright (c) 2016-2024 ILGPU Project. All rights reserved.
 
 Originally developed by Marcel Koester.
 

--- a/Src/ILGPU.Algorithms/Properties/ILGPU.Algorithms.nuspec.targets
+++ b/Src/ILGPU.Algorithms/Properties/ILGPU.Algorithms.nuspec.targets
@@ -4,7 +4,7 @@
     <PackageVersion>$(Version)</PackageVersion>
 
     <Title>ILGPU Algorithms Library</Title>
-    <Copyright>Copyright (c) 2016-2023 ILGPU Project. All rights reserved.</Copyright>
+    <Copyright>Copyright (c) 2016-2024 ILGPU Project. All rights reserved.</Copyright>
     <Company />
     <Authors>ILGPU Algorithms Project</Authors>
     <Description>ILGPU Algorithms library for high-level GPU programming.</Description>

--- a/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.cs
+++ b/Src/ILGPU/Backends/OpenCL/CLCodeGenerator.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2019-2023 ILGPU Project
+//                        Copyright (c) 2019-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: CLCodeGenerator.cs
@@ -199,7 +199,7 @@ namespace ILGPU.Backends.OpenCL
 
         private int labelCounter;
         private readonly Dictionary<BasicBlock, string> blockLookup =
-            new Dictionary<BasicBlock, string>();
+            new Dictionary<BasicBlock, string>(new BasicBlock.Comparer());
         private readonly string labelPrefix;
 
         private StringBuilder prefixBuilder = new StringBuilder();
@@ -439,7 +439,8 @@ namespace ILGPU.Backends.OpenCL
                 blockLookup.Add(block, DeclareLabel());
 
             // Find all phi nodes, allocate target registers and setup internal mapping
-            var phiMapping = new Dictionary<BasicBlock, List<Variable>>();
+            var phiMapping = new Dictionary<BasicBlock, List<Variable>>(
+                new BasicBlock.Comparer());
             var dominators = Method.Blocks.CreateDominators();
             var phiBindings = PhiBindings.Create(
                 blocks,

--- a/Src/ILGPU/Backends/PTX/PTXCodeGenerator.cs
+++ b/Src/ILGPU/Backends/PTX/PTXCodeGenerator.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2018-2023 ILGPU Project
+//                        Copyright (c) 2018-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: PTXCodeGenerator.cs
@@ -286,7 +286,8 @@ namespace ILGPU.Backends.PTX
         #region Instance
 
         private int labelCounter;
-        private readonly Dictionary<BasicBlock, string> blockLookup = new();
+        private readonly Dictionary<BasicBlock, string> blockLookup = new(
+            new BasicBlock.Comparer());
 
         private readonly Dictionary<(Encoding, string), string> stringConstants = new();
         private readonly PhiBindings phiBindings;

--- a/Src/ILGPU/Backends/Velocity/VelocityCodeGenerator.cs
+++ b/Src/ILGPU/Backends/Velocity/VelocityCodeGenerator.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2022-2023 ILGPU Project
+//                        Copyright (c) 2022-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: VelocityCodeGenerator.cs
@@ -96,7 +96,8 @@ namespace ILGPU.Backends.Velocity
         /// <summary>
         /// Maps blocks to labels.
         /// </summary>
-        private readonly Dictionary<BasicBlock, ILLabel> blockLookup = new();
+        private readonly Dictionary<BasicBlock, ILLabel> blockLookup =
+            new(new BasicBlock.Comparer());
 
         /// <summary>
         /// The masks analysis holding information about the masks being required.

--- a/Src/ILGPU/Frontend/Block.CFGBuilder.cs
+++ b/Src/ILGPU/Frontend/Block.CFGBuilder.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2018-2023 ILGPU Project
+//                        Copyright (c) 2018-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Block.CFGBuilder.cs
@@ -71,7 +71,7 @@ namespace ILGPU.Frontend
             private readonly Dictionary<int, Block> blockMapping =
                 new Dictionary<int, Block>();
             private readonly Dictionary<BasicBlock, Block> basicBlockMapping =
-                new Dictionary<BasicBlock, Block>();
+                new Dictionary<BasicBlock, Block>(new BasicBlock.Comparer());
             private readonly Dictionary<Block, List<Block>> successorMapping =
                 new Dictionary<Block, List<Block>>();
 

--- a/Src/ILGPU/IR/Analyses/Loops.cs
+++ b/Src/ILGPU/IR/Analyses/Loops.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2020-2023 ILGPU Project
+//                        Copyright (c) 2020-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Loops.cs
@@ -757,8 +757,8 @@ namespace ILGPU.IR.Analyses
             // Initialize all lists and sets
             var headers = InlineList<BasicBlock>.Create(2);
             var breakers = InlineList<BasicBlock>.Create(2);
-            var entryBlocks = new HashSet<BasicBlock>();
-            var exitBlocks = new HashSet<BasicBlock>();
+            var entryBlocks = new HashSet<BasicBlock>(new BasicBlock.Comparer());
+            var exitBlocks = new HashSet<BasicBlock>(new BasicBlock.Comparer());
 
             // Gather all loop entries and exists
             foreach (var member in members)

--- a/Src/ILGPU/IR/BasicBlockCollection.cs
+++ b/Src/ILGPU/IR/BasicBlockCollection.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2020-2023 ILGPU Project
+//                        Copyright (c) 2020-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: BasicBlockCollection.cs
@@ -339,7 +339,7 @@ namespace ILGPU.IR
         public readonly HashSet<BasicBlock> ToSet<TPredicate>(TPredicate predicate)
             where TPredicate : InlineList.IPredicate<BasicBlock>
         {
-            var result = new HashSet<BasicBlock>();
+            var result = new HashSet<BasicBlock>(new BasicBlock.Comparer());
             foreach (var block in this)
             {
                 if (predicate.Apply(block))

--- a/Src/ILGPU/IR/BasicBlockMapping.cs
+++ b/Src/ILGPU/IR/BasicBlockMapping.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2020-2023 ILGPU Project
+//                        Copyright (c) 2020-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: BasicBlockMapping.cs
@@ -746,7 +746,7 @@ namespace ILGPU.IR
 
         /// <summary cref="InitBlockSet"/>
         [MemberNotNull(nameof(blockSet))]
-        partial void InitBlockSet() => blockSet = new HashSet<BasicBlock>();
+        partial void InitBlockSet() => blockSet = new(new BasicBlock.Comparer());
 
         #endregion
 
@@ -785,7 +785,8 @@ namespace ILGPU.IR
 
         /// <summary cref="InitBlockMap"/>
         [MemberNotNull(nameof(blockMap))]
-        partial void InitBlockMap() => blockMap = new Dictionary<BasicBlock, T>();
+        partial void InitBlockMap() => blockMap =
+            new Dictionary<BasicBlock, T>(new BasicBlock.Comparer());
 
         #endregion
 

--- a/Src/ILGPU/IR/Verifier.cs
+++ b/Src/ILGPU/IR/Verifier.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2020-2023 ILGPU Project
+//                        Copyright (c) 2020-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Verifier.cs
@@ -184,11 +184,11 @@ namespace ILGPU.IR
             private readonly List<BasicBlock> blocksInRpo =
                 new List<BasicBlock>();
             private readonly HashSet<BasicBlock> containedBlocks =
-                new HashSet<BasicBlock>();
+                new(new BasicBlock.Comparer());
             private readonly Dictionary<BasicBlock, HashSet<BasicBlock>> predecessors =
-                new Dictionary<BasicBlock, HashSet<BasicBlock>>();
+                new(new BasicBlock.Comparer());
             private readonly Dictionary<BasicBlock, HashSet<BasicBlock>> successors =
-                new Dictionary<BasicBlock, HashSet<BasicBlock>>();
+                new(new BasicBlock.Comparer());
 
             /// <summary>
             /// Constructs a new control-flow verifier.
@@ -204,15 +204,15 @@ namespace ILGPU.IR
             #region Methods
 
             /// <summary>
-            /// Creates new predecessor and successor ink sets.
+            /// Creates new predecessor and successor link sets.
             /// </summary>
             /// <param name="block">The current block.</param>
             private void CreateLinkSets(BasicBlock block)
             {
                 if (!predecessors.ContainsKey(block))
-                    predecessors.Add(block, new HashSet<BasicBlock>());
+                    predecessors.Add(block, new(new BasicBlock.Comparer()));
                 if (!successors.ContainsKey(block))
-                    successors.Add(block, new HashSet<BasicBlock>());
+                    successors.Add(block, new(new BasicBlock.Comparer()));
             }
 
             /// <summary>
@@ -325,7 +325,7 @@ namespace ILGPU.IR
 
             private readonly HashSet<Value> values = new HashSet<Value>();
             private readonly Dictionary<BasicBlock, HashSet<Value>> mapping =
-                new Dictionary<BasicBlock, HashSet<Value>>();
+                new Dictionary<BasicBlock, HashSet<Value>>(new BasicBlock.Comparer());
 
             /// <summary>
             /// Constructs a new value verifier.
@@ -465,7 +465,7 @@ namespace ILGPU.IR
                         phiValue.BasicBlock.Predecessors.Length);
 
                     // Verify nodes and sources
-                    var visited = new HashSet<BasicBlock>();
+                    var visited = new HashSet<BasicBlock>(new BasicBlock.Comparer());
                     for (int i = 0, e = phiValue.Nodes.Length; i < e; ++i)
                     {
                         Value value = phiValue.Nodes[i];

--- a/Src/ILGPU/Properties/ILGPU.nuspec.targets
+++ b/Src/ILGPU/Properties/ILGPU.nuspec.targets
@@ -4,7 +4,7 @@
         <PackageVersion>$(Version)</PackageVersion>
 
         <Title>ILGPU</Title>
-        <Copyright>Copyright (c) 2016-2023 ILGPU Project. All rights reserved.</Copyright>
+        <Copyright>Copyright (c) 2016-2024 ILGPU Project. All rights reserved.</Copyright>
         <Company />
         <Authors>Marcel Koester</Authors>
         <Description>ILGPU Just-In-Time Compiler</Description>


### PR DESCRIPTION
Unit tests on MacOS and net8 are failing due to a stack overflow in ControlFlowVerifier.ComputePostOrder. Appears to be an issue with the default implicit comparer for BasicBlock.