### PR TITLE
Fixed upper bounds on number of threads in RuntimeTests for MacOS.

### DIFF
--- a/Src/ILGPU.Tests.CPU/RuntimeTests.cs
+++ b/Src/ILGPU.Tests.CPU/RuntimeTests.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2021-2023 ILGPU Project
+//                        Copyright (c) 2021-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: RuntimeTests.cs
@@ -65,7 +65,7 @@ namespace ILGPU.Tests.CPU
             {
                 // Detect the number of processors and check whether we run in a supported
                 // range of tests
-                int maxNumThreads = Environment.ProcessorCount * 768;
+                int maxNumThreads = Environment.ProcessorCount * 256;
                 Skip.If(customDevice.NumThreads > maxNumThreads);
             }
 


### PR DESCRIPTION
This PR fixes MacOS tests failing on new runner hardware.