### PR TITLE
Fixed disassembly of Conv_R_Un opcode.

### DIFF
--- a/Src/ILGPU/Frontend/CodeGenerator/CodeGenerator.cs
+++ b/Src/ILGPU/Frontend/CodeGenerator/CodeGenerator.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2018-2023 ILGPU Project
+//                        Copyright (c) 2018-2025 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: CodeGenerator.cs
@@ -36,6 +36,7 @@ namespace ILGPU.Frontend
         private readonly Dictionary<VariableRef, (TypeNode, ConvertFlags)>
             variableTypes =
             new Dictionary<VariableRef, (TypeNode, ConvertFlags)>();
+        private ILInstruction? nextInstruction;
 
         /// <summary>
         /// Constructs a new code generator.
@@ -329,6 +330,7 @@ namespace ILGPU.Frontend
             for (int i = Block.InstructionOffset; i < endOffset; ++i)
             {
                 var instruction = DisassembledMethod[i];
+                nextInstruction = i + 1 < endOffset ? DisassembledMethod[i + 1] : null;
 
                 // Setup debug information
                 Location = instruction.Location;

--- a/Src/ILGPU/Frontend/CodeGenerator/Convert.cs
+++ b/Src/ILGPU/Frontend/CodeGenerator/Convert.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2018-2023 ILGPU Project
+//                        Copyright (c) 2018-2025 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Convert.cs
@@ -22,16 +22,23 @@ namespace ILGPU.Frontend
         /// <summary>
         /// Realizes a convert instruction.
         /// </summary>
-        /// <param name="targetType">The target type.</param>
+        /// <param name="targetTypeDefinition">The target type definition.</param>
         /// <param name="instructionFlags">The instruction flags.</param>
         private void MakeConvert(
-            Type targetType,
+            object targetTypeDefinition,
             ILInstructionFlags instructionFlags)
         {
             var value = Block.Pop();
             var convertFlags = ConvertFlags.None;
             if (instructionFlags.HasFlags(ILInstructionFlags.Unsigned))
                 convertFlags |= ConvertFlags.SourceUnsigned;
+            if (targetTypeDefinition is not Type targetType)
+            {
+                var dependentType = (DependentTypeArguments)targetTypeDefinition;
+                targetType = dependentType.DetermineType(
+                    value.BasicValueType,
+                    nextInstruction);
+            }
             if (targetType.IsUnsignedInt())
             {
                 convertFlags |= ConvertFlags.SourceUnsigned;

--- a/Src/ILGPU/Frontend/CodeGenerator/Driver.cs
+++ b/Src/ILGPU/Frontend/CodeGenerator/Driver.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2018-2023 ILGPU Project
+//                        Copyright (c) 2018-2025 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Driver.cs
@@ -220,7 +220,7 @@ namespace ILGPU.Frontend
                     return true;
 
                 case ILInstructionType.Conv:
-                    MakeConvert(instruction.GetArgumentAs<Type>(), instruction.Flags);
+                    MakeConvert(instruction.Argument, instruction.Flags);
                     return true;
 
                 case ILInstructionType.Initobj:

--- a/Src/ILGPU/Frontend/Disassembler.cs
+++ b/Src/ILGPU/Frontend/Disassembler.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2018-2023 ILGPU Project
+//                        Copyright (c) 2018-2025 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: Disassembler.cs
@@ -189,7 +189,7 @@ namespace ILGPU.Frontend
                 if (TryDisassemblePrefix(opCode))
                     continue;
 
-                if (TryDisasembleInstruction(opCode))
+                if (TryDisassembleInstruction(opCode))
                 {
                     // Reset flags
                     flags = ILInstructionFlags.None;

--- a/Src/ILGPU/Frontend/DisassemblerDriver.cs
+++ b/Src/ILGPU/Frontend/DisassemblerDriver.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2018-2021 ILGPU Project
+//                        Copyright (c) 2018-2025 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: DisassemblerDriver.cs
@@ -32,7 +32,7 @@ namespace ILGPU.Frontend
     {
         [SuppressMessage("Microsoft.Maintainability", "CA1505:AvoidUnmaintainableCode")]
         [SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity")]
-        private bool TryDisasembleInstruction(ILOpCode opCode)
+        private bool TryDisassembleInstruction(ILOpCode opCode)
         {
             switch (opCode)
             {
@@ -403,7 +403,7 @@ namespace ILGPU.Frontend
                     AppendInstructionWithFlags(ILInstructionType.Conv, 1, 1, ILInstructionFlags.None, typeof(double));
                     return true;
                 case ILOpCode.Conv_R_Un:
-                    AppendInstructionWithFlags(ILInstructionType.Conv, 1, 1, ILInstructionFlags.Unsigned, typeof(double));
+                    AppendInstructionWithFlags(ILInstructionType.Conv, 1, 1, ILInstructionFlags.Unsigned, ILInstruction.ConvRUnArguments);
                     return true;
                 case ILOpCode.Conv_U1:
                     AppendInstructionWithFlags(ILInstructionType.Conv, 1, 1, ILInstructionFlags.None, typeof(byte));

--- a/Src/ILGPU/Frontend/ILInstruction.cs
+++ b/Src/ILGPU/Frontend/ILInstruction.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2018-2023 ILGPU Project
+//                        Copyright (c) 2018-2025 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: ILInstruction.cs
@@ -633,10 +633,64 @@ namespace ILGPU.Frontend
     }
 
     /// <summary>
+    /// Represents dependent type information derived from the element type at the top
+    /// of the evaluation stack.
+    /// </summary>
+    public abstract class DependentTypeArguments
+    {
+        /// <summary>
+        /// Determines the target type using the element type from the evaluation stack.
+        /// </summary>
+        /// <param name="topOfStack">The element type on the evaluation stack.</param>
+        /// <param name="nextInstruction">The next instruction (if any).</param>
+        /// <returns>The target type.</returns>
+        public abstract Type DetermineType(
+            BasicValueType topOfStack,
+            ILInstruction? nextInstruction);
+    }
+
+    /// <summary>
     /// Represents a single IL instruction.
     /// </summary>
     public sealed class ILInstruction : IEquatable<ILInstruction>
     {
+        #region Nested Types
+
+        /// <summary>
+        /// Represents an implement automatic dependent type conversion argument
+        /// remapping using a dictionary.
+        /// </summary>
+        public sealed class ConvertTypeArguments : DependentTypeArguments
+        {
+            /// <summary>
+            /// Determines the target type using an internal dictionary mapping.
+            /// </summary>
+            /// <param name="topOfStack">The element type on the evaluation stack.</param>
+            /// <param name="nextInstruction">The next instruction (if any).</param>
+            /// <returns>The target type.</returns>
+            public override Type DetermineType(
+                BasicValueType topOfStack,
+                ILInstruction? nextInstruction)
+            {
+                var targetType = nextInstruction?.Argument as Type ?? null;
+
+                // Fall back to double for full precision in case of an unknown conversion
+                return targetType ?? typeof(double);
+            }
+        }
+
+        #endregion
+
+        #region Static
+
+        /// <summary>
+        /// Represents unsigned dependent type conversion arguments.
+        /// </summary>
+        public static readonly ConvertTypeArguments ConvRUnArguments =
+            new ConvertTypeArguments();
+
+        #endregion
+
         #region Instance
 
         /// <summary>


### PR DESCRIPTION
This PR fixes #1309 and supersedes #1310.

It introduces a new way to track type-dependent arguments in `ILInstruction` instances. During code generation, the current top-of-the-stack element, as well as the next instruction, can be matched against dependent type information and appropriate instructions on the IR level will be selected.

In case of `conv.r` we test the next operation and select type information accordingly:
```c#
float = conv.r.un -> conv.r4
double = conv.r.un -> conv.r8
```

Please note that this fix will have to be merged before #1355.