### PR TITLE
Downgrade macOS image to build netcoreapp3.1 and net5.0.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
                 [[ "${{ github.ref }}" =~ "refs/tags/v" ]]
               )
             )
-          ) && os+=("macos-latest")
+          ) && os+=("macos-13")
 
           # Temporarily disabled cuda
           # [ "${{ steps.is-fork.outputs.fork }}" == "false" ] && os+=("cuda")


### PR DESCRIPTION
The ILGPU v1.5.x branch is no longer building on macOS.

Downgraded to an older macOS image to workaround the issue.

We will likely struggle to support netcoreapp3.1 and net5.0 in the future.