### PR TITLE
Bump unit test nuget packages.

### DIFF
--- a/Src/ILGPU.Algorithms.Tests.CPU/ILGPU.Algorithms.Tests.CPU.csproj
+++ b/Src/ILGPU.Algorithms.Tests.CPU/ILGPU.Algorithms.Tests.CPU.csproj
@@ -25,8 +25,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Src/ILGPU.Algorithms.Tests.Cuda/ILGPU.Algorithms.Tests.Cuda.csproj
+++ b/Src/ILGPU.Algorithms.Tests.Cuda/ILGPU.Algorithms.Tests.Cuda.csproj
@@ -25,8 +25,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Src/ILGPU.Algorithms.Tests.OpenCL/ILGPU.Algorithms.Tests.OpenCL.csproj
+++ b/Src/ILGPU.Algorithms.Tests.OpenCL/ILGPU.Algorithms.Tests.OpenCL.csproj
@@ -25,8 +25,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Src/ILGPU.Algorithms.Tests/ArrayExtensionTests.tt
+++ b/Src/ILGPU.Algorithms.Tests/ArrayExtensionTests.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                   ILGPU Algorithms
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: ArrayExtensionTests.tt/ArrayExtensionTests.cs
@@ -31,8 +31,8 @@ namespace ILGPU.Algorithms.Tests
 
         #region MemberData
 
-        public static TheoryData<object, object> TestDataLength1D =>
-            new TheoryData<object, object>
+        public static TheoryData<object, int> TestDataLength1D =>
+            new TheoryData<object, int>
         {
 <#
         // TODO: Ignoring Half type, otherwise XUnit complains about an
@@ -50,8 +50,8 @@ namespace ILGPU.Algorithms.Tests
 #>
         };
 
-        public static TheoryData<object, object, object> TestDataLength2D =>
-            new TheoryData<object, object, object>
+        public static TheoryData<object, int, int> TestDataLength2D =>
+            new TheoryData<object, int, int>
         {
 <#
         foreach (var type in types) {
@@ -64,8 +64,8 @@ namespace ILGPU.Algorithms.Tests
 #>
         };
 
-        public static TheoryData<object, object, object, object> TestDataLength3D =>
-            new TheoryData<object, object, object, object>
+        public static TheoryData<object, int, int, int> TestDataLength3D =>
+            new TheoryData<object, int, int, int>
         {
 <#
         foreach (var type in types) {

--- a/Src/ILGPU.Algorithms.Tests/GroupExtensionTests.tt
+++ b/Src/ILGPU.Algorithms.Tests/GroupExtensionTests.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                   ILGPU Algorithms
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: GroupExtensionTests.tt/GroupExtensionTests.cs
@@ -62,9 +62,9 @@ namespace ILGPU.Algorithms.Tests
 <#
         foreach (var srOp in ScanReduceOperations) {
 #>
-        public static TheoryData< object, object, object, object, object, object>
+        public static TheoryData< object, object, object, object, object, int>
             <#= srOp.Name #>TestData =>
-            new TheoryData< object, object, object, object, object, object>
+            new TheoryData< object, object, object, object, object, int>
         {
             // Type, ScanReduceOperation, Sequencer, Start of Sequence,
             // StepSize of Sequence, Fraction of Size

--- a/Src/ILGPU.Algorithms.Tests/ILGPU.Algorithms.Tests.csproj
+++ b/Src/ILGPU.Algorithms.Tests/ILGPU.Algorithms.Tests.csproj
@@ -30,7 +30,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.1" />
+    <PackageReference Include="xunit" Version="2.6.6" />
     <PackageReference Include="T4.Build" Version="0.2.4" PrivateAssets="All" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>

--- a/Src/ILGPU.Algorithms.Tests/InitializeTests.cs
+++ b/Src/ILGPU.Algorithms.Tests/InitializeTests.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                   ILGPU Algorithms
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: InitializeTests.cs
@@ -24,8 +24,8 @@ namespace ILGPU.Algorithms.Tests
 
         #region MemberData
 
-        public static TheoryData<object, object> SimpleTestData =>
-            new TheoryData<object, object>
+        public static TheoryData<object, int> SimpleTestData =>
+            new TheoryData<object, int>
         {
             { sbyte.MinValue, 1 },
             { byte.MaxValue, 1 },

--- a/Src/ILGPU.Algorithms.Tests/MatrixTests.cs
+++ b/Src/ILGPU.Algorithms.Tests/MatrixTests.cs
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------------------------
 //                                   ILGPU Algorithms
-//                           Copyright (c) 2023 ILGPU Project
+//                        Copyright (c) 2023-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: MatrixTests.cs
@@ -29,8 +29,8 @@ namespace ILGPU.Algorithms.Tests
 
         #region MemberData
 
-        public static TheoryData<object, object, object, object, object> DimensionsData =>
-            new TheoryData<object, object, object, object, object>
+        public static TheoryData<int, int, int, int, float> DimensionsData =>
+            new TheoryData<int, int, int, int, float>
             {
                 { 39, 42, 17, 2918291, 0.8f },
                 { 39, 42, 17, 2918291, 0.5f },

--- a/Src/ILGPU.Algorithms.Tests/OptimizationTests.cs
+++ b/Src/ILGPU.Algorithms.Tests/OptimizationTests.cs
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------------------------
 //                                   ILGPU Algorithms
-//                           Copyright (c) 2023 ILGPU Project
+//                        Copyright (c) 2023-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: OptimizationTests.cs
@@ -138,7 +138,7 @@ namespace ILGPU.Algorithms.Tests
             TElementType,
             TEvalType,
             TRandom>(
-            OptimizerConfig<TElementType> optimizerConfig,
+            object optimizerConfigObj,
             TFunc function,
             TElementType lower,
             TElementType upper,
@@ -154,11 +154,13 @@ namespace ILGPU.Algorithms.Tests
             where TFunc : struct,
                 IOptimizationFunction<TNumericType, TElementType, TEvalType>
         {
+            var optimizerConfig = (OptimizerConfig<TElementType>)optimizerConfigObj;
+
             // Skip larger problems on the CPU
             Skip.If(
                 Accelerator.AcceleratorType == AcceleratorType.CPU &&
                 optimizerConfig.NumIterations * optimizerConfig.NumParticles > 2048);
-            
+
             const int Seed = 24404699;
             using var pso = new PSO<
                 TNumericType,

--- a/Src/ILGPU.Algorithms.Tests/RadixSortExtensionTests.tt
+++ b/Src/ILGPU.Algorithms.Tests/RadixSortExtensionTests.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                   ILGPU Algorithms
-//                        Copyright (c) 2021-2023 ILGPU Project
+//                        Copyright (c) 2021-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: RadixSortExtensionTests.tt/RadixSortExtensionTests.cs
@@ -34,9 +34,9 @@ namespace ILGPU.Algorithms.Tests
 
         #region MemberData
 
-        public static TheoryData<object, object, object, object, object, object>
+        public static TheoryData<object, object, object, object, object, int>
             AscendingTestData =>
-            new TheoryData<object, object, object, object, object, object>
+            new TheoryData<object, object, object, object, object, int>
         {
             // Type, RadixSortOperation, Sequencer, Start of Sequencer,
             // StepSize of Sequencer, BufferLength
@@ -53,9 +53,9 @@ namespace ILGPU.Algorithms.Tests
 #>
         };
 
-        public static TheoryData<object, object, object, object>
+        public static TheoryData<object, object, object, int>
             AscendingPairsTestData =>
-            new TheoryData<object, object, object, object>
+            new TheoryData<object, object, object, int>
         {
             // Type, RadixSortOperation, Sequencer, Start of Sequencer, BufferLength
 <#
@@ -70,9 +70,9 @@ namespace ILGPU.Algorithms.Tests
 #>
         };
 
-        public static TheoryData<object, object, object, object, object, object>
+        public static TheoryData<object, object, object, object, object, int>
             DescendingTestData =>
-            new TheoryData<object, object, object, object, object, object>
+            new TheoryData<object, object, object, object, object, int>
         {
             // Type, RadixSortOperation, Sequencer, Start of Sequencer,
             // StepSize of Sequencer, BufferLength
@@ -88,9 +88,9 @@ namespace ILGPU.Algorithms.Tests
 #>
         };
 
-        public static TheoryData<object, object, object, object>
+        public static TheoryData<object, object, object, int>
             DescendingPairsTestData =>
-            new TheoryData<object, object, object, object>
+            new TheoryData<object, object, object, int>
         {
             // Type, RadixSortOperation, Sequencer, BufferLength
 <#
@@ -105,9 +105,9 @@ namespace ILGPU.Algorithms.Tests
 #>
         };
 
-        public static TheoryData<object, object, object, object, object, object>
+        public static TheoryData<object, object, object, object, object, int>
             ConstantTestData =>
-            new TheoryData<object, object, object, object, object, object>
+            new TheoryData<object, object, object, object, object, int>
         {
             // Type, RadixSortOperation, Sequencer, Start of Sequencer,
             // StepSize of Sequencer, BufferLength
@@ -434,10 +434,10 @@ namespace ILGPU.Algorithms.Tests
 
     partial class WarpExtensionTests
     {
-        public static TheoryData<object, object, object, object, object, object>
+        public static TheoryData<object, object, object, object, object, int>
             AscendingTestData => RadixSortExtensionTests.AscendingTestData;
 
-        public static TheoryData<object, object, object, object, object, object>
+        public static TheoryData<object, object, object, object, object, int>
             DescendingTestData => RadixSortExtensionTests.DescendingTestData;
 
         internal static void WarpWideRadixSort<T, TRadixSortOperation>(
@@ -561,10 +561,10 @@ namespace ILGPU.Algorithms.Tests
 
     partial class GroupExtensionTests
     {
-        public static TheoryData<object, object, object, object, object, object>
+        public static TheoryData<object, object, object, object, object, int>
             AscendingTestData => RadixSortExtensionTests.AscendingTestData;
 
-        public static TheoryData<object, object, object, object, object, object>
+        public static TheoryData<object, object, object, object, object, int>
             DescendingTestData => RadixSortExtensionTests.DescendingTestData;
 
         internal static void GroupWideRadixSort<T, TRadixSortOperation>(

--- a/Src/ILGPU.Algorithms.Tests/RandomTests.tt
+++ b/Src/ILGPU.Algorithms.Tests/RandomTests.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                   ILGPU Algorithms
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: RandomTests.tt/RandomTests.cs
@@ -49,8 +49,8 @@ namespace ILGPU.Algorithms.Tests
             : base(output, testContext)
         { }
 
-        public static TheoryData<object, object, object> RandomTestData =>
-            new TheoryData<object, object, object>
+        public static TheoryData<object, int, int> RandomTestData =>
+            new TheoryData<object, int, int>
         {
 <# foreach (var rng in rngs) { #>
             { default(<#= rng #>), 1024, 16 },

--- a/Src/ILGPU.Algorithms.Tests/ReductionExtensionTests.tt
+++ b/Src/ILGPU.Algorithms.Tests/ReductionExtensionTests.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                   ILGPU Algorithms
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: ReductionExtensionTests.tt/ReductionExtensionTests.cs
@@ -38,9 +38,9 @@ namespace ILGPU.Algorithms.Tests
 #>
         #region MemberData
 
-        public static TheoryData<object, object, object, object, object, object>
+        public static TheoryData<object, object, object, object, object, int>
             AscendingTestData =>
-            new TheoryData<object, object, object, object, object, object>
+            new TheoryData<object, object, object, object, object, int>
         {
             // Type, IScanReduceOperation, Sequencer, Start of Sequencer,
             // StepSize of Sequencer, BufferLength
@@ -59,9 +59,9 @@ namespace ILGPU.Algorithms.Tests
 #>
         };
 
-        public static TheoryData<object, object, object, object, object, object>
+        public static TheoryData<object, object, object, object, object, int>
             DescendingTestData =>
-            new TheoryData<object, object, object, object, object, object>
+            new TheoryData<object, object, object, object, object, int>
         {
 <#
         foreach (var type in types) {
@@ -78,9 +78,9 @@ namespace ILGPU.Algorithms.Tests
 #>
         };
 
-        public static TheoryData<object, object, object, object, object, object>
+        public static TheoryData<object, object, object, object, object, int>
             ConstantTestData =>
-            new TheoryData<object, object, object, object, object, object>
+            new TheoryData<object, object, object, object, object, int>
         {
 <#
         foreach (var type in types) {

--- a/Src/ILGPU.Algorithms.Tests/ReorderExtensionTests.tt
+++ b/Src/ILGPU.Algorithms.Tests/ReorderExtensionTests.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                   ILGPU Algorithms
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: ReorderExtensionTests.tt/ReorderExtensionTests.cs
@@ -36,9 +36,9 @@ namespace ILGPU.Algorithms.Tests
 
         #region MemberData
 
-        public static TheoryData<object, object, object, object, object, object>
+        public static TheoryData<object, object, object, object, object, int>
             ReorderTestData =>
-            new TheoryData<object, object, object, object, object, object>
+            new TheoryData<object, object, object, object, object, int>
             {
                 // Type, ITransformer, Sequencer, Start of Sequencer,
                 // StepSize of Sequencer, BufferLength
@@ -65,9 +65,9 @@ namespace ILGPU.Algorithms.Tests
 #>
             };
 
-        public static TheoryData<object, object, object, object, object, object, object>
+        public static TheoryData<object, object, object, object, object, object, int>
             ReorderTransformSourceTargetTestData =>
-            new TheoryData<object, object, object, object, object, object, object>
+            new TheoryData<object, object, object, object, object, object, int>
             {
                 // Type1, Type2, ITransformer, Sequencer, Start of Sequencer,
                 // StepSize of Sequencer, BufferLength

--- a/Src/ILGPU.Algorithms.Tests/ScanExtensionTests.tt
+++ b/Src/ILGPU.Algorithms.Tests/ScanExtensionTests.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                   ILGPU Algorithms
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: ScanExtensionTests.tt/ScanExtensionTests.cs
@@ -40,9 +40,9 @@ namespace ILGPU.Algorithms.Tests
 <#
         foreach (var srOp in ScanReduceOperations) {
 #>
-        public static TheoryData<object, object, object, object, object, object>
+        public static TheoryData<object, object, object, object, object, int>
             Ascending<#= srOp.Name #>TestData =>
-            new TheoryData<object, object, object, object, object, object>
+            new TheoryData<object, object, object, object, object, int>
         {
             // Type, IScanReduceOperation, Sequencer, Start of Sequencer,
             // StepSize of Sequencer, BufferSize
@@ -59,9 +59,9 @@ namespace ILGPU.Algorithms.Tests
 #>
         };
 
-        public static TheoryData<object, object, object, object, object, object>
+        public static TheoryData<object, object, object, object, object, int>
             Descending<#= srOp.Name #>TestData =>
-            new TheoryData<object, object, object, object, object, object>
+            new TheoryData<object, object, object, object, object, int>
         {
             // Type, IScanReduceOperation, Sequencer, Start of Sequencer,
             // StepSize of Sequencer, BufferSize
@@ -78,9 +78,9 @@ namespace ILGPU.Algorithms.Tests
 #>
         };
 
-        public static TheoryData<object, object, object, object, object, object>
+        public static TheoryData<object, object, object, object, object, int>
             Constant<#= srOp.Name #>TestData =>
-            new TheoryData<object, object, object, object, object, object>
+            new TheoryData<object, object, object, object, object, int>
         {
             // Type, IScanReduceOperation, Sequencer, Start of Sequencer,
             // StepSize of Sequencer, BufferSize

--- a/Src/ILGPU.Algorithms.Tests/SequencerTests.tt
+++ b/Src/ILGPU.Algorithms.Tests/SequencerTests.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                   ILGPU Algorithms
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: SequencerTests.tt/SequencerTests.cs
@@ -38,8 +38,8 @@ namespace ILGPU.Algorithms.Tests
 
         #region MemberData
 
-        public static TheoryData<object> TestDataLength =>
-            new TheoryData<object>
+        public static TheoryData<int> TestDataLength =>
+            new TheoryData<int>
         {
 <#
         foreach (var size in ArraySizes) {

--- a/Src/ILGPU.Algorithms.Tests/TransformerExtensionTests.tt
+++ b/Src/ILGPU.Algorithms.Tests/TransformerExtensionTests.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                   ILGPU Algorithms
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: TransformerExtensionTests.tt/TransformerExtensionTests.cs
@@ -33,8 +33,8 @@ namespace ILGPU.Algorithms.Tests
 
         #region MemberData
 
-        public static TheoryData<object> TestDataLength =>
-            new TheoryData<object>
+        public static TheoryData<int> TestDataLength =>
+            new TheoryData<int>
         {
 <#
             foreach (var size in ArraySizes) {
@@ -45,8 +45,8 @@ namespace ILGPU.Algorithms.Tests
 #>
         };
 
-        public static TheoryData<object, object, object> CastFromIndex1TestData =>
-            new TheoryData<object, object, object>
+        public static TheoryData<object, object, int> CastFromIndex1TestData =>
+            new TheoryData<object, object, int>
         {
 <#
         var types = AtomicNumericTypes;

--- a/Src/ILGPU.Algorithms.Tests/VectorTests.cs
+++ b/Src/ILGPU.Algorithms.Tests/VectorTests.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                   ILGPU Algorithms
-//                        Copyright (c) 2021-2023 ILGPU Project
+//                        Copyright (c) 2021-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: VectorTests.cs
@@ -29,8 +29,8 @@ namespace ILGPU.Algorithms.Tests
 
         #region MemberData
 
-        public static TheoryData<object, object> Vector2dTestData =>
-            new TheoryData<object, object>
+        public static TheoryData<int, object> Vector2dTestData =>
+            new TheoryData<int, object>
             {
                 { 1, default(Vector2Zero) },
                 { 32, default(Vector2One) },
@@ -38,8 +38,8 @@ namespace ILGPU.Algorithms.Tests
                 { 128, default(Vector2UnitY) },
             };
 
-        public static TheoryData<object, object> Vector3dTestData =>
-            new TheoryData<object, object>
+        public static TheoryData<int, object> Vector3dTestData =>
+            new TheoryData<int, object>
             {
                 { 1, default(Vector3Zero) },
                 { 32, default(Vector3One) },
@@ -48,8 +48,8 @@ namespace ILGPU.Algorithms.Tests
                 { 65, default(Vector3UnitZ) },
             };
 
-        public static TheoryData<object, object> Vector4dTestData =>
-            new TheoryData<object, object>
+        public static TheoryData<int, object> Vector4dTestData =>
+            new TheoryData<int, object>
             {
                 { 1, default(Vector4Zero) },
                 { 32, default(Vector4One) },

--- a/Src/ILGPU.Algorithms.Tests/WarpExtensionTests.tt
+++ b/Src/ILGPU.Algorithms.Tests/WarpExtensionTests.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                   ILGPU Algorithms
-//                        Copyright (c) 2021-2022 ILGPU Project
+//                        Copyright (c) 2021-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: WarpExtensionTests.tt/WarpExtensionTests.cs
@@ -63,9 +63,9 @@ namespace ILGPU.Algorithms.Tests
 <#
         foreach (var srOp in ScanReduceOperations) {
 #>
-        public static TheoryData<object, object, object, object, object, object>
+        public static TheoryData<object, object, object, object, object, int>
             <#= srOp.Name #>TestData =>
-            new TheoryData<object, object, object, object, object, object>
+            new TheoryData<object, object, object, object, object, int>
         {
             // Type, ScanReduceOperation, Sequencer, Start of Sequence,
             // StepSize of Sequence, Fraction of Size

--- a/Src/ILGPU.Analyzers.Tests/ILGPU.Analyzers.Tests.csproj
+++ b/Src/ILGPU.Analyzers.Tests/ILGPU.Analyzers.Tests.csproj
@@ -6,17 +6,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="Verify.SourceGenerators" Version="2.1.0" />
-    <PackageReference Include="Verify.Xunit" Version="19.12.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Verify.SourceGenerators" Version="2.2.0" />
+    <PackageReference Include="Verify.Xunit" Version="23.0.1" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Src/ILGPU.Analyzers.Tests/InterleaveFields.cs
+++ b/Src/ILGPU.Analyzers.Tests/InterleaveFields.cs
@@ -18,7 +18,6 @@ using VerifyCS =
 
 namespace ILGPU.Analyzers.Tests
 {
-    [UsesVerify]
     public class InterleaveFields
     {
         [Fact]

--- a/Src/ILGPU.Analyzers.Tests/Snapshots/InterleaveFields.NestedNamespaceClassNotPartial.verified.txt
+++ b/Src/ILGPU.Analyzers.Tests/Snapshots/InterleaveFields.NestedNamespaceClassNotPartial.verified.txt
@@ -6,8 +6,6 @@
       Severity: Error,
       WarningLevel: 0,
       Location: : (5,10)-(5,15),
-      Description: ,
-      HelpLink: ,
       MessageFormat: The type '{0}' containing '{1}' must be partial,
       Message: The type 'Gamma' containing 'MyPoint4' must be partial,
       Category: Usage

--- a/Src/ILGPU.Analyzers.Tests/Snapshots/InterleaveFields.SimpleNotPartial.verified.txt
+++ b/Src/ILGPU.Analyzers.Tests/Snapshots/InterleaveFields.SimpleNotPartial.verified.txt
@@ -6,8 +6,6 @@
       Severity: Error,
       WarningLevel: 0,
       Location: : (10,7)-(10,15),
-      Description: ,
-      HelpLink: ,
       MessageFormat: The struct '{0}' must be partial,
       Message: The struct 'MyPoint4' must be partial,
       Category: Usage

--- a/Src/ILGPU.Analyzers/ILGPU.Analyzers.csproj
+++ b/Src/ILGPU.Analyzers/ILGPU.Analyzers.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>-->
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
   </ItemGroup>
 

--- a/Src/ILGPU.Tests.CPU/ILGPU.Tests.CPU.csproj
+++ b/Src/ILGPU.Tests.CPU/ILGPU.Tests.CPU.csproj
@@ -17,8 +17,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Src/ILGPU.Tests.Cuda/ILGPU.Tests.Cuda.csproj
+++ b/Src/ILGPU.Tests.Cuda/ILGPU.Tests.Cuda.csproj
@@ -16,8 +16,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Src/ILGPU.Tests.OpenCL/ILGPU.Tests.OpenCL.csproj
+++ b/Src/ILGPU.Tests.OpenCL/ILGPU.Tests.OpenCL.csproj
@@ -16,8 +16,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Src/ILGPU.Tests.Velocity/ILGPU.Tests.Velocity.csproj
+++ b/Src/ILGPU.Tests.Velocity/ILGPU.Tests.Velocity.csproj
@@ -16,8 +16,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Src/ILGPU.Tests/ArrayViews.cs
+++ b/Src/ILGPU.Tests/ArrayViews.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: ArrayViews.cs
@@ -863,8 +863,8 @@ namespace ILGPU.Tests
             }
         }
 
-        public static TheoryData<object, object> AlignToData =>
-            new TheoryData<object, object>
+        public static TheoryData<int, object> AlignToData =>
+            new TheoryData<int, object>
             {
                 { 8, int.MaxValue },
                 { 16, int.MaxValue },

--- a/Src/ILGPU.Tests/CompareFloatOperations.tt
+++ b/Src/ILGPU.Tests/CompareFloatOperations.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2021-2023 ILGPU Project
+//                        Copyright (c) 2021-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: CompareFloatOperations.tt/CompareFloatOperations.cs
@@ -74,8 +74,9 @@ namespace ILGPU.Tests
             c[index] = result ? 1 : 0;
         }
 
-        public static TheoryData<object, object> <#= testName #>Data =>
-            new TheoryData<object, object>
+        public static TheoryData<<#= type.Type #>, <#= type.Type #>>
+            <#= testName #>Data =>
+            new TheoryData<<#= type.Type #>, <#= type.Type #>>
             {
 <#          foreach (var range in floatRanges) { #>
 <#              foreach (var range2 in floatRanges) { #>

--- a/Src/ILGPU.Tests/ILGPU.Tests.csproj
+++ b/Src/ILGPU.Tests/ILGPU.Tests.csproj
@@ -34,7 +34,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.1" />
+    <PackageReference Include="xunit" Version="2.6.6" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     <PackageReference Include="T4.Build" Version="0.2.4" PrivateAssets="All" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />

--- a/Src/ILGPU.Tests/PageLockedMemory.cs
+++ b/Src/ILGPU.Tests/PageLockedMemory.cs
@@ -25,7 +25,7 @@ namespace ILGPU.Tests
 
         private const int Length = 1024;
 
-        public static TheoryData<object> Numbers => new TheoryData<object>
+        public static TheoryData<long> Numbers => new TheoryData<long>
         {
             { 10 },
             { -10 },

--- a/Src/ILGPU.Tests/UnaryFloatOperations.cs
+++ b/Src/ILGPU.Tests/UnaryFloatOperations.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2021-2023 ILGPU Project
+//                        Copyright (c) 2021-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: UnaryFloatOperations.cs
@@ -23,12 +23,12 @@ namespace ILGPU.Tests
             : base(output, testContext)
         { }
 
-        public static TheoryData<object, object, object, object, object> HalfData =>
-            new TheoryData<object, object, object, object, object>
+        public static TheoryData<Half, bool, bool, bool, bool> HalfData =>
+            new TheoryData<Half, bool, bool, bool, bool>
         {
             { Half.PositiveInfinity, false, false, true, false },
             { Half.NegativeInfinity, false, false, false, true },
-            { 0.0f, true, false, false, false },
+            { Half.Zero, true, false, false, false },
             { Half.MaxValue, true, false, false, false },
             { Half.MinValue, true, false, false, false },
             { Half.NaN, false, true, false, false },


### PR DESCRIPTION
Updates the nuget packages related to unit tests.

Combines #1128, #1129, #1152, #1153 and #1156.

There was a breaking change with xUnit, and TheoryData is now stricter in enforcing the correct types.