### PR TITLE
Remove some Gc holes

### DIFF
--- a/Src/ILGPU.Algorithms/Optimization/CPU/SGOOptimizer.cs
+++ b/Src/ILGPU.Algorithms/Optimization/CPU/SGOOptimizer.cs
@@ -14,6 +14,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 
 #if NET7_0_OR_GREATER
@@ -478,7 +479,7 @@ namespace ILGPU.Algorithms.Optimization.CPU
         {
             ref var baseRef = ref positions.AsSpan().GetItemRef(
                 playerIndex * NumPaddedDimensions);
-            return new Span<T>(Unsafe.AsPointer(ref baseRef), NumPaddedDimensions);
+            return MemoryMarshal.CreateSpan(ref baseRef, NumPaddedDimensions);
         }
 
         /// <summary>
@@ -493,7 +494,7 @@ namespace ILGPU.Algorithms.Optimization.CPU
         {
             ref var baseRef = ref nextPositions.AsSpan().GetItemRef(
                 playerIndex * NumPaddedDimensions);
-            return new Span<T>(Unsafe.AsPointer(ref baseRef), NumPaddedDimensions);
+            return MemoryMarshal.CreateSpan(ref baseRef, NumPaddedDimensions);
         }
 
         /// <summary>

--- a/Src/ILGPU.Algorithms/Vectors/VectorTypes.tt
+++ b/Src/ILGPU.Algorithms/Vectors/VectorTypes.tt
@@ -465,9 +465,9 @@ namespace ILGPU.Algorithms.Vectors
         /// <returns>The readonly span instance.</returns>
         public unsafe ReadOnlySpan<<#= type.Type #>> AsSpan() =>
 #if NET8_0_OR_GREATER
-            new(Unsafe.AsPointer(ref Unsafe.AsRef(in this)), <#= vectorLength #>);
+            MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in this), <#= vectorLength #>);
 #else
-            new(Unsafe.AsPointer(ref Unsafe.AsRef(this)), <#= vectorLength #>);
+            MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(this), <#= vectorLength #>);
 #endif
 
         /// <summary>

--- a/Src/ILGPU/Frontend/InvocationContext.cs
+++ b/Src/ILGPU/Frontend/InvocationContext.cs
@@ -16,7 +16,6 @@ using ILGPU.IR.Values;
 using ILGPU.Util;
 using System;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Text;
 using ValueList = ILGPU.Util.InlineList<ILGPU.IR.Values.ValueReference>;
 
@@ -33,7 +32,7 @@ namespace ILGPU.Frontend
         /// <summary>
         /// The internal arguments pointer.
         /// </summary>
-        private readonly void* argumentsRef;
+        private readonly ref ValueList argumentsRef;
 
         /// <summary>
         /// Constructs a new invocation context.
@@ -58,7 +57,7 @@ namespace ILGPU.Frontend
             CallerMethod = callerMethod;
             Method = method;
 
-            argumentsRef = Unsafe.AsPointer(ref arguments);
+            argumentsRef = ref arguments;
         }
 
         #endregion
@@ -119,7 +118,7 @@ namespace ILGPU.Frontend
         /// Returns the call arguments.
         /// </summary>
         public readonly ref ValueList Arguments =>
-            ref Unsafe.AsRef<ValueList>(argumentsRef);
+            ref argumentsRef;
 
         /// <summary>
         /// Returns the number of arguments.

--- a/Src/ILGPU/Runtime/CPU/CPUMemoryBuffer.cs
+++ b/Src/ILGPU/Runtime/CPU/CPUMemoryBuffer.cs
@@ -72,12 +72,14 @@ namespace ILGPU.Runtime.CPU
             ref byte sourcePtr,
             ref byte targetPtr,
             long sourceLengthInBytes,
-            long targetLengthInBytes) =>
-            Buffer.MemoryCopy(
-                Unsafe.AsPointer(ref sourcePtr),
-                Unsafe.AsPointer(ref targetPtr),
-                sourceLengthInBytes,
-                targetLengthInBytes);
+            long targetLengthInBytes)
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(targetLengthInBytes, sourceLengthInBytes);
+            Unsafe.CopyBlock(
+                ref targetPtr,
+                ref sourcePtr,
+                (uint)sourceLengthInBytes);
+        }
 
         /// <summary>
         /// Copies CPU data (target view) from the given source view.

--- a/Src/ILGPU/Util/Vectors.cs
+++ b/Src/ILGPU/Util/Vectors.cs
@@ -31,10 +31,7 @@ namespace ILGPU.Util
         public static unsafe Vector<T> LoadAlignedVectorUnsafe<T>(
             this ReadOnlySpan<T> source)
             where T : struct
-        {
-            void* sourcePtr = Unsafe.AsPointer(ref MemoryMarshal.GetReference(source));
-            return Unsafe.Read<Vector<T>>(sourcePtr);
-        }
+            => Unsafe.As<T, Vector<T>>(ref MemoryMarshal.GetReference(source));
 
         /// <summary>
         /// Loads a vector (unsafe) from the given span while assuming proper alignment.
@@ -58,9 +55,6 @@ namespace ILGPU.Util
             this Vector<T> value,
             Span<T> target)
             where T : struct
-        {
-            void* targetPtr = Unsafe.AsPointer(ref MemoryMarshal.GetReference(target));
-            Unsafe.Write(targetPtr, value);
-        }
+            => Unsafe.As<T, Vector<T>>(ref MemoryMarshal.GetReference(target)) = value;
     }
 }


### PR DESCRIPTION
Going via Unsafe.AsPointer risks creating Gc holes where the GC has moved the memory but the pointer has not been updates

Use safer alternatives via `ref`