### PR TITLE
Added DLL resolver for Cuda on WSL.

### DIFF
--- a/Src/ILGPU/Runtime/Cuda/CudaContextExtensions.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaContextExtensions.cs
@@ -113,6 +113,11 @@ namespace ILGPU.Runtime.Cuda
         #region Windows Subsystem for Linux
 
         /// <summary>
+        /// The base directory where WSL is expected to be installed.
+        /// </summary>
+        private const string WslLibaryBasePath = "/usr/lib/wsl/lib";
+
+        /// <summary>
         /// Detects if we are running on WSL.
         /// </summary>
         [SuppressMessage(
@@ -123,10 +128,11 @@ namespace ILGPU.Runtime.Cuda
         {
             try
             {
-                return RuntimeInformation.IsOSPlatform(OSPlatform.Linux) &&
-                    File.ReadAllText("/proc/version").Contains(
+                return RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+                    && File.ReadAllText("/proc/version").Contains(
                         "Microsoft",
-                        StringComparison.OrdinalIgnoreCase);
+                        StringComparison.OrdinalIgnoreCase)
+                    && Directory.Exists(WslLibaryBasePath);
             }
             catch (Exception)
             {
@@ -164,7 +170,7 @@ namespace ILGPU.Runtime.Cuda
             foreach (var (prefix, suffix) in WslLibraryCombinations)
             {
                 var filename = $"{prefix}{libraryName}{suffix}";
-                var libraryPath = Path.Combine("/usr/lib/wsl/lib", filename);
+                var libraryPath = Path.Combine(WslLibaryBasePath, filename);
 
                 if (NativeLibrary.TryLoad(libraryPath, out var handle))
                     return handle;


### PR DESCRIPTION
Fixes #1008.

The Cuda WSL library is not added to the environment path (by default).
https://docs.nvidia.com/cuda/wsl-user-guide/index.html#known-limitations-for-linux-cuda-applications

This PR adds a custom DLL resolver for the Cuda DLL, when running on WSL.
