### PR TITLE
Bump Microsoft.CodeAnalysis.CSharp from 4.8.0 to 4.9.2

### DIFF
--- a/Src/ILGPU.Analyzers.Tests/ILGPU.Analyzers.Tests.csproj
+++ b/Src/ILGPU.Analyzers.Tests/ILGPU.Analyzers.Tests.csproj
@@ -10,7 +10,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Verify.SourceGenerators" Version="2.2.0" />
     <PackageReference Include="Verify.Xunit" Version="23.0.1" />

--- a/Src/ILGPU.Analyzers/ILGPU.Analyzers.csproj
+++ b/Src/ILGPU.Analyzers/ILGPU.Analyzers.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>-->
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
   </ItemGroup>
 


### PR DESCRIPTION
Replaces #1171.