### PR TITLE
Fixed OpenCL printf newline output.

### DIFF
--- a/Src/ILGPU/IR/Values/IOValues.cs
+++ b/Src/ILGPU/IR/Values/IOValues.cs
@@ -310,11 +310,16 @@ namespace ILGPU.IR.Values
         /// </summary>
         public string ToEscapedPrintFExpression() =>
             ToPrintFExpression()
+            // Replace backslash before others, so that we do not double-escape.
+            .Replace("\\", @"\\", StringComparison.Ordinal)
+            // On Unix, replaces NewLine of \n with an escaped \n.
+            // On Windows, replaces NewLine of \r\n with an escaped \n.
+            // The printf call expects \n, and will translate to the appropriate newline.
+            .Replace(Environment.NewLine, @"\n", StringComparison.Ordinal)
             .Replace("\t", @"\t", StringComparison.Ordinal)
             .Replace("\r", @"\r", StringComparison.Ordinal)
             .Replace("\n", @"\n", StringComparison.Ordinal)
-            .Replace("\"", "\\\"", StringComparison.Ordinal)
-            .Replace("\\", @"\\", StringComparison.Ordinal);
+            .Replace("\"", "\\\"", StringComparison.Ordinal);
 
         #endregion
 


### PR DESCRIPTION
The `Interop.WriteLine` output on Windows OpenCL was always less than desirable - showing "\r\n" in the output instead of a newline. We suspected this was an OpenCL driver issue.

![image](https://github.com/m4rs-mt/ILGPU/assets/27792737/40820766-89b7-45bf-9652-f32b650f8337)

This PR fixes the output by addressing two issues.

The first issue is that escaping `\` was the last step, which incorrectly double-escaped all previous escapes.

The second issue is that `\r\n` is a Windows convention, but C-printf normally uses just `\n`. The underlying C-printf implementation then converts `\n` to `\r\n` on Windows devices. To handle this, we use `Environment.NewLine` to deal with whether we are running on Windows or Unix. Without converting `\r\n` as a single translation, my OpenCL implementation would translate `\r` to "r", and then `\n` to a newline.

The fixed output now looks correct:
![image](https://github.com/m4rs-mt/ILGPU/assets/27792737/25ef813c-46bc-46d8-a646-1daf8db52872)
