### PR TITLE
Fixed disassembly of Conv_R_Un opcode.

### DIFF
--- a/Src/ILGPU/Frontend/DisassemblerDriver.cs
+++ b/Src/ILGPU/Frontend/DisassemblerDriver.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2018-2021 ILGPU Project
+//                        Copyright (c) 2018-2024 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: DisassemblerDriver.cs
@@ -403,7 +403,7 @@ namespace ILGPU.Frontend
                     AppendInstructionWithFlags(ILInstructionType.Conv, 1, 1, ILInstructionFlags.None, typeof(double));
                     return true;
                 case ILOpCode.Conv_R_Un:
-                    AppendInstructionWithFlags(ILInstructionType.Conv, 1, 1, ILInstructionFlags.Unsigned, typeof(double));
+                    AppendInstructionWithFlags(ILInstructionType.Conv, 1, 1, ILInstructionFlags.Unsigned, typeof(float));
                     return true;
                 case ILOpCode.Conv_U1:
                     AppendInstructionWithFlags(ILInstructionType.Conv, 1, 1, ILInstructionFlags.None, typeof(byte));


### PR DESCRIPTION
Fixes #1309.

Looking at the documentation, it should be a `float` operation rather than `double`.

However @m4rs-mt, I do not understand the last section of the implementation notes. Do we need to do anything special to handle the `float64` case?

`If overflow occurs converting a floating-point type to an integer the result returned is unspecified. The conv.r.un operation takes an integer off the stack, interprets it as unsigned, and replaces it with a floating-point number to represent the integer: either a float32, if this is wide enough to represent the integer without loss of precision, or else a float64.`

Source: https://learn.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.conv_r_un?view=net-8.0