### PR TITLE
Updated NVVM to support Cuda SDK v8.

### DIFF
--- a/Src/ILGPU/Context.Builder.cs
+++ b/Src/ILGPU/Context.Builder.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2021-2023 ILGPU Project
+//                        Copyright (c) 2021-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Context.Builder.cs
@@ -345,7 +345,7 @@ namespace ILGPU
                 var nvvmBinDir = Path.Combine(nvvmRoot, nvvmBinName);
                 var nvvmSearchPattern =
                     RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                    ? "nvvm*.dll"
+                    ? "nvvm64*.dll"
                     : "libnvvm*.so";
                 var nvvmFiles = Directory.EnumerateFiles(nvvmBinDir, nvvmSearchPattern);
                 LibNvvmPath = nvvmFiles.FirstOrDefault()

--- a/Src/ILGPU/Runtime/Cuda/NvvmAPI.cs
+++ b/Src/ILGPU/Runtime/Cuda/NvvmAPI.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2021-2023 ILGPU Project
+//                        Copyright (c) 2021-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: NvvmAPI.cs
@@ -138,7 +138,7 @@ namespace ILGPU.Runtime.Cuda
         private readonly NvvmCreateProgram nvvmCreateProgram;
         private readonly NvvmDestroyProgram nvvmDestroyProgram;
         private readonly NvvmAddModuleToProgram nvvmAddModuleToProgram;
-        private readonly NvvmLazyAddModuleToProgram nvvmLazyAddModuleToProgram;
+        private readonly NvvmLazyAddModuleToProgram? nvvmLazyAddModuleToProgram;
         private readonly NvvmCompileProgram nvvmCompileProgram;
         private readonly NvvmVerifyProgram nvvmVerifyProgram;
         private readonly NvvmGetCompiledResultSize nvvmGetCompiledResultSize;
@@ -183,11 +183,6 @@ namespace ILGPU.Runtime.Cuda
                     NativeLibrary.GetExport(
                         libNvvmModule,
                         "nvvmAddModuleToProgram"));
-            nvvmLazyAddModuleToProgram =
-                Marshal.GetDelegateForFunctionPointer<NvvmLazyAddModuleToProgram>(
-                    NativeLibrary.GetExport(
-                        libNvvmModule,
-                        "nvvmLazyAddModuleToProgram"));
             nvvmCompileProgram =
                 Marshal.GetDelegateForFunctionPointer<NvvmCompileProgram>(
                     NativeLibrary.GetExport(
@@ -218,6 +213,16 @@ namespace ILGPU.Runtime.Cuda
                     NativeLibrary.GetExport(
                         libNvvmModule,
                         "nvvmGetProgramLog"));
+
+            if (NativeLibrary.TryGetExport(
+                libNvvmModule,
+                "nvvmLazyAddModuleToProgram",
+                out var nvvmLazyAddModuleToProgramPtr))
+            {
+                nvvmLazyAddModuleToProgram =
+                    Marshal.GetDelegateForFunctionPointer<NvvmLazyAddModuleToProgram>(
+                        nvvmLazyAddModuleToProgramPtr);
+            }
         }
 
         /// <inheritdoc/>
@@ -311,7 +316,9 @@ namespace ILGPU.Runtime.Cuda
             IntPtr buffer,
             IntPtr size,
             string? name) =>
-            nvvmLazyAddModuleToProgram(program, buffer, size, name);
+            nvvmLazyAddModuleToProgram != null
+            ? nvvmLazyAddModuleToProgram(program, buffer, size, name)
+            : nvvmAddModuleToProgram(program, buffer, size, name);
 
         /// <summary>
         /// Compiles the program.


### PR DESCRIPTION
Extracted from #1148.

When LibDevice support was added in #707, it was targeting Cuda SDK v11.

In Cuda SDK v8, there is a conflict in searching for `nvvm*.dll` because the folder contains `nvvm64_31_0.dll` and `nvvm32_31_0.dll`. Updated to use `nvvm64*.dll`, since we only support 64-bit Cuda in ILGPU.

In addition, Cuda SDK v8 does not have an implementation of `nvvmLazyAddModuleToProgram` - this was added in v9. Added a fallback to use the older, non-lazy `nvvmAddModuleToProgram`.