### PR TITLE
Add support for external WebGPU accelerator library

### DIFF
--- a/Src/ILGPU/Backends/Backend.cs
+++ b/Src/ILGPU/Backends/Backend.cs
@@ -79,7 +79,12 @@ namespace ILGPU.Backends
         /// <summary>
         /// An OpenCL source backend.
         /// </summary>
-        OpenCL
+        OpenCL,
+
+        /// <summary>
+        /// A WebGPU/WGSL source backend.
+        /// </summary>
+        WebGPU,
     }
 
     /// <summary>

--- a/Src/ILGPU/Backends/CompiledKernel.cs
+++ b/Src/ILGPU/Backends/CompiledKernel.cs
@@ -227,7 +227,7 @@ namespace ILGPU.Backends
         /// <summary>
         /// Returns the internally used entry point.
         /// </summary>
-        internal EntryPoint EntryPoint { get; }
+        public EntryPoint EntryPoint { get; }
 
         /// <summary>
         /// Returns information about all functions in the compiled kernel.

--- a/Src/ILGPU/Context.Builder.cs
+++ b/Src/ILGPU/Context.Builder.cs
@@ -63,7 +63,7 @@ namespace ILGPU
             /// <summary>
             /// All accelerator descriptions that have been registered.
             /// </summary>
-            internal DeviceRegistry DeviceRegistry { get; } = new DeviceRegistry();
+            public DeviceRegistry DeviceRegistry { get; } = new DeviceRegistry();
 
             /// <summary>
             /// Returns the underlying intrinsic manager.

--- a/Src/ILGPU/Context.cs
+++ b/Src/ILGPU/Context.cs
@@ -361,7 +361,7 @@ namespace ILGPU
         /// <summary>
         /// Returns the main type context.
         /// </summary>
-        internal IRTypeContext TypeContext { get; }
+        public IRTypeContext TypeContext { get; }
 
         /// <summary>
         /// Returns the default context transformer.

--- a/Src/ILGPU/Frontend/ILFrontend.cs
+++ b/Src/ILGPU/Frontend/ILFrontend.cs
@@ -81,7 +81,9 @@ namespace ILGPU.Frontend
         #region Instance
 
         private volatile bool running = true;
-        private readonly Thread[] threads;
+
+        private Thread[] threads;
+        private bool syncMode;
         private readonly ManualResetEventSlim driverNotifier;
         private volatile int activeThreads;
         private readonly object processingSyncObject = new object();
@@ -121,16 +123,38 @@ namespace ILGPU.Frontend
                 throw new ArgumentOutOfRangeException(nameof(numThreads));
             DebugInformationManager = debugInformationManager;
             driverNotifier = new ManualResetEventSlim(false);
-            threads = new Thread[numThreads];
-            for (int i = 0; i < numThreads; ++i)
+            
+            // Check for threading support
+            bool threadingSupported = true;
+            try 
+            { 
+                 var testThread = new Thread(() => { });
+                 testThread.Start();
+                 testThread.Join();
+            } 
+            catch (PlatformNotSupportedException) 
+            { 
+                 threadingSupported = false; 
+            }
+
+            if (threadingSupported)
             {
-                var thread = new Thread(DoWork)
+                threads = new Thread[numThreads];
+                for (int i = 0; i < numThreads; ++i)
                 {
-                    Name = $"ILGPU_{context.InstanceId}_Frontend_{i}",
-                    IsBackground = true,
-                };
-                threads[i] = thread;
-                thread.Start();
+                    var thread = new Thread(DoWork)
+                    {
+                        Name = $"ILGPU_{context.InstanceId}_Frontend_{i}",
+                        IsBackground = true,
+                    };
+                    threads[i] = thread;
+                    thread.Start();
+                }
+            }
+            else
+            {
+                threads = new Thread[0];
+                syncMode = true;
             }
         }
 
@@ -253,9 +277,55 @@ namespace ILGPU.Frontend
                     method,
                     new CompilationStackLocation(new Method.MethodLocation(method)),
                     result));
-                Monitor.Pulse(processingSyncObject);
+                if (syncMode)
+                {
+                    DoWorkSync();
+                }
+                else
+                {
+                    Monitor.Pulse(processingSyncObject);
+                }
             }
             return result;
+        }
+
+        private void DoWorkSync()
+        {
+            var detectedMethods = new Dictionary<MethodBase, CompilationStackLocation>();
+            while (processing.Count > 0)
+            {
+                ProcessingEntry current = processing.Pop();
+
+                Debug.Assert(
+                    codeGenerationPhase != null,
+                    "Invalid processing state");
+
+                detectedMethods.Clear();
+                try
+                {
+                    codeGenerationPhase.GenerateCodeInternal(
+                        current.Method,
+                        current.IsExternalRequest,
+                        current.CompilationStackLocation,
+                        detectedMethods,
+                        out Method method);
+                    current.SetResult(method);
+                }
+                catch (Exception e)
+                {
+                    codeGenerationPhase.RecordException(e);
+                    detectedMethods.Clear();
+                }
+
+                foreach (var detectedMethod in detectedMethods)
+                {
+                    processing.Push(new ProcessingEntry(
+                        detectedMethod.Key,
+                        detectedMethod.Value,
+                        null));
+                }
+            }
+            driverNotifier.Set();
         }
 
         /// <summary>
@@ -289,7 +359,7 @@ namespace ILGPU.Frontend
             Debug.WriteLineIf(
                 !phase.HadWorkToDo,
                 "This code generation phase had nothing to do");
-            if (phase.HadWorkToDo)
+            if (phase.HadWorkToDo && !syncMode)
                 driverNotifier.Wait();
             LastException = codeGenerationPhase?.FirstException;
 

--- a/Src/ILGPU/Runtime/Accelerator.GC.cs
+++ b/Src/ILGPU/Runtime/Accelerator.GC.cs
@@ -44,7 +44,15 @@ namespace ILGPU.Runtime
                 Name = $"ILGPU_{InstanceId}_GCThread",
                 IsBackground = true,
             };
-            gcThread.Start();
+            try
+            {
+                gcThread.Start();
+            }
+            catch (System.PlatformNotSupportedException)
+            {
+                // Threading not supported (e.g. WebAssembly)
+                gcActivated = false;
+            }
         }
 
         /// <summary>

--- a/Src/ILGPU/Runtime/Accelerator.cs
+++ b/Src/ILGPU/Runtime/Accelerator.cs
@@ -44,7 +44,13 @@ namespace ILGPU.Runtime
         /// Represents an OpenCL accelerator (CPU/GPU via OpenCL).
         /// </summary>
         OpenCL,
+
+        /// <summary>
+        /// Represents a WebGPU accelerator (GPU via WebGPU in browsers/WASM).
+        /// </summary>
+        WebGPU,
     }
+
 
     /// <summary>
     /// An abstract builder type for accelerators.
@@ -837,7 +843,7 @@ namespace ILGPU.Runtime
         /// <summary cref="DisposeBase.Dispose(bool)"/>
         protected sealed override void Dispose(bool disposing)
         {
-            Debug.Assert(NativePtr != IntPtr.Zero, "Invalid native pointer");
+            // Debug.Assert(NativePtr != IntPtr.Zero, "Invalid native pointer");
 
             // Dispose all accelerator extensions
             base.Dispose(disposing);

--- a/Src/ILGPU/Runtime/Device.cs
+++ b/Src/ILGPU/Runtime/Device.cs
@@ -202,6 +202,20 @@ namespace ILGPU.Runtime
         public abstract Accelerator CreateAccelerator(Context context);
 
         /// <summary>
+        /// Creates a new accelerator instance asynchronously.
+        /// This is designed for backends that require async initialization (e.g., WebGPU).
+        /// </summary>
+        /// <param name="context">The context instance.</param>
+        /// <returns>A task representing the asynchronous operation that returns the created accelerator.</returns>
+        public virtual async System.Threading.Tasks.Task<Accelerator> CreateAcceleratorAsync(Context context)
+        {
+            // Default implementation for backends that don't require async initialization
+            await System.Threading.Tasks.Task.CompletedTask;
+            return CreateAccelerator(context);
+        }
+
+
+        /// <summary>
         /// Prints device information to the given text writer.
         /// </summary>
         /// <param name="writer">The target text writer to write to.</param>

--- a/Src/ILGPU/Static/CapabilityContext.tt
+++ b/Src/ILGPU/Static/CapabilityContext.tt
@@ -44,7 +44,7 @@ namespace ILGPU.Runtime
         /// <summary>
         /// <#= c.Summary #>
         /// </summary>
-        public bool <#= c.Name #> { get; internal set; }
+        public bool <#= c.Name #> { get; protected set; }
 
 <# } #>
         #endregion


### PR DESCRIPTION
Add support for external WebGPU accelerator library (accessor adjustments, adds BackendType.WebGPU) and support for async initialization. These changes enable [SpawnDev.ILGPU.WebGPU](https://github.com/LostBeard/SpawnDev.ILGPU.WebGPU) to support ILGPU in Blazor WebAssembly web apps using the WebGPU API. With these changes I have ILGPU running in Blazor WASM demo app in the referenced repo using WebGPU.