### PR TITLE
Enable default interface members

### DIFF
--- a/Src/ILGPU.Tests/DisassemblerTests.cs
+++ b/Src/ILGPU.Tests/DisassemblerTests.cs
@@ -107,7 +107,7 @@ namespace ILGPU.Tests
                 .ThrowIfNull();
             var method = methodInfo.MakeGenericMethod(genericType);
 
-            var disassembler = new Disassembler(method, SequencePointEnumerator.Empty);
+            var disassembler = new Disassembler(new(null, method), SequencePointEnumerator.Empty);
             disassembler.Disassemble();
         }
     }

--- a/Src/ILGPU.Tests/InterfaceTests.cs
+++ b/Src/ILGPU.Tests/InterfaceTests.cs
@@ -1,0 +1,96 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                        ILGPU
+//                           Copyright (c) 2021 ILGPU Project
+//                                    www.ilgpu.net
+//
+// File: InterfaceTests.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details.
+// ---------------------------------------------------------------------------------------
+
+using ILGPU.Runtime;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ILGPU.Tests
+{
+    public abstract class InterfaceTests : TestBase
+    {
+        protected InterfaceTests(ITestOutputHelper output, TestContext testContext) : base(output, testContext) { }
+
+        [Fact]
+        [KernelMethod(nameof(TestKernel2))]
+        public void TestNestedDefaultInterface() {
+            float[] expected = [138f];
+
+            var array = Accelerator.Allocate1D([new TestStruct(2, 67)]);
+            var output = Accelerator.Allocate1D<float>(1);
+
+            var kernel = Accelerator.LoadAutoGroupedStreamKernel((Index1D i, ArrayView<TestStruct> data, ArrayView<float> output) => output[i] = TestKernel2(data[i]));
+            kernel(array.View.IntExtent, array.View, output.View);
+
+            Verify(output.View, expected);
+        }
+
+        [Fact]
+        [KernelMethod(nameof(TestKernel1))]
+        public void TestDefaultInterface() {
+            float[] expected = [34.5f];
+
+            var array = Accelerator.Allocate1D([new TestStruct(2, 67)]);
+            var output = Accelerator.Allocate1D<float>(1);
+
+            var kernel = Accelerator.LoadAutoGroupedStreamKernel((Index1D i, ArrayView<TestStruct> data, ArrayView<float> output) => output[i] = TestKernel1(data[i]));
+            kernel(array.View.IntExtent, array.View, output.View);
+
+            Verify(output.View, expected);
+        }
+
+        [Fact]
+        [KernelMethod(nameof(TestKernel3))]
+        public void TestDefaultInterfaceOverloading() {
+            float[] expected = [69f];
+
+            var array = Accelerator.Allocate1D([new TestStruct2(2, 67)]);
+            var output = Accelerator.Allocate1D<float>(1);
+
+            var kernel = Accelerator.LoadAutoGroupedStreamKernel((Index1D i, ArrayView<TestStruct2> data, ArrayView<float> output) => output[i] = TestKernel3(data[i]));
+            kernel(array.View.IntExtent, array.View, output.View);
+
+            Verify(output.View, expected);
+        }
+
+        private static float TestKernel1<TS>(TS v) where TS : ITestInterface {
+            return v.Center;
+        }
+
+        private static float TestKernel2<TS>(TS v) where TS : ITestInterface {
+            return v.NestedCenterCall;
+        }
+
+        private static float TestKernel3<TS>(TS v) where TS : ITestInterface {
+            return v.Center;
+        }
+
+        public interface ITestInterface {
+            public float Min { get; }
+            public float Max { get; }
+            public float Center => (Min + Max)/2;
+            public float NestedCenterCall {
+                [MethodImpl(MethodImplOptions.NoInlining)]
+                get => Center*4;
+            }
+        }
+
+        public record struct TestStruct(float Min, float Max) : ITestInterface;
+
+        //Demonstrate correct overloading
+        public record struct TestStruct2(float Min, float Max) : ITestInterface {
+            float ITestInterface.Center => Min + Max;
+        }
+    }
+
+}

--- a/Src/ILGPU/Backends/Backend.cs
+++ b/Src/ILGPU/Backends/Backend.cs
@@ -272,13 +272,13 @@ namespace ILGPU.Backends
                     CompiledKernel.FunctionInfo>(Count);
                 functionInfo.Add(new CompiledKernel.FunctionInfo(
                     KernelMethod.Name,
-                    KernelMethod.Source,
+                    KernelMethod.Source.Value.Underlying,
                     KernelAllocas.LocalMemorySize));
                 foreach (var (method, allocas) in this)
                 {
                     functionInfo.Add(new CompiledKernel.FunctionInfo(
                         method.Name,
-                        method.Source,
+                        method.Source.Value.Underlying,
                         allocas.LocalMemorySize));
                 }
                 return new CompiledKernel.KernelInfo(
@@ -597,10 +597,8 @@ namespace ILGPU.Backends
                 var mainContext = codeGenerationPhase.IRContext;
 
                 Frontend.CodeGenerationResult generationResult;
-                using (var frontendPhase = codeGenerationPhase.
-                    BeginFrontendCodeGeneration())
-                {
-                    generationResult = frontendPhase.GenerateCode(entry.MethodSource);
+                using (var frontendPhase = codeGenerationPhase.BeginFrontendCodeGeneration()) {
+                    generationResult = frontendPhase.GenerateCode(new(null, entry.MethodSource));
                 }
 
                 if (codeGenerationPhase.IsFaulted)

--- a/Src/ILGPU/Backends/NotSupportedIntrinsicException.cs
+++ b/Src/ILGPU/Backends/NotSupportedIntrinsicException.cs
@@ -37,8 +37,8 @@ namespace ILGPU.Backends
         /// </param>
         public NotSupportedIntrinsicException(Method intrinsicMethod)
             : this(
-                  intrinsicMethod.HasSource
-                  ? intrinsicMethod.Source.Name
+                  intrinsicMethod.Source != null
+                  ? intrinsicMethod.Source.Value.Underlying.Name
                   : intrinsicMethod.Name)
         { }
 

--- a/Src/ILGPU/Backends/OpenCL/Transformations/CLAcceleratorSpecializer.cs
+++ b/Src/ILGPU/Backends/OpenCL/Transformations/CLAcceleratorSpecializer.cs
@@ -90,7 +90,7 @@ namespace ILGPU.Backends.OpenCL.Transformations
                 expressionString);
 
             // Create a call to the native printf
-            var printFMethod = context.Declare(PrintFMethod, out bool _);
+            var printFMethod = context.Declare(new(null, PrintFMethod), out bool _);
             var callBuilder = builder.CreateCall(location, printFMethod);
             callBuilder.Add(expression);
             foreach (Value argument in writeToOutput.Arguments)

--- a/Src/ILGPU/Backends/PTX/PTXLibDeviceMethods.tt
+++ b/Src/ILGPU/Backends/PTX/PTXLibDeviceMethods.tt
@@ -39,7 +39,7 @@ namespace ILGPU.Backends.PTX
     {
         internal static bool IsLibDeviceMethod(Method method) =>
             method.HasSource &&
-            method.Source.DeclaringType == typeof(PTXLibDeviceMethods);
+            method.Source.Underlying.DeclaringType == typeof(PTXLibDeviceMethods);
 
 <#
     foreach (var func in functions)

--- a/Src/ILGPU/Backends/PTX/Transformations/PTXAcceleratorSpecializer.cs
+++ b/Src/ILGPU/Backends/PTX/Transformations/PTXAcceleratorSpecializer.cs
@@ -129,7 +129,7 @@ namespace ILGPU.Backends.PTX.Transformations
             var innerBuilder = methodBuilder[innerBlock];
             var assertFailed = innerBuilder.CreateCall(
                 location,
-                context.Declare(AssertFailedMethod, out var _));
+                context.Declare(new(null, AssertFailedMethod), out var _));
 
             // Move the debug assertion to this block
             var sourceMessage = debugAssert.Message.ResolveAs<StringValue>().AsNotNull();
@@ -208,7 +208,7 @@ namespace ILGPU.Backends.PTX.Transformations
                 MemoryAddressSpace.Generic);
 
             // Create a call to the native printf
-            var printFMethod = context.Declare(PrintFMethod, out bool _);
+            var printFMethod = context.Declare(new(null, PrintFMethod), out bool _);
             var callBuilder = builder.CreateCall(location, printFMethod);
             callBuilder.Add(expression);
             callBuilder.Add(alloca);

--- a/Src/ILGPU/Frontend/Block.cs
+++ b/Src/ILGPU/Frontend/Block.cs
@@ -11,6 +11,7 @@
 
 using ILGPU.Frontend.Intrinsic;
 using ILGPU.IR;
+using ILGPU.IR.Construction;
 using ILGPU.IR.Types;
 using ILGPU.IR.Values;
 using ILGPU.Resources;
@@ -256,11 +257,11 @@ namespace ILGPU.Frontend
         /// <param name="instanceValue">The instance value (if available).</param>
         public ValueList PopMethodArgs(
             Location location,
-            MethodBase methodBase,
+            SpecializedMethod method,
             Value? instanceValue)
         {
-            var parameters = methodBase.GetParameters();
-            var parameterOffset = methodBase.GetParameterOffset();
+            var parameters = method.Underlying.GetParameters();
+            var parameterOffset = method.Underlying.GetParameterOffset();
             var result = ValueList.Create(parameters.Length + parameterOffset);
 
             // Handle main params
@@ -277,9 +278,9 @@ namespace ILGPU.Frontend
             // Check instance value
             if (parameterOffset > 0)
             {
-                if (instanceValue == null)
-                {
-                    var baseDeclaringType = methodBase.DeclaringType.AsNotNull();
+                if (instanceValue == null) {
+                    var baseDeclaringType = method.InstanceType.AsNotNull();
+
                     var declaringType = Builder.CreateType(baseDeclaringType);
                     if (!Intrinsics.IsIntrinsicArrayType(baseDeclaringType))
                     {

--- a/Src/ILGPU/Frontend/CodeGenerator/Objects.cs
+++ b/Src/ILGPU/Frontend/CodeGenerator/Objects.cs
@@ -68,8 +68,8 @@ namespace ILGPU.Frontend
             CreateStore(alloca, value);
 
             // Invoke constructor for type
-            var values = Block.PopMethodArgs(Location, method, alloca);
-            CreateCall(constructor, ref values);
+            var values = Block.PopMethodArgs(Location, new(null, method), alloca);
+            CreateCall(new(null, constructor), ref values);
 
             // Push created instance on the stack
             Block.Push(CreateLoad(

--- a/Src/ILGPU/Frontend/DisassembledMethod.cs
+++ b/Src/ILGPU/Frontend/DisassembledMethod.cs
@@ -11,6 +11,7 @@
 
 using ILGPU.Frontend.DebugInformation;
 using ILGPU.IR;
+using ILGPU.IR.Construction;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection;
@@ -27,7 +28,7 @@ namespace ILGPU.Frontend
         #region Instance
 
         internal DisassembledMethod(
-            MethodBase method,
+            SpecializedMethod method,
             ImmutableArray<ILInstruction> instructions,
             int maxStackSize)
         {
@@ -47,7 +48,7 @@ namespace ILGPU.Frontend
         /// <summary>
         /// Returns the method that was disassembled.
         /// </summary>
-        public MethodBase Method { get; }
+        public SpecializedMethod Method { get; }
 
         /// <summary>
         /// Returns the first disassembled instruction.
@@ -97,7 +98,7 @@ namespace ILGPU.Frontend
         /// </summary>
         /// <param name="method">The method to disassemble.</param>
         /// <returns>The disassembled method.</returns>
-        public static Task<DisassembledMethod> DisassembleAsync(MethodBase method) =>
+        public static Task<DisassembledMethod> DisassembleAsync(SpecializedMethod method) =>
             DisassembleAsync(method, SequencePointEnumerator.Empty);
 
         /// <summary>
@@ -109,7 +110,7 @@ namespace ILGPU.Frontend
         /// </param>
         /// <returns>The disassembled method.</returns>
         public static Task<DisassembledMethod> DisassembleAsync(
-            MethodBase method,
+            SpecializedMethod method,
             SequencePointEnumerator sequencePointEnumerator) =>
             Task.Run(() =>
             {

--- a/Src/ILGPU/Frontend/DisassemblerDriver.cs
+++ b/Src/ILGPU/Frontend/DisassemblerDriver.cs
@@ -192,7 +192,7 @@ namespace ILGPU.Frontend
                     DisassembleCall(ILInstructionType.Callvirt, ReadIntArg());
                     return true;
                 case ILOpCode.Ret:
-                    AppendInstruction(ILInstructionType.Ret, (ushort)MethodBase.GetParameterOffset(), 0, OpCodes.Ret);
+                    AppendInstruction(ILInstructionType.Ret, (ushort)Method.Underlying.GetParameterOffset(), 0, OpCodes.Ret);
                     return true;
 
                     // Branch
@@ -708,7 +708,7 @@ namespace ILGPU.Frontend
                 case ILOpCode.Tail:
                     AddFlags(ILInstructionFlags.Tail);
                     return true;
-                case ILOpCode.Constrained: 
+                case ILOpCode.Constrained:
                     AddFlags(ILInstructionFlags.Constrained);
                     flagsArgument = ReadTypeArg();
                     return true;

--- a/Src/ILGPU/Frontend/Intrinsic/ArrayIntrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/ArrayIntrinsics.cs
@@ -38,8 +38,7 @@ namespace ILGPU.Frontend.Intrinsic
         {
             var builder = context.Builder;
             var location = context.Location;
-            return context.Method.Name switch
-            {
+            return context.Method.Underlying.Name switch {
                 ".ctor" => CreateNewArray(ref context),
                 "Get" => CreateGetArrayElement(ref context),
                 "Set" => CreateSetArrayElement(ref context),
@@ -56,7 +55,7 @@ namespace ILGPU.Frontend.Intrinsic
                 nameof(Array.Empty) => CreateEmptyArray(ref context),
                 _ => throw location.GetNotSupportedException(
                     ErrorMessages.NotSupportedIntrinsic,
-                    context.Method.Name),
+                    context.Method.Underlying.Name),
             };
         }
 
@@ -79,8 +78,7 @@ namespace ILGPU.Frontend.Intrinsic
             }
 
             // Create an array view type of the appropriate dimension
-            var managedElementType =
-                context.Method.DeclaringType.AsNotNull().GetElementType().AsNotNull();
+            var managedElementType = context.Method.InstanceType.AsNotNull().GetElementType().AsNotNull();
             var elementType = builder.CreateType(managedElementType);
             var arrayType = builder.CreateArrayType(elementType, dimension);
 

--- a/Src/ILGPU/Frontend/Intrinsic/ConvertIntrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/ConvertIntrinsics.cs
@@ -50,7 +50,7 @@ namespace ILGPU.Frontend.Intrinsic
             ref InvocationContext context,
             ConvertIntriniscAttribute attribute)
         {
-            var returnType = context.Method.GetReturnType();
+            var returnType = context.Method.Underlying.GetReturnType();
             var typeNode = context.Builder.CreateType(returnType);
             return context.Builder.CreateConvert(
                 context.Location,

--- a/Src/ILGPU/Frontend/Intrinsic/LanguageIntrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/LanguageIntrinsics.cs
@@ -119,8 +119,8 @@ namespace ILGPU.Frontend.Intrinsic
             var arguments = InlineList<ValueReference>.Create(capacity);
             var directions = ImmutableArray.CreateBuilder<CudaEmitParameterDirection>(
                 capacity);
-            var methodParams = context.Method.GetParameters();
-            var genericArgs = context.Method.GetGenericArguments();
+            var methodParams = context.Method.Underlying.GetParameters();
+            var genericArgs = context.Method.Underlying.GetGenericArguments();
 
             for (int i = 1; i < context.Arguments.Count; i++)
             {

--- a/Src/ILGPU/Frontend/Intrinsic/RemappedIntrinsics.cs
+++ b/Src/ILGPU/Frontend/Intrinsic/RemappedIntrinsics.cs
@@ -9,6 +9,7 @@
 // Source License. See LICENSE.txt for details.
 // ---------------------------------------------------------------------------------------
 
+using ILGPU.IR.Construction;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -148,7 +149,7 @@ namespace ILGPU.Frontend.Intrinsic
                 {
                     AddRemapping(
                         srcFunc,
-                        (ref InvocationContext context) => context.Method = dstFunc);
+                        (ref InvocationContext context) => context.Method = new(targetType, dstFunc));
                 }
                 else if (required)
                 {
@@ -184,9 +185,8 @@ namespace ILGPU.Frontend.Intrinsic
         /// </summary>
         /// <param name="context">The invocation context.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void RemapIntrinsic(ref InvocationContext context)
-        {
-            if (FunctionRemappers.TryGetValue(context.Method, out var remapper))
+        public static void RemapIntrinsic(ref InvocationContext context) {
+            if (FunctionRemappers.TryGetValue(context.Method.Underlying, out var remapper))
                 remapper(ref context);
         }
 

--- a/Src/ILGPU/Frontend/InvocationContext.cs
+++ b/Src/ILGPU/Frontend/InvocationContext.cs
@@ -48,8 +48,8 @@ namespace ILGPU.Frontend
             CodeGenerator codeGenerator,
             Location location,
             Block block,
-            MethodBase callerMethod,
-            MethodBase method,
+            SpecializedMethod callerMethod,
+            SpecializedMethod method,
             ref ValueList arguments)
         {
             CodeGenerator = codeGenerator;
@@ -103,17 +103,17 @@ namespace ILGPU.Frontend
         /// <summary>
         /// Represents the caller method.
         /// </summary>
-        public MethodBase CallerMethod { get; }
+        public SpecializedMethod CallerMethod { get; }
 
         /// <summary>
         /// Represents the targeted method.
         /// </summary>
-        public MethodBase Method { get; set; }
+        public SpecializedMethod Method { get; set; }
 
         /// <summary>
         /// Returns the associated module.
         /// </summary>
-        public Module Module => Method.Module;
+        public Module Module => Method.Underlying.Module;
 
         /// <summary>
         /// Returns the call arguments.
@@ -147,24 +147,24 @@ namespace ILGPU.Frontend
         /// Returns the generic arguments of the used method.
         /// </summary>
         /// <returns>The generic arguments of the used method.</returns>
-        public Type[] GetMethodGenericArguments() => Method.GetGenericArguments();
+        public Type[] GetMethodGenericArguments() => Method.Underlying.GetGenericArguments();
 
         /// <summary>
         /// Returns the generic arguments of the used method.
         /// </summary>
         /// <returns>The generic arguments of the used method.</returns>
         public Type[] GetTypeGenericArguments() =>
-            Method.DeclaringType.AsNotNull().GetGenericArguments();
+            Method.Underlying.DeclaringType.AsNotNull().GetGenericArguments();
 
         /// <summary>
         /// Declares a (potentially new) method.
         /// </summary>
         /// <param name="methodBase">The method to declare.</param>
         /// <returns>The declared method reference.</returns>
-        public Method DeclareMethod(MethodBase methodBase) =>
-            methodBase != null
-            ? CodeGenerator.DeclareMethod(methodBase)
-            : throw Location.GetArgumentNullException(nameof(methodBase));
+        public Method DeclareMethod(SpecializedMethod method) =>
+            method.Underlying != null
+            ? CodeGenerator.DeclareMethod(method)
+            : throw Location.GetArgumentNullException(nameof(method));
 
         #endregion
 
@@ -177,7 +177,7 @@ namespace ILGPU.Frontend
         public override string ToString()
         {
             var builder = new StringBuilder();
-            builder.Append(Method.Name);
+            builder.Append(Method.Underlying.Name);
             builder.Append('(');
             if (Arguments.Count > 0)
             {

--- a/Src/ILGPU/IR/Construction/Method.Builder.cs
+++ b/Src/ILGPU/IR/Construction/Method.Builder.cs
@@ -221,7 +221,7 @@ namespace ILGPU.IR
             /// <summary>
             /// Returns the original source method (may be null).
             /// </summary>
-            public MethodBase Source => Method.Source;
+            public SpecializedMethod? Source => Method.Source;
 
             /// <summary>
             /// Returns all blocks of the source method.

--- a/Src/ILGPU/IR/Construction/Methods.cs
+++ b/Src/ILGPU/IR/Construction/Methods.cs
@@ -11,11 +11,17 @@
 
 using ILGPU.IR.Types;
 using ILGPU.IR.Values;
+using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using ValueList = ILGPU.Util.InlineList<ILGPU.IR.Values.ValueReference>;
 
-namespace ILGPU.IR.Construction
-{
+namespace ILGPU.IR.Construction {
+
+    public record struct SpecializedMethod(Type? SpecializedInstanceType, MethodBase Underlying) {
+        public Type InstanceType => SpecializedInstanceType ?? Underlying.DeclaringType;
+    }
+
     partial class IRBuilder
     {
         /// <summary>
@@ -77,3 +83,4 @@ namespace ILGPU.IR.Construction
         }
     }
 }
+

--- a/Src/ILGPU/IR/Intrinsics/IntrinsicImplementationProvider.cs
+++ b/Src/ILGPU/IR/Intrinsics/IntrinsicImplementationProvider.cs
@@ -214,12 +214,9 @@ namespace ILGPU.IR.Intrinsics
 
                 lock (mappings)
                 {
-                    var redirect = mapping.ResolveRedirect(
-                        resolver,
-                        out var genericMapping);
-                    if (!mappings.ContainsKey(redirect))
-                    {
-                        var result = codeGenerationPhase.GenerateCode(redirect);
+                    var redirect = mapping.ResolveRedirect(resolver, out var genericMapping);
+                    if (!mappings.ContainsKey(redirect)) {
+                        var result = codeGenerationPhase.GenerateCode(new(null, redirect));
                         mappings.Add(
                             redirect,
                             new MappingEntry(mapping, genericMapping, result));
@@ -425,7 +422,7 @@ namespace ILGPU.IR.Intrinsics
             [NotNullWhen(true)] out IntrinsicMapping<TDelegate>? mapping)
         {
             mapping = default;
-            return (methodInfo = method.Source as MethodInfo) != null &&
+            return (methodInfo = method.Source?.Underlying as MethodInfo) != null &&
                 method.HasFlags(MethodFlags.Intrinsic) &&
                 TryGetMapping(methodInfo, out mapping);
         }

--- a/Src/ILGPU/IR/Method.cs
+++ b/Src/ILGPU/IR/Method.cs
@@ -12,6 +12,7 @@
 using ILGPU.Frontend;
 using ILGPU.IR.Analyses.ControlFlowDirection;
 using ILGPU.IR.Analyses.TraversalOrders;
+using ILGPU.IR.Construction;
 using ILGPU.IR.Intrinsics;
 using ILGPU.IR.Types;
 using ILGPU.IR.Values;
@@ -298,7 +299,7 @@ namespace ILGPU.IR
             /// Constructs a new method location.
             /// </summary>
             /// <param name="method">The target method (if any).</param>
-            public MethodLocation(MethodBase method)
+            public MethodLocation(MethodBase? method)
             {
                 Method = method;
             }
@@ -306,7 +307,7 @@ namespace ILGPU.IR
             /// <summary>
             /// Returns the managed method (if any).
             /// </summary>
-            public MethodBase Method { get; }
+            public MethodBase? Method { get; }
 
             /// <summary>
             /// Tries to include managed method information if possible.
@@ -400,10 +401,9 @@ namespace ILGPU.IR
             : base(
                   location.IsKnown
                   ? location
-                  : new MethodLocation(declaration.Source.AsNotNull()))
+                  : new MethodLocation(declaration.Source?.Underlying))
         {
-            Location.Assert(
-                declaration.HasHandle && declaration.ReturnType != null);
+            Location.Assert(declaration.HasHandle && declaration.ReturnType != null);
 
             BaseContext = baseContext;
             Declaration = declaration;
@@ -449,12 +449,7 @@ namespace ILGPU.IR
         /// <summary>
         /// Returns the original source method (may be null).
         /// </summary>
-        public MethodBase Source => Declaration.Source.AsNotNull();
-
-        /// <summary>
-        /// Returns true if the associated source method is not null.
-        /// </summary>
-        public bool HasSource => Declaration.HasSource;
+        public SpecializedMethod? Source => Declaration.Source;
 
         /// <summary>
         /// Returns the return-type of the method.

--- a/Src/ILGPU/IR/MethodHandle.cs
+++ b/Src/ILGPU/IR/MethodHandle.cs
@@ -9,6 +9,7 @@
 // Source License. See LICENSE.txt for details.
 // ---------------------------------------------------------------------------------------
 
+using ILGPU.IR.Construction;
 using ILGPU.IR.Types;
 using System;
 using System.Diagnostics;
@@ -229,7 +230,7 @@ namespace ILGPU.IR
         public MethodDeclaration(
             MethodHandle handle,
             TypeNode returnType,
-            MethodBase source)
+            SpecializedMethod source)
             : this(handle, returnType, source, MethodFlags.None)
         { }
 
@@ -243,9 +244,8 @@ namespace ILGPU.IR
         public MethodDeclaration(
             MethodHandle handle,
             TypeNode returnType,
-            MethodBase? source,
-            MethodFlags flags)
-        {
+            SpecializedMethod? source,
+            MethodFlags flags) {
             Handle = handle;
             ReturnType = returnType
                 ?? throw new ArgumentNullException(nameof(returnType));
@@ -253,7 +253,7 @@ namespace ILGPU.IR
             Flags = flags;
 
             if (flags == MethodFlags.None && Source != null)
-                Flags = Method.ResolveMethodFlags(Source);
+                Flags = Method.ResolveMethodFlags(Source.Value.Underlying);
         }
 
         #endregion
@@ -286,14 +286,9 @@ namespace ILGPU.IR
         public TypeNode ReturnType { get; }
 
         /// <summary>
-        /// Returns true if the associated source method is not null.
-        /// </summary>
-        public bool HasSource => Source != null;
-
-        /// <summary>
         /// Returns the managed source method.
         /// </summary>
-        public MethodBase? Source { get; }
+        public SpecializedMethod? Source { get; }
 
         #endregion
 

--- a/Src/ILGPU/IR/MethodMapping.cs
+++ b/Src/ILGPU/IR/MethodMapping.cs
@@ -9,6 +9,7 @@
 // Source License. See LICENSE.txt for details.
 // ---------------------------------------------------------------------------------------
 
+using ILGPU.IR.Construction;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -33,7 +34,7 @@ namespace ILGPU.IR
         /// <summary>
         /// Returns the original source method (may be null).
         /// </summary>
-        MethodBase Source { get; }
+        SpecializedMethod? Source { get; }
     }
 
     /// <summary>
@@ -135,7 +136,7 @@ namespace ILGPU.IR
             /// <param name="handle">The resolved function handle (if any).</param>
             /// <returns>True, if the requested function could be resolved.</returns>
             public bool TryGetHandle(
-                MethodBase method,
+                SpecializedMethod method,
                 [NotNullWhen(true)] out MethodHandle? handle) =>
                 Parent.TryGetHandle(method, out handle);
 
@@ -173,8 +174,8 @@ namespace ILGPU.IR
 
         #region Instance
 
-        private readonly Dictionary<MethodBase, MethodHandle> managedMethods =
-            new Dictionary<MethodBase, MethodHandle>();
+        private readonly Dictionary<SpecializedMethod, MethodHandle> managedMethods =
+            new Dictionary<SpecializedMethod, MethodHandle>();
         private readonly Dictionary<MethodHandle, int> methods =
             new Dictionary<MethodHandle, int>();
         private readonly List<T> dataList = new List<T>();
@@ -221,7 +222,7 @@ namespace ILGPU.IR
         /// <param name="handle">The resolved function handle (if any).</param>
         /// <returns>True, if the requested function could be resolved.</returns>
         public bool TryGetHandle(
-            MethodBase method,
+            SpecializedMethod method,
             [NotNullWhen(true)] out MethodHandle? handle)
         {
             if (managedMethods.TryGetValue(method, out var result))
@@ -278,7 +279,7 @@ namespace ILGPU.IR
             }
             var source = data.Source;
             if (source != null)
-                managedMethods[source] = handle;
+                managedMethods[source.Value] = handle;
         }
 
         /// <summary>

--- a/Src/ILGPU/IR/Transformations/Inliner.cs
+++ b/Src/ILGPU/IR/Transformations/Inliner.cs
@@ -44,9 +44,8 @@ namespace ILGPU.IR.Transformations
             if (!method.HasImplementation)
                 return;
 
-            if (method.HasSource)
-            {
-                var source = method.Source;
+            if (method.Source != null) {
+                var source = method.Source.Value.Underlying;
                 if ((source.MethodImplementationFlags &
                     MethodImplAttributes.NoInlining) ==
                     MethodImplAttributes.NoInlining)


### PR DESCRIPTION
Added in ability to resolve default interface members.

For instance, the following would not compile:

```csharp
public interface TestInterface {
    public int Min { get; }
    public int Max { get; }
    public int Center => (Min + Max)/2;
}

public record struct TestStruct(int Min, int Max) : TestInterface {
}
```

because "get_Center"'s definition is in TestInterface. When ILGPU attempts to resolve the underlying datatype, it returns with TestInterface.

With .NET's latest constraint type for struct members this type needs to be forwarded from the call site down to every reference of "this" in the instance definition. To do this, I created a "SpecializedMethod" object that forwards the constrained type.

Nested example where forwarded is required (If get_NestedCenterCall is invoked with constrained type, this type has to be forwarded to get_Center):

```csharp

 public interface ITestInterface {
            public float Min { get; }
            public float Max { get; }
            public float Center => (Min + Max)/2;
            public float NestedCenterCall {
                get => Center*4;
            }
        }
```

Essentially, this PR replaces most usages of MethodBase to SpecializedMethod containing the specialized call type instance and the MethodBase.