### PR TITLE
Fixed issue with Cordic XMath.Pow/Exp on Cuda.

### DIFF
--- a/Src/ILGPU.Algorithms/XMath/Cordic.Pow.tt
+++ b/Src/ILGPU.Algorithms/XMath/Cordic.Pow.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                   ILGPU Algorithms
-//                        Copyright (c) 2020-2021 ILGPU Project
+//                        Copyright (c) 2020-2025 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Cordic.Pow.tt/Cordic.Pow.cs
@@ -49,8 +49,18 @@ namespace ILGPU.Algorithms
                 // Deal with negative exponents
                 if (value < 0)
                     return 1.0<#= operation.ValueSuffix #> /
-                        Exp(-1.0<#= operation.ValueSuffix #> * value);
+                        ExpImpl(-1.0<#= operation.ValueSuffix #> * value);
 
+                // Deal with positive exponents.
+                return ExpImpl(value);
+            }
+
+            /// <summary>
+            /// NB: Separated implementation to prevent recursive call from handling
+            /// negative values.
+            /// </summary>
+            private static <#= operation.DataType #> ExpImpl(<#= operation.DataType #> value)
+            {
                 // The exponential function is related to hyperbolic functions with the
                 // identity:
                 //  exp(x) = cosh(x) + sinh(x)


### PR DESCRIPTION
Fixes #1328 and #1331.

The implementation of `XMath.Pow(double)` calls `XMath.Exp(double)`. And the implementation of `XMath.Exp(double)` on Cuda uses a custom implementation in ILGPU, using the CORDIC algorithm.

Within the implementation of Exp, it handles negative inputs by calling Exp again, with a positive input.

It looks like when mixed with LocalMemory in a kernel, Cuda will sometimes generate an illegal memory access. This occurs even if the local memory is not accessed, as per [this investigation](https://github.com/m4rs-mt/ILGPU/issues/1331#issuecomment-2909550552).

This "recursive" call should only be a single level deep, but the compiler probably cannot determine this.

This PR separates the core implementation of Exp into two functions, so that the compiler can predict that there is no recursion.