### PR TITLE
Fixed regression from environment variables with CodeQL pipeline.

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -74,9 +74,6 @@ jobs:
                      -p:LibrarySamplesTargetFrameworks=$LibrarySamplesTargetFrameworks `
                      -p:LibrarySamplesTargetFrameworksWindows=$LibrarySamplesTargetFrameworksWindows `
                      ${{ matrix.solution }}
-      env:
-        ILGPU_DOTNET_PREVIEW: ${{ matrix.preview }}
-      continue-on-error: ${{ matrix.preview }}
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
Regression introduced in #1132 when adding support for .NET 8.0 SDK. Some unintended changes were commited.

This is causing #1152 and #1153 to fail.