### PR TITLE
Disabled assertions on GPU unit tests.

### DIFF
--- a/Src/ILGPU.Tests.CPU/TestContext.cs
+++ b/Src/ILGPU.Tests.CPU/TestContext.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                           Copyright (c) 2021 ILGPU Project
+//                        Copyright (c) 2021-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: TestContext.cs
@@ -58,7 +58,7 @@ namespace ILGPU.Tests.CPU
             Action<Context.Builder> prepareContext)
             : base(
                   optimizationLevel,
-                  builder => prepareContext(builder.CPU(GetCPUDeviceKind())),
+                  builder => prepareContext(builder.CPU(GetCPUDeviceKind()).Assertions()),
                   context => context.CreateCPUAccelerator(0))
         { }
 

--- a/Src/ILGPU.Tests/Generic/TestContext.cs
+++ b/Src/ILGPU.Tests/Generic/TestContext.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2021-2022 ILGPU Project
+//                        Copyright (c) 2021-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: TestContext.cs
@@ -37,7 +37,6 @@ namespace ILGPU.Tests
             Context = Context.Create(builder =>
                 prepareContext(
                     builder
-                    .Assertions()
                     .Arrays(ArrayMode.InlineMutableStaticArrays)
                     .Verify()
                     .Optimize(level)


### PR DESCRIPTION
The CI pipeline of the `v1.5.x` branch is consistently failing on "Cuda, ILGPU.Algorithms, net7.0" with `ILGPU.Runtime.Cuda.CudaException : too many resources requested for launch`.

In #1103 of the `master` branch, it appears that we disabled assertions on GPU devices, for ILGPU.Algorithms.

This PR is a workaround that disables assertions on GPU devices, including for ILGPU.