### PR TITLE
Optimized PTX IntrinsicMath implementation to use LibDevice.

### DIFF
--- a/Src/ILGPU.Algorithms/PTX/PTXContext.cs
+++ b/Src/ILGPU.Algorithms/PTX/PTXContext.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                   ILGPU Algorithms
-//                        Copyright (c) 2019-2023 ILGPU Project
+//                        Copyright (c) 2019-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: PTXContext.cs
@@ -46,7 +46,8 @@ namespace ILGPU.Algorithms.PTX
         private static readonly PTXIntrinsic MathCodeGeneratorIntrinsic =
             new PTXIntrinsic(
                 MathCodeGenerator,
-                IntrinsicImplementationMode.GenerateCode)
+                IntrinsicImplementationMode.GenerateCode,
+                libDeviceRequired: false)
             .ThrowIfNull();
 
         /// <summary>
@@ -70,7 +71,8 @@ namespace ILGPU.Algorithms.PTX
                 PTXMathType,
                 nameof(PTXMath.GenerateMathIntrinsic),
                 IntrinsicImplementationMode.GenerateCode,
-                minArchitecture);
+                minArchitecture,
+                libDeviceRequired: false);
 
         /// <summary>
         /// Resolves a PTX intrinsic for the given math-function configuration.
@@ -87,7 +89,10 @@ namespace ILGPU.Algorithms.PTX
                 types,
                 null)
                 .ThrowIfNull();
-            return new PTXIntrinsic(targetMethod, IntrinsicImplementationMode.Redirect);
+            return new PTXIntrinsic(
+                targetMethod,
+                IntrinsicImplementationMode.Redirect,
+                libDeviceRequired: false);
         }
 
         /// <summary>

--- a/Src/ILGPU/Backends/PTX/PTXIntrinsic.cs
+++ b/Src/ILGPU/Backends/PTX/PTXIntrinsic.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2019-2021 ILGPU Project
+//                        Copyright (c) 2019-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: PTXIntrinsic.cs
@@ -51,6 +51,66 @@ namespace ILGPU.Backends.PTX
                   targetMethod,
                   mode)
         { }
+
+        /// <summary>
+        /// Constructs a new PTX intrinsic that can handle all architectures
+        /// newer or equal to <paramref name="minArchitecture"/>.
+        /// </summary>
+        /// <param name="targetMethod">The associated target method.</param>
+        /// <param name="mode">The code-generation mode.</param>
+        /// <param name="minArchitecture">The target/minimum architecture.</param>
+        public PTXIntrinsic(
+            MethodInfo targetMethod,
+            IntrinsicImplementationMode mode,
+            CudaArchitecture minArchitecture)
+            : base(
+                  BackendType.PTX,
+                  targetMethod,
+                  mode)
+        {
+            MinArchitecture = minArchitecture;
+        }
+
+        /// <summary>
+        /// Constructs a new PTX intrinsic.
+        /// </summary>
+        /// <param name="targetMethod">The associated target method.</param>
+        /// <param name="mode">The code-generation mode.</param>
+        /// <param name="minArchitecture">The target/minimum architecture.</param>
+        /// <param name="maxArchitecture">The max architecture (exclusive).</param>
+        public PTXIntrinsic(
+            MethodInfo targetMethod,
+            IntrinsicImplementationMode mode,
+            CudaArchitecture? minArchitecture,
+            CudaArchitecture? maxArchitecture)
+            : base(
+                  BackendType.PTX,
+                  targetMethod,
+                  mode)
+        {
+            MinArchitecture = minArchitecture;
+            MaxArchitecture = maxArchitecture;
+        }
+
+        /// <summary>
+        /// Constructs a new PTX intrinsic.
+        /// </summary>
+        /// <param name="targetMethod">The associated target method.</param>
+        /// <param name="mode">The code-generator mode.</param>
+        /// <param name="libDeviceRequired">
+        /// Indicates whether LibDevice is required.
+        /// </param>
+        public PTXIntrinsic(
+            MethodInfo targetMethod,
+            IntrinsicImplementationMode mode,
+            bool libDeviceRequired)
+            : base(
+                  BackendType.PTX,
+                  targetMethod,
+                  mode)
+        {
+            LibDeviceRequired = libDeviceRequired;
+        }
 
         /// <summary>
         /// Constructs a new PTX intrinsic that can handle all architectures.
@@ -143,6 +203,32 @@ namespace ILGPU.Backends.PTX
             MaxArchitecture = maxArchitecture;
         }
 
+        /// <summary>
+        /// Constructs a new PTX intrinsic.
+        /// </summary>
+        /// <param name="handlerType">The associated target handler type.</param>
+        /// <param name="methodName">The target method name (or null).</param>
+        /// <param name="mode">The code-generator mode.</param>
+        /// <param name="minArchitecture">The target/minimum architecture.</param>
+        /// <param name="libDeviceRequired">
+        /// Indicates whether LibDevice is required.
+        /// </param>
+        public PTXIntrinsic(
+            Type handlerType,
+            string methodName,
+            IntrinsicImplementationMode mode,
+            CudaArchitecture minArchitecture,
+            bool libDeviceRequired)
+            : base(
+                  BackendType.PTX,
+                  handlerType,
+                  methodName,
+                  mode)
+        {
+            MinArchitecture = minArchitecture;
+            LibDeviceRequired = libDeviceRequired;
+        }
+
         #endregion
 
         #region Properties
@@ -164,6 +250,11 @@ namespace ILGPU.Backends.PTX
         /// </remarks>
         public CudaArchitecture? MaxArchitecture { get; }
 
+        /// <summary>
+        /// Returns whether LibDevice is required to use this instrinsic.
+        /// </summary>
+        public bool? LibDeviceRequired { get; }
+
         #endregion
 
         #region Methods
@@ -174,7 +265,9 @@ namespace ILGPU.Backends.PTX
             && (!MinArchitecture.HasValue ||
                 ptxBackend.Architecture >= MinArchitecture.Value)
             && (!MaxArchitecture.HasValue ||
-                    ptxBackend.Architecture < MaxArchitecture.Value);
+                ptxBackend.Architecture < MaxArchitecture.Value)
+            && (!LibDeviceRequired.HasValue ||
+                ptxBackend.NvvmAPI != null == LibDeviceRequired.Value);
 
         #endregion
     }

--- a/Src/ILGPU/Backends/PTX/PTXIntrinsics.Generated.tt
+++ b/Src/ILGPU/Backends/PTX/PTXIntrinsics.Generated.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2016-2021 ILGPU Project
+//                        Copyright (c) 2016-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: PTXIntrinsics.Generated.tt/PTXIntrinsics.Generated.cs
@@ -35,6 +35,61 @@ var fp16Ops = new (string, string, string, string)[]
 
     ("Ternary", "MultiplyAdd", "FmaFP32", "SM_53"),
 };
+
+var unaryMathFunctions = new (string, string, TypeInformation)[]
+{
+    ("AcosF",       "Acos",     FloatTypes[2]),
+    ("AsinF",       "Asin",     FloatTypes[2]),
+    ("AtanF",       "Atan",     FloatTypes[2]),
+    ("CeilingF",    "Ceil",     FloatTypes[2]),
+    ("CosF",        "Cos",      FloatTypes[2]),
+    ("CoshF",       "Cosh",     FloatTypes[2]),
+    ("ExpF",        "Exp",      FloatTypes[2]),
+    ("Exp2F",       "Exp2",     FloatTypes[2]),
+    ("FloorF",      "Floor",    FloatTypes[2]),
+    ("LogF",        "Log",      FloatTypes[2]),
+    ("Log2F",       "Log2",     FloatTypes[2]),
+    ("Log10F",      "Log10",    FloatTypes[2]),
+    ("RsqrtF",      "Rsqrt",    FloatTypes[2]),
+    ("SinF",        "Sin",      FloatTypes[2]),
+    ("SinhF",       "Sinh",     FloatTypes[2]),
+    ("SqrtF",       "Sqrt",     FloatTypes[2]),
+    ("TanF",        "Tan",      FloatTypes[2]),
+    ("TanhF",       "Tanh",     FloatTypes[2]),
+    
+    ("AcosF",       "Acos",     FloatTypes[1]),
+    ("AsinF",       "Asin",     FloatTypes[1]),
+    ("AtanF",       "Atan",     FloatTypes[1]),
+    ("CeilingF",    "Ceil",     FloatTypes[1]),
+    ("CosF",        "Cos",      FloatTypes[1]),
+    ("CoshF",       "Cosh",     FloatTypes[1]),
+    ("ExpF",        "Exp",      FloatTypes[1]),
+    ("Exp2F",       "Exp2",     FloatTypes[1]),
+    ("FloorF",      "Floor",    FloatTypes[1]),
+    ("LogF",        "Log",      FloatTypes[1]),
+    ("Log2F",       "Log2",     FloatTypes[1]),
+    ("Log10F",      "Log10",    FloatTypes[1]),
+    ("RsqrtF",      "Rsqrt",    FloatTypes[1]),
+    ("SinF",        "Sin",      FloatTypes[1]),
+    ("SinhF",       "Sinh",     FloatTypes[1]),
+    ("SqrtF",       "Sqrt",     FloatTypes[1]),
+    ("TanF",        "Tan",      FloatTypes[1]),
+    ("TanhF",       "Tanh",     FloatTypes[1]),
+};
+
+var binaryMathFunctions = new (string, string, string, TypeInformation)[]
+{
+    ("Atan2F",      "Atan", null,                       FloatTypes[2]),
+    ("BinaryLogF",  "Log",  "IntrinsicMath.BinaryLog",  FloatTypes[2]),
+    ("PowF",        "Pow",  null,                       FloatTypes[2]),
+    ("Rem",         "Fmod", null,                       FloatTypes[2]),
+
+    ("Atan2F",      "Atan", null,                       FloatTypes[1]),
+    ("BinaryLogF",  "Log",  "IntrinsicMath.BinaryLog",  FloatTypes[1]),
+    ("PowF",        "Pow",  null,                       FloatTypes[1]),
+    ("Rem",         "Fmod", null,                       FloatTypes[1]),
+};
+
 #>
 using ILGPU.IR.Intrinsics;
 using ILGPU.IR.Values;
@@ -153,6 +208,44 @@ namespace ILGPU.Backends.PTX
                 CreateFP16Intrinsic(
                     nameof(HalfExtensions.<#= name #>),
                     <#= sm != null ? $"CudaArchitecture.{sm}" : "null" #>));
+<# } #>
+        }
+
+        #endregion
+
+        #region Math
+
+        /// <summary>
+        /// Registers all Math intrinsics with the given manager.
+        /// </summary>
+        /// <param name="manager">The target implementation manager.</param>
+        private static void RegisterMathFunctions(IntrinsicImplementationManager manager)
+        {
+<# foreach (var (kind, methodName, type) in unaryMathFunctions) { #>
+            manager.RegisterUnaryArithmetic(
+                UnaryArithmeticKind.<#= kind #>,
+                BasicValueType.<#= type.GetBasicValueType() #>,
+                CreateLibDeviceMathIntrinsic(
+                    nameof(LibDevice.<#= methodName #>),
+                    typeof(<#= type.Type #>)));
+<# } #>
+
+<# foreach (var (kind, methodName, baseClass, type) in binaryMathFunctions) { #>
+            manager.RegisterBinaryArithmetic(
+                BinaryArithmeticKind.<#= kind #>,
+                BasicValueType.<#= type.GetBasicValueType() #>,
+    <# if (baseClass == null) { #>
+                CreateLibDeviceMathIntrinsic(
+                    nameof(LibDevice.<#= methodName #>),
+                    typeof(<#= type.Type #>),
+                    typeof(<#= type.Type #>)));
+    <# } else { #>
+                CreateMathIntrinsic(
+                    typeof(<#= baseClass #>),
+                    nameof(<#= baseClass #>.<#= methodName #>),
+                    typeof(<#= type.Type #>),
+                    typeof(<#= type.Type #>)));
+    <# } #>
 <# } #>
         }
 

--- a/Src/ILGPU/Backends/PTX/PTXIntrinsics.cs
+++ b/Src/ILGPU/Backends/PTX/PTXIntrinsics.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2019-2023 ILGPU Project
+//                        Copyright (c) 2019-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: PTXIntrinsics.cs
@@ -13,7 +13,9 @@ using ILGPU.AtomicOperations;
 using ILGPU.IR.Intrinsics;
 using ILGPU.IR.Values;
 using ILGPU.Runtime.Cuda;
+using ILGPU.Util;
 using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 
 namespace ILGPU.Backends.PTX
@@ -85,6 +87,51 @@ namespace ILGPU.Backends.PTX
             : new PTXIntrinsic(HalfType, name, IntrinsicImplementationMode.Redirect);
 
         /// <summary>
+        /// Creates a PTX intrinsic for the given math function.
+        /// </summary>
+        /// <param name="name">The intrinsic name.</param>
+        /// <param name="types">The parameter types.</param>
+        /// <returns>The resolved intrinsic representation.</returns>
+        private static PTXIntrinsic CreateLibDeviceMathIntrinsic(
+            string name,
+            params Type[] types)
+        {
+            var targetMethod = typeof(LibDevice).GetMethod(
+                name,
+                BindingFlags.Public | BindingFlags.Static,
+                null,
+                types,
+                null)
+                .ThrowIfNull();
+            return new PTXIntrinsic(
+                targetMethod,
+                IntrinsicImplementationMode.Redirect,
+                libDeviceRequired: true);
+        }
+
+        /// <summary>
+        /// Creates a PTX intrinsic for the given math function.
+        /// </summary>
+        /// <param name="baseType">The source type containing the intrinsic.</param>
+        /// <param name="name">The intrinsic name.</param>
+        /// <param name="types">The parameter types.</param>
+        /// <returns>The resolved intrinsic representation.</returns>
+        private static PTXIntrinsic CreateMathIntrinsic(
+            Type baseType,
+            string name,
+            params Type[] types)
+        {
+            var targetMethod = baseType.GetMethod(
+                name,
+                BindingFlags.Public | BindingFlags.Static,
+                null,
+                types,
+                null)
+                .ThrowIfNull();
+            return new PTXIntrinsic(targetMethod, IntrinsicImplementationMode.Redirect);
+        }
+
+        /// <summary>
         /// Registers all PTX intrinsics with the given manager.
         /// </summary>
         /// <param name="manager">The target implementation manager.</param>
@@ -95,6 +142,7 @@ namespace ILGPU.Backends.PTX
             RegisterWarpShuffles(manager);
             RegisterFP16(manager);
             RegisterBitFunctions(manager);
+            RegisterMathFunctions(manager);
         }
 
         #endregion

--- a/Src/ILGPU/Context.Builder.cs
+++ b/Src/ILGPU/Context.Builder.cs
@@ -323,7 +323,16 @@ namespace ILGPU
             /// Automatically detects the CUDA SDK location.
             /// </summary>
             /// <returns>The current builder instance.</returns>
-            public Builder LibDevice()
+            public Builder LibDevice() =>
+                LibDevice(throwIfNotFound: true);
+
+            /// <summary>
+            /// Turns on LibDevice support.
+            /// Automatically detects the CUDA SDK location.
+            /// </summary>
+            /// <param name="throwIfNotFound">Determines error handling.</param>
+            /// <returns>The current builder instance.</returns>
+            internal Builder LibDevice(bool throwIfNotFound)
             {
                 // Find the CUDA installation path.
                 var cudaEnvName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
@@ -332,9 +341,11 @@ namespace ILGPU
                 var cudaPath = Environment.GetEnvironmentVariable(cudaEnvName);
                 if (string.IsNullOrEmpty(cudaPath))
                 {
-                    throw new NotSupportedException(string.Format(
+                    return throwIfNotFound
+                    ? throw new NotSupportedException(string.Format(
                         RuntimeErrorMessages.NotSupportedLibDeviceEnvironmentVariable,
-                        cudaEnvName));
+                        cudaEnvName))
+                    : this;
                 }
                 var nvvmRoot = Path.Combine(cudaPath, "nvvm");
 
@@ -348,21 +359,33 @@ namespace ILGPU
                     ? "nvvm64*.dll"
                     : "libnvvm*.so";
                 var nvvmFiles = Directory.EnumerateFiles(nvvmBinDir, nvvmSearchPattern);
-                LibNvvmPath = nvvmFiles.FirstOrDefault()
-                    ?? throw new NotSupportedException(string.Format(
+                var libNvvmPath = nvvmFiles.FirstOrDefault();
+                if (libNvvmPath == null)
+                {
+                    return throwIfNotFound
+                    ? throw new NotSupportedException(string.Format(
                         RuntimeErrorMessages.NotSupportedLibDeviceNotFoundNvvmDll,
-                        nvvmBinDir));
+                        nvvmBinDir))
+                    : this;
+                }
 
                 // Find the LibDevice Bitcode.
                 var libDeviceDir = Path.Combine(nvvmRoot, "libdevice");
                 var libDeviceFiles = Directory.EnumerateFiles(
                     libDeviceDir,
                     "libdevice.*.bc");
-                LibDevicePath = libDeviceFiles.FirstOrDefault()
-                    ?? throw new NotSupportedException(string.Format(
+                var libDevicePath = libDeviceFiles.FirstOrDefault();
+                if (libDevicePath == null)
+                {
+                    return throwIfNotFound
+                    ? throw new NotSupportedException(string.Format(
                         RuntimeErrorMessages.NotSupportedLibDeviceNotFoundBitCode,
-                        libDeviceDir));
+                        libDeviceDir))
+                    : this;
+                }
 
+                LibNvvmPath = libNvvmPath;
+                LibDevicePath = libDevicePath;
                 return this;
             }
 

--- a/Src/ILGPU/Context.Builder.cs
+++ b/Src/ILGPU/Context.Builder.cs
@@ -360,7 +360,7 @@ namespace ILGPU
                     : "libnvvm*.so";
                 var nvvmFiles = Directory.EnumerateFiles(nvvmBinDir, nvvmSearchPattern);
                 var libNvvmPath = nvvmFiles.FirstOrDefault();
-                if (libNvvmPath == null)
+                if (libNvvmPath is null)
                 {
                     return throwIfNotFound
                     ? throw new NotSupportedException(string.Format(
@@ -375,7 +375,7 @@ namespace ILGPU
                     libDeviceDir,
                     "libdevice.*.bc");
                 var libDevicePath = libDeviceFiles.FirstOrDefault();
-                if (libDevicePath == null)
+                if (libDevicePath is null)
                 {
                     return throwIfNotFound
                     ? throw new NotSupportedException(string.Format(

--- a/Src/ILGPU/Runtime/Cuda/CudaContextExtensions.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaContextExtensions.cs
@@ -87,7 +87,7 @@ namespace ILGPU.Runtime.Cuda
             }
 
             // Silently enable automatic LibDevice detection, if not already configured.
-            if (builder.LibDevicePath == null && builder.LibNvvmPath == null)
+            if (builder.LibDevicePath is null && builder.LibNvvmPath is null)
                 builder.LibDevice(throwIfNotFound: false);
 
             CudaDevice.GetDevices(

--- a/Src/ILGPU/Runtime/Cuda/CudaContextExtensions.cs
+++ b/Src/ILGPU/Runtime/Cuda/CudaContextExtensions.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2021-2023 ILGPU Project
+//                        Copyright (c) 2021-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: CudaContextExtensions.cs
@@ -85,6 +85,10 @@ namespace ILGPU.Runtime.Cuda
                     RuntimeErrorMessages.CudaPlatform64,
                     Backend.RuntimePlatform));
             }
+
+            // Silently enable automatic LibDevice detection, if not already configured.
+            if (builder.LibDevicePath == null && builder.LibNvvmPath == null)
+                builder.LibDevice(throwIfNotFound: false);
 
             CudaDevice.GetDevices(
                 configure,


### PR DESCRIPTION
Extracted from #1148.

Depends on #1187  and #1185.

PTXMath in ILGPU.Algorithms provides a number of math functions using Cordic implemenentations. However, these are considerably slower compared to LibDevice.

Currently, LibDevice methods need to be explicitly called.

This PR automatically tries to initialize LibDevice when the Context is being configured. If found, all the Math intrinsics are redirected to using LibDevice. The Cordic implementation in ILGPU.Algorithms will only activate itself if LibDevice is not available.