### PR TITLE
Fixed association of FixedInts.tt/cs in project file.

### DIFF
--- a/Src/ILGPU.Algorithms/ILGPU.Algorithms.csproj
+++ b/Src/ILGPU.Algorithms/ILGPU.Algorithms.csproj
@@ -242,11 +242,11 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>ComparisonOperations.tt</DependentUpon>
     </Compile>
-    <None Update="FixedPrecision\FixedInts.cs">
+    <Compile Update="FixedPrecision\FixedInts.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
       <DependentUpon>FixedInts.tt</DependentUpon>
-    </None>
+    </Compile>
     <Compile Update="HistogramLaunchers.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>


### PR DESCRIPTION
In Visual Studio, the CS file was not shown as a child of the TT file.