### PR TITLE
CI: Fix warnings & deprecation messages in the workflows

### DIFF
--- a/.github/workflows/nudge.yml
+++ b/.github/workflows/nudge.yml
@@ -14,6 +14,6 @@ jobs:
     if: (!github.event.repository.fork && !(github.event.workflow_run.name == 'Update Copyright Year' && github.event.workflow_run.event == 'push'))
     steps:
       - name: Send notification
-        uses: pavlovic-ivan/octo-nudge@v1
+        uses: pavlovic-ivan/octo-nudge@v2
         with:
           webhooks: ${{ secrets.NUDGE_WEBHOOKS }}


### PR DESCRIPTION
### What type of PR is this?

CI: Resolve deprecation & warning messages in workflows 
Enable DependaBot for GitHub actions

### What this PR does / why we need it:

Node16 has been out of support since [September 2023](https://github.com/nodejs/Release/#end-of-life-releases). - more info in the [post](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/) 


### Which issue(s) this PR fixes:

Resolves: https://github.com/G-Research/gr-oss/issues/709

------------
## Testing results

🟢 Nudge - https://github.com/gr-oss-devops/ILGPU/actions/runs/9160837291/job/25184386863

__NOTE__

`technote-space/create-pr-action@v2` doesn't have release fix for `node16`, currently it affects only `Update Copyright Year` and `Update Cuda Versions` workflows
