### PR TITLE
Lifecycle of IntrinsicProvider

### DIFF
--- a/Src/ILGPU.Tests/Generic/TestBase.cs
+++ b/Src/ILGPU.Tests/Generic/TestBase.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2021-2023 ILGPU Project
+//                        Copyright (c) 2021-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: TestBase.cs

--- a/Src/ILGPU.Tests/Generic/TestBase.cs
+++ b/Src/ILGPU.Tests/Generic/TestBase.cs
@@ -142,7 +142,7 @@ namespace ILGPU.Tests
             using var stream = Accelerator.CreateStream();
 
             // Compile kernel manually and load the compiled kernel into the accelerator
-            var backend = Accelerator.GetBackend();
+            using var backend = Accelerator.GetBackend();
             Output.WriteLine($"Compiling '{kernel.Name}'");
             var entryPoint = typeof(TIndex) == typeof(KernelConfig)
                 ? EntryPointDescription.FromExplicitlyGroupedKernel(kernel)

--- a/Src/ILGPU/Backends/Backend.cs
+++ b/Src/ILGPU/Backends/Backend.cs
@@ -877,12 +877,14 @@ namespace ILGPU.Backends
         #region IDisposable
 
         /// <summary cref="DisposeBase.Dispose(bool)"/>
-        protected override void Dispose(bool disposing)
+        protected override void Dispose(bool disposing) => base.Dispose(disposing);
+        /*
         {
             if (disposing)
                 IntrinsicProvider.Dispose();
             base.Dispose(disposing);
         }
+        */
 
         #endregion
     }

--- a/Src/ILGPU/Backends/Backend.cs
+++ b/Src/ILGPU/Backends/Backend.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2017-2023 ILGPU Project
+//                        Copyright (c) 2017-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Backend.cs


### PR DESCRIPTION
Marcel, 

I am of the opinion that Backend is not on the same lifecycle as IntrinsicProvider and the IntrinsicProvider should not be dispose of the IntrinsicProvider. This said,  I do not know the original intension of the relationship between Backend and IntrinsicProvider. 