### PR TITLE
remove using on Accelerator.LoadKernel()

### DIFF
--- a/Src/ILGPU.Tests/Generic/TestBase.cs
+++ b/Src/ILGPU.Tests/Generic/TestBase.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2021-2023 ILGPU Project
+//                        Copyright (c) 2021-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: TestBase.cs
@@ -164,7 +164,7 @@ namespace ILGPU.Tests
 
             // Load the compiled kernel
             Output.WriteLine($"Loading '{kernel.Name}'");
-            using var acceleratorKernel = Accelerator.LoadKernel(compiled);
+            var acceleratorKernel = Accelerator.LoadKernel(compiled);
 
             // Launch the kernel
             Output.WriteLine($"Launching '{kernel.Name}'");


### PR DESCRIPTION
Marcel - Here is the requested life cycle fix removing the using from "using var acceleratorKernel = Accelerator.LoadKernel(compiled);" I could not figure out how to roll back backend.cs in the other pull request, so I created a new pull request.