### PR TITLE
Bump Cuda versions.

### DIFF
--- a/Src/ILGPU.Algorithms/Runtime/Cuda/CuBlasMappings.ttinclude
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/CuBlasMappings.ttinclude
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                   ILGPU Algorithms
-//                        Copyright (c) 2020-2023 ILGPU Project
+//                        Copyright (c) 2020-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: CuBlasMappings.ttinclude
@@ -318,15 +318,6 @@ public static readonly string[] Dgmm = new string[]
 };
 
 // Helper
-
-public static IEnumerable<(T, string, string)> GetBlasMapping<T>(params T[] values)
-{
-    for (int i = 0; i < values.Length; ++i)
-    {
-        var (type, elemType) = CuBlasTypes[i];
-        yield return (values[i], type, elemType);
-    }
-}
 
 public static IEnumerable<(string, T, string, string)> GetBlasMapping<T>(
     params (string, T[])[] bindings)

--- a/Src/ILGPU/Static/CudaVersions.xml
+++ b/Src/ILGPU/Static/CudaVersions.xml
@@ -525,4 +525,27 @@
     <Version InstructionSet="8.4" Driver="12.4" Architecture="8.7" />
     <Version InstructionSet="8.4" Driver="12.4" Architecture="8.9" />
     <Version InstructionSet="8.4" Driver="12.4" Architecture="9.0" />
+    <Version InstructionSet="8.5" Driver="12.5" Architecture="1.0" />
+    <Version InstructionSet="8.5" Driver="12.5" Architecture="1.1" />
+    <Version InstructionSet="8.5" Driver="12.5" Architecture="1.2" />
+    <Version InstructionSet="8.5" Driver="12.5" Architecture="1.3" />
+    <Version InstructionSet="8.5" Driver="12.5" Architecture="2.0" />
+    <Version InstructionSet="8.5" Driver="12.5" Architecture="3.0" />
+    <Version InstructionSet="8.5" Driver="12.5" Architecture="3.2" />
+    <Version InstructionSet="8.5" Driver="12.5" Architecture="3.5" />
+    <Version InstructionSet="8.5" Driver="12.5" Architecture="3.7" />
+    <Version InstructionSet="8.5" Driver="12.5" Architecture="5.0" />
+    <Version InstructionSet="8.5" Driver="12.5" Architecture="5.2" />
+    <Version InstructionSet="8.5" Driver="12.5" Architecture="5.3" />
+    <Version InstructionSet="8.5" Driver="12.5" Architecture="6.0" />
+    <Version InstructionSet="8.5" Driver="12.5" Architecture="6.1" />
+    <Version InstructionSet="8.5" Driver="12.5" Architecture="6.2" />
+    <Version InstructionSet="8.5" Driver="12.5" Architecture="7.0" />
+    <Version InstructionSet="8.5" Driver="12.5" Architecture="7.2" />
+    <Version InstructionSet="8.5" Driver="12.5" Architecture="7.5" />
+    <Version InstructionSet="8.5" Driver="12.5" Architecture="8.0" />
+    <Version InstructionSet="8.5" Driver="12.5" Architecture="8.6" />
+    <Version InstructionSet="8.5" Driver="12.5" Architecture="8.7" />
+    <Version InstructionSet="8.5" Driver="12.5" Architecture="8.9" />
+    <Version InstructionSet="8.5" Driver="12.5" Architecture="9.0" />
 </Versions>


### PR DESCRIPTION
Backported #1230 to v1.5.x branch.

Depends on #1233.