### PR TITLE
Bump copyright headers.

### DIFF
--- a/Src/ILGPU.Tests/BinaryFloatOperations.tt
+++ b/Src/ILGPU.Tests/BinaryFloatOperations.tt
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                           Copyright (c) 2025 ILGPU Project
+//                        Copyright (c) 2025-2026 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: BinaryFloatOperations.tt/BinaryFloatOperations.cs

--- a/Src/ILGPU/Backends/PTX/PTXCodeGenerator.Values.cs
+++ b/Src/ILGPU/Backends/PTX/PTXCodeGenerator.Values.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2018-2025 ILGPU Project
+//                        Copyright (c) 2018-2026 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: PTXCodeGenerator.Values.cs

--- a/Src/ILGPU/Backends/PTX/PTXInstructions.cs
+++ b/Src/ILGPU/Backends/PTX/PTXInstructions.cs
@@ -1,6 +1,6 @@
 ﻿// ---------------------------------------------------------------------------------------
 //                                        ILGPU
-//                        Copyright (c) 2019-2025 ILGPU Project
+//                        Copyright (c) 2019-2026 ILGPU Project
 //                                    www.ilgpu.net
 //
 // File: PTXInstructions.cs


### PR DESCRIPTION
With the squash merge of #1362, the headers need updating again.