### PR TITLE
Fixed LibDevice compilation on compute_100 and later.

### DIFF
--- a/Src/ILGPU/Backends/PTX/PTXLibDeviceNvvm.tt
+++ b/Src/ILGPU/Backends/PTX/PTXLibDeviceNvvm.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2021-2024 ILGPU Project
+//                        Copyright (c) 2021-2025 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: PTXLibDeviceNvvm.tt/PTXLibDeviceNvvm.cs
@@ -42,7 +42,7 @@ namespace ILGPU.Backends.PTX
 
         private const string prefix = @"
             target triple = ""nvptx64-unknown-cuda""
-            target datalayout = ""e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v32:32:32-v64:64:64-v128:128:128-n16:32:64""";
+            target datalayout = ""e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-i128:128:128-f32:32:32-f64:64:64-v16:16:16-v32:32:32-v64:64:64-v128:128:128-n16:32:64""";
 
 <#
     foreach (var func in functions)
@@ -82,8 +82,8 @@ namespace ILGPU.Backends.PTX
                 {
                     if (addPrefix)
                     {
-                        builder.AppendLine(string.Format(irVersionFormat, majorIR));
                         builder.AppendLine(prefix);
+                        builder.AppendLine(string.Format(irVersionFormat, majorIR));
                         addPrefix = false;
                     }
 


### PR DESCRIPTION
A member of the community reported issues using LibDevice on a newer RTX 5090 device.

After some investigation, the NVVM compiler returned `NVVM_ERROR_COMPILATION` on the NVVM IR:
```
!nvvmir.version = !{{!0}}
!0 = !{{i32 2, i32 0}}

target triple = \"nvptx64-unknown-cuda\"
target datalayout = \"e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v32:32:32-v64:64:64-v128:128:128-n16:32:64\"

declare float @__nv_cosf(float %x)

define float @__ilgpu__nv_cosf(float %x)
{
entry:
    %call = call float @__nv_cosf(float %x)
    ret float %call
}
```

This could be reproduced by setting the compiler argument `-arch=compute_100`, or newer.
https://developer.nvidia.com/cuda-gpus#:~:text=Table_title:%20CUDA%20GPU%20Compute%20Capability%20Table_content:%20header:,NVIDIA%20A100%20NVIDIA%20A30%20%7C%20GeForce/RTX:%20%7C

After investigating further, the solution is to place the target directives *first*.

I have also updated the `target datalayout` directive with the `i128` registers, as per the NVVM IR specification:
https://docs.nvidia.com/cuda/nvvm-ir-spec/index.html#data-layout

